### PR TITLE
Add travis script for google-fonts-flutter repo presubmit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+os:
+  - linux
+sudo: false
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libstdc++6
+      - fonts-noto
+git:
+  depth: 3
+env:
+  - FLUTTER_VERSION=stable
+  - FLUTTER_VERSION=beta
+matrix:
+  allow_failures:
+    - env: FLUTTER_VERSION=beta
+before_script:
+  - git clone https://github.com/flutter/flutter.git ../flutter -b $FLUTTER_VERSION
+  - ../flutter/bin/flutter doctor
+  - chmod +x travis_script.sh
+script:
+  - ./travis_script.sh
+cache:
+  directories:
+    - $HOME/shared/.pub-cache
+notifications:
+  email:
+    johnsonmh+github@gmail.com
+
+# Only building master means that we don't run two builds for each pull request.
+branches:
+  only: [master]

--- a/lib/google_fonts.dart
+++ b/lib/google_fonts.dart
@@ -34,8 +34,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/abeezee/v13/esDR31xSG-6AGleN6tKukbcHCpE.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/abeezee/v13/esDT31xSG-6AGleN2tCklZUCGpG-GQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/abeezee/v13/esDR31xSG-6AGleN6tKukbcHCpE.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/abeezee/v13/esDT31xSG-6AGleN2tCklZUCGpG-GQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -104,7 +106,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/abel/v10/MwQ5bhbm2POE6VhLPJp6qGI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/abel/v10/MwQ5bhbm2POE6VhLPJp6qGI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -173,11 +176,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/abhayalibre/v5/e3tmeuGtX-Co5MNzeAOqinEge0PWovdU4w.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/abhayalibre/v5/e3t5euGtX-Co5MNzeAOqinEYj2ryqtxI6oYtBA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/abhayalibre/v5/e3t5euGtX-Co5MNzeAOqinEYo23yqtxI6oYtBA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/abhayalibre/v5/e3t5euGtX-Co5MNzeAOqinEYx2zyqtxI6oYtBA.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/abhayalibre/v5/e3t5euGtX-Co5MNzeAOqinEY22_yqtxI6oYtBA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/abhayalibre/v5/e3tmeuGtX-Co5MNzeAOqinEge0PWovdU4w.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/abhayalibre/v5/e3t5euGtX-Co5MNzeAOqinEYj2ryqtxI6oYtBA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/abhayalibre/v5/e3t5euGtX-Co5MNzeAOqinEYo23yqtxI6oYtBA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/abhayalibre/v5/e3t5euGtX-Co5MNzeAOqinEYx2zyqtxI6oYtBA.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/abhayalibre/v5/e3t5euGtX-Co5MNzeAOqinEY22_yqtxI6oYtBA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -246,7 +254,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/abrilfatface/v11/zOL64pLDlL1D99S8g8PtiKchm-BsjOLhZBY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/abrilfatface/v11/zOL64pLDlL1D99S8g8PtiKchm-BsjOLhZBY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -315,7 +324,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/aclonica/v10/K2FyfZJVlfNNSEBXGb7TCI6oBjLz.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/aclonica/v10/K2FyfZJVlfNNSEBXGb7TCI6oBjLz.ttf',
     };
 
     return googleFontsTextStyle(
@@ -384,7 +394,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/acme/v9/RrQfboBx-C5_bx3Lb23lzLk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/acme/v9/RrQfboBx-C5_bx3Lb23lzLk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -453,7 +464,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/actor/v9/wEOzEBbCkc5cO3ekXygtUMIO.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/actor/v9/wEOzEBbCkc5cO3ekXygtUMIO.ttf',
     };
 
     return googleFontsTextStyle(
@@ -522,7 +534,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/adamina/v13/j8_r6-DH1bjoc-dwu-reETl4Bno.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/adamina/v13/j8_r6-DH1bjoc-dwu-reETl4Bno.ttf',
     };
 
     return googleFontsTextStyle(
@@ -591,13 +604,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/adventpro/v10/V8mCoQfxVT4Dvddr_yOwjVmtLZxcBtItFw.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/adventpro/v10/V8mDoQfxVT4Dvddr_yOwjfWMDbZyCts0DqQ.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/adventpro/v10/V8mDoQfxVT4Dvddr_yOwjZGPDbZyCts0DqQ.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/adventpro/v10/V8mAoQfxVT4Dvddr_yOwtT2nKb5ZFtI.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/adventpro/v10/V8mDoQfxVT4Dvddr_yOwjcmODbZyCts0DqQ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/adventpro/v10/V8mDoQfxVT4Dvddr_yOwjeWJDbZyCts0DqQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/adventpro/v10/V8mDoQfxVT4Dvddr_yOwjYGIDbZyCts0DqQ.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/adventpro/v10/V8mCoQfxVT4Dvddr_yOwjVmtLZxcBtItFw.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/adventpro/v10/V8mDoQfxVT4Dvddr_yOwjfWMDbZyCts0DqQ.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/adventpro/v10/V8mDoQfxVT4Dvddr_yOwjZGPDbZyCts0DqQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/adventpro/v10/V8mAoQfxVT4Dvddr_yOwtT2nKb5ZFtI.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/adventpro/v10/V8mDoQfxVT4Dvddr_yOwjcmODbZyCts0DqQ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/adventpro/v10/V8mDoQfxVT4Dvddr_yOwjeWJDbZyCts0DqQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/adventpro/v10/V8mDoQfxVT4Dvddr_yOwjYGIDbZyCts0DqQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -666,7 +686,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/aguafinascript/v8/If2QXTv_ZzSxGIO30LemWEOmt1bHqs4pgicOrg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/aguafinascript/v8/If2QXTv_ZzSxGIO30LemWEOmt1bHqs4pgicOrg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -735,7 +756,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/akronim/v9/fdN-9sqWtWZZlHRp-gBxkFYN-a8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/akronim/v9/fdN-9sqWtWZZlHRp-gBxkFYN-a8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -804,7 +826,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/aladin/v8/ZgNSjPJFPrvJV5f16Sf4pGT2Ng.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/aladin/v8/ZgNSjPJFPrvJV5f16Sf4pGT2Ng.ttf',
     };
 
     return googleFontsTextStyle(
@@ -873,7 +896,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/alata/v1/PbytFmztEwbIofe6xKcRQEOX.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/alata/v1/PbytFmztEwbIofe6xKcRQEOX.ttf',
     };
 
     return googleFontsTextStyle(
@@ -942,7 +966,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/alatsi/v1/TK3iWkUJAxQ2nLNGHjUHte5fKg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/alatsi/v1/TK3iWkUJAxQ2nLNGHjUHte5fKg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1011,7 +1036,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/aldrich/v10/MCoTzAn-1s3IGyJMZaAS3pP5H_E.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/aldrich/v10/MCoTzAn-1s3IGyJMZaAS3pP5H_E.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1080,8 +1106,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/alef/v11/FeVfS0NQpLYgrjJbC5FxxbU.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/alef/v11/FeVQS0NQpLYglo50L5la2bxii28.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/alef/v11/FeVfS0NQpLYgrjJbC5FxxbU.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/alef/v11/FeVQS0NQpLYglo50L5la2bxii28.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1150,16 +1178,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/alegreya/v13/4UaBrEBBsBhlBjvfkRLmzanB44N1.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/alegreya/v13/4UaHrEBBsBhlBjvfkSLkx63j5pN1MwI.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/alegreya/v13/4UaGrEBBsBhlBjvfkSoS5I3JyJ98KhtH.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/alegreya/v13/4UaErEBBsBhlBjvfkSLk_1nKwpteLwtHJlc.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/alegreya/v13/4UaGrEBBsBhlBjvfkSpa4o3JyJ98KhtH.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/alegreya/v13/4UaErEBBsBhlBjvfkSLk_xHMwpteLwtHJlc.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/alegreya/v13/4UaGrEBBsBhlBjvfkSpG4Y3JyJ98KhtH.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/alegreya/v13/4UaErEBBsBhlBjvfkSLk_w3PwpteLwtHJlc.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/alegreya/v13/4UaGrEBBsBhlBjvfkSpi4I3JyJ98KhtH.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/alegreya/v13/4UaErEBBsBhlBjvfkSLk_ynOwpteLwtHJlc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/alegreya/v13/4UaBrEBBsBhlBjvfkRLmzanB44N1.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/alegreya/v13/4UaHrEBBsBhlBjvfkSLkx63j5pN1MwI.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/alegreya/v13/4UaGrEBBsBhlBjvfkSoS5I3JyJ98KhtH.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/alegreya/v13/4UaErEBBsBhlBjvfkSLk_1nKwpteLwtHJlc.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/alegreya/v13/4UaGrEBBsBhlBjvfkSpa4o3JyJ98KhtH.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/alegreya/v13/4UaErEBBsBhlBjvfkSLk_xHMwpteLwtHJlc.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/alegreya/v13/4UaGrEBBsBhlBjvfkSpG4Y3JyJ98KhtH.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/alegreya/v13/4UaErEBBsBhlBjvfkSLk_w3PwpteLwtHJlc.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/alegreya/v13/4UaGrEBBsBhlBjvfkSpi4I3JyJ98KhtH.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/alegreya/v13/4UaErEBBsBhlBjvfkSLk_ynOwpteLwtHJlc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1228,16 +1266,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/alegreyasc/v11/taiOGmRtCJ62-O0HhNEa-a6o05E5abe_.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/alegreyasc/v11/taiMGmRtCJ62-O0HhNEa-Z6q2ZUbbKe_DGs.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/alegreyasc/v11/taiTGmRtCJ62-O0HhNEa-ZZc-rUxQqu2FXKD.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/alegreyasc/v11/taiRGmRtCJ62-O0HhNEa-Z6q4WEySK-UEGKDBz4.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/alegreyasc/v11/taiTGmRtCJ62-O0HhNEa-ZYU_LUxQqu2FXKD.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/alegreyasc/v11/taiRGmRtCJ62-O0HhNEa-Z6q4Sk0SK-UEGKDBz4.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/alegreyasc/v11/taiTGmRtCJ62-O0HhNEa-ZYI_7UxQqu2FXKD.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/alegreyasc/v11/taiRGmRtCJ62-O0HhNEa-Z6q4TU3SK-UEGKDBz4.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/alegreyasc/v11/taiTGmRtCJ62-O0HhNEa-ZYs_rUxQqu2FXKD.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/alegreyasc/v11/taiRGmRtCJ62-O0HhNEa-Z6q4RE2SK-UEGKDBz4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/alegreyasc/v11/taiOGmRtCJ62-O0HhNEa-a6o05E5abe_.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/alegreyasc/v11/taiMGmRtCJ62-O0HhNEa-Z6q2ZUbbKe_DGs.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/alegreyasc/v11/taiTGmRtCJ62-O0HhNEa-ZZc-rUxQqu2FXKD.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/alegreyasc/v11/taiRGmRtCJ62-O0HhNEa-Z6q4WEySK-UEGKDBz4.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/alegreyasc/v11/taiTGmRtCJ62-O0HhNEa-ZYU_LUxQqu2FXKD.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/alegreyasc/v11/taiRGmRtCJ62-O0HhNEa-Z6q4Sk0SK-UEGKDBz4.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/alegreyasc/v11/taiTGmRtCJ62-O0HhNEa-ZYI_7UxQqu2FXKD.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/alegreyasc/v11/taiRGmRtCJ62-O0HhNEa-Z6q4TU3SK-UEGKDBz4.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/alegreyasc/v11/taiTGmRtCJ62-O0HhNEa-ZYs_rUxQqu2FXKD.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/alegreyasc/v11/taiRGmRtCJ62-O0HhNEa-Z6q4RE2SK-UEGKDBz4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1306,20 +1354,34 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUt9_-1phKLFgshYDvh6Vwt5TltuGdShm5bsg.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUv9_-1phKLFgshYDvh6Vwt7V9V3G1WpGtLsgu7.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUu9_-1phKLFgshYDvh6Vwt5fFPmE18imdCqxI.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUo9_-1phKLFgshYDvh6Vwt7V9VFE92jkVHuxKiBA.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUz9_-1phKLFgshYDvh6Vwt3V1nvEVXlm4.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUt9_-1phKLFgshYDvh6Vwt7V9tuGdShm5bsg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUu9_-1phKLFgshYDvh6Vwt5alOmE18imdCqxI.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUo9_-1phKLFgshYDvh6Vwt7V9VTE52jkVHuxKiBA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUu9_-1phKLFgshYDvh6Vwt5eFImE18imdCqxI.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUo9_-1phKLFgshYDvh6Vwt7V9VBEh2jkVHuxKiBA.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUu9_-1phKLFgshYDvh6Vwt5f1LmE18imdCqxI.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUo9_-1phKLFgshYDvh6Vwt7V9VGEt2jkVHuxKiBA.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUu9_-1phKLFgshYDvh6Vwt5dlKmE18imdCqxI.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/alegreyasans/v10/5aUo9_-1phKLFgshYDvh6Vwt7V9VPEp2jkVHuxKiBA.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUt9_-1phKLFgshYDvh6Vwt5TltuGdShm5bsg.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUv9_-1phKLFgshYDvh6Vwt7V9V3G1WpGtLsgu7.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUu9_-1phKLFgshYDvh6Vwt5fFPmE18imdCqxI.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUo9_-1phKLFgshYDvh6Vwt7V9VFE92jkVHuxKiBA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUz9_-1phKLFgshYDvh6Vwt3V1nvEVXlm4.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUt9_-1phKLFgshYDvh6Vwt7V9tuGdShm5bsg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUu9_-1phKLFgshYDvh6Vwt5alOmE18imdCqxI.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUo9_-1phKLFgshYDvh6Vwt7V9VTE52jkVHuxKiBA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUu9_-1phKLFgshYDvh6Vwt5eFImE18imdCqxI.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUo9_-1phKLFgshYDvh6Vwt7V9VBEh2jkVHuxKiBA.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUu9_-1phKLFgshYDvh6Vwt5f1LmE18imdCqxI.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUo9_-1phKLFgshYDvh6Vwt7V9VGEt2jkVHuxKiBA.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUu9_-1phKLFgshYDvh6Vwt5dlKmE18imdCqxI.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/alegreyasans/v10/5aUo9_-1phKLFgshYDvh6Vwt7V9VPEp2jkVHuxKiBA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1388,20 +1450,34 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGn4-RGJqfMvt7P8FUr0Q1j-Hf1Dipl8g5FPYtmMg.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGl4-RGJqfMvt7P8FUr0Q1j-Hf1BkxdlgRBH452Mvds.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGm4-RGJqfMvt7P8FUr0Q1j-Hf1DuJH0iRrMYJ_K-4.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGk4-RGJqfMvt7P8FUr0Q1j-Hf1BkxdXiZhNaB6O-51OA.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGh4-RGJqfMvt7P8FUr0Q1j-Hf1Nk5v9ixALYs.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGn4-RGJqfMvt7P8FUr0Q1j-Hf1Bkxl8g5FPYtmMg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGm4-RGJqfMvt7P8FUr0Q1j-Hf1DrpG0iRrMYJ_K-4.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGk4-RGJqfMvt7P8FUr0Q1j-Hf1BkxdBidhNaB6O-51OA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGm4-RGJqfMvt7P8FUr0Q1j-Hf1DvJA0iRrMYJ_K-4.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGk4-RGJqfMvt7P8FUr0Q1j-Hf1BkxdTiFhNaB6O-51OA.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGm4-RGJqfMvt7P8FUr0Q1j-Hf1Du5D0iRrMYJ_K-4.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGk4-RGJqfMvt7P8FUr0Q1j-Hf1BkxdUiJhNaB6O-51OA.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGm4-RGJqfMvt7P8FUr0Q1j-Hf1DspC0iRrMYJ_K-4.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGk4-RGJqfMvt7P8FUr0Q1j-Hf1BkxddiNhNaB6O-51OA.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGn4-RGJqfMvt7P8FUr0Q1j-Hf1Dipl8g5FPYtmMg.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGl4-RGJqfMvt7P8FUr0Q1j-Hf1BkxdlgRBH452Mvds.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGm4-RGJqfMvt7P8FUr0Q1j-Hf1DuJH0iRrMYJ_K-4.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGk4-RGJqfMvt7P8FUr0Q1j-Hf1BkxdXiZhNaB6O-51OA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGh4-RGJqfMvt7P8FUr0Q1j-Hf1Nk5v9ixALYs.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGn4-RGJqfMvt7P8FUr0Q1j-Hf1Bkxl8g5FPYtmMg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGm4-RGJqfMvt7P8FUr0Q1j-Hf1DrpG0iRrMYJ_K-4.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGk4-RGJqfMvt7P8FUr0Q1j-Hf1BkxdBidhNaB6O-51OA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGm4-RGJqfMvt7P8FUr0Q1j-Hf1DvJA0iRrMYJ_K-4.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGk4-RGJqfMvt7P8FUr0Q1j-Hf1BkxdTiFhNaB6O-51OA.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGm4-RGJqfMvt7P8FUr0Q1j-Hf1Du5D0iRrMYJ_K-4.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGk4-RGJqfMvt7P8FUr0Q1j-Hf1BkxdUiJhNaB6O-51OA.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGm4-RGJqfMvt7P8FUr0Q1j-Hf1DspC0iRrMYJ_K-4.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/alegreyasanssc/v9/mtGk4-RGJqfMvt7P8FUr0Q1j-Hf1BkxddiNhNaB6O-51OA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1470,12 +1546,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/aleo/v3/c4mg1nF8G8_syKbr9DVDno985KM.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/aleo/v3/c4mi1nF8G8_swAjxeDdJmq159KOnWA.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/aleo/v3/c4mv1nF8G8_s8ArD0D1ogoY.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/aleo/v3/c4mh1nF8G8_swAjJ1B9tkoZl_Q.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/aleo/v3/c4mg1nF8G8_syLbs9DVDno985KM.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/aleo/v3/c4mi1nF8G8_swAjxaDBJmq159KOnWA.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/aleo/v3/c4mg1nF8G8_syKbr9DVDno985KM.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/aleo/v3/c4mi1nF8G8_swAjxeDdJmq159KOnWA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/aleo/v3/c4mv1nF8G8_s8ArD0D1ogoY.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/aleo/v3/c4mh1nF8G8_swAjJ1B9tkoZl_Q.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/aleo/v3/c4mg1nF8G8_syLbs9DVDno985KM.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/aleo/v3/c4mi1nF8G8_swAjxaDBJmq159KOnWA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1544,7 +1626,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/alexbrush/v11/SZc83FzrJKuqFbwMKk6EtUL57DtOmCc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/alexbrush/v11/SZc83FzrJKuqFbwMKk6EtUL57DtOmCc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1613,7 +1696,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/alfaslabone/v9/6NUQ8FmMKwSEKjnm5-4v-4Jh6dVretWvYmE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/alfaslabone/v9/6NUQ8FmMKwSEKjnm5-4v-4Jh6dVretWvYmE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1682,7 +1766,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/alice/v11/OpNCnoEEmtHa6FcJpA_chzJ0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/alice/v11/OpNCnoEEmtHa6FcJpA_chzJ0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1751,7 +1836,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/alike/v12/HI_EiYEYI6BIoEjBSZXAQ4-d.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/alike/v12/HI_EiYEYI6BIoEjBSZXAQ4-d.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1820,7 +1906,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/alikeangular/v10/3qTrojWunjGQtEBlIcwMbSoI3kM6bB7FKjE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/alikeangular/v10/3qTrojWunjGQtEBlIcwMbSoI3kM6bB7FKjE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1889,8 +1976,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/allan/v12/ea8XadU7WuTxEtb2P9SF8nZE.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/allan/v12/ea8aadU7WuTxEu5KEPCN2WpNgEKU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/allan/v12/ea8XadU7WuTxEtb2P9SF8nZE.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/allan/v12/ea8aadU7WuTxEu5KEPCN2WpNgEKU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -1959,7 +2048,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/allerta/v10/TwMO-IAHRlkbx940UnEdSQqO5uY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/allerta/v10/TwMO-IAHRlkbx940UnEdSQqO5uY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2028,7 +2118,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/allertastencil/v10/HTx0L209KT-LmIE9N7OR6eiycOeF-zz313DuvQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/allertastencil/v10/HTx0L209KT-LmIE9N7OR6eiycOeF-zz313DuvQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2097,7 +2188,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/allura/v8/9oRPNYsQpS4zjuAPjAIXPtrrGA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/allura/v8/9oRPNYsQpS4zjuAPjAIXPtrrGA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2166,10 +2258,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/almarai/v2/tssoApxBaigK_hnnS_anhnicoq72sXg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/almarai/v2/tsstApxBaigK_hnnc1qPonC3vqc.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/almarai/v2/tssoApxBaigK_hnnS-aghnicoq72sXg.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/almarai/v2/tssoApxBaigK_hnnS_qjhnicoq72sXg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/almarai/v2/tssoApxBaigK_hnnS_anhnicoq72sXg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/almarai/v2/tsstApxBaigK_hnnc1qPonC3vqc.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/almarai/v2/tssoApxBaigK_hnnS-aghnicoq72sXg.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/almarai/v2/tssoApxBaigK_hnnS_qjhnicoq72sXg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2238,10 +2334,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/almendra/v12/H4ckBXKAlMnTn0CskyY6wr-wg763.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/almendra/v12/H4ciBXKAlMnTn0CskxY4yLuShq63czE.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/almendra/v12/H4cjBXKAlMnTn0Cskx6G7Zu4qKK-aihq.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/almendra/v12/H4chBXKAlMnTn0CskxY48Ae9oqacbzhqDtg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/almendra/v12/H4ckBXKAlMnTn0CskyY6wr-wg763.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/almendra/v12/H4ciBXKAlMnTn0CskxY4yLuShq63czE.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/almendra/v12/H4cjBXKAlMnTn0Cskx6G7Zu4qKK-aihq.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/almendra/v12/H4chBXKAlMnTn0CskxY48Ae9oqacbzhqDtg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2310,7 +2410,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/almendradisplay/v10/0FlPVOGWl1Sb4O3tETtADHRRlZhzXS_eTyer338.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/almendradisplay/v10/0FlPVOGWl1Sb4O3tETtADHRRlZhzXS_eTyer338.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2379,7 +2480,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/almendrasc/v10/Iure6Yx284eebowr7hbyTZZJprVA4XQ0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/almendrasc/v10/Iure6Yx284eebowr7hbyTZZJprVA4XQ0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2448,7 +2550,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/amarante/v7/xMQXuF1KTa6EvGx9bq-3C3rAmD-b.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/amarante/v7/xMQXuF1KTa6EvGx9bq-3C3rAmD-b.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2517,10 +2620,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/amaranth/v10/KtkuALODe433f0j1zPnCF9GqwnzW.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/amaranth/v10/KtkoALODe433f0j1zMnAHdWIx2zWD4I.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/amaranth/v10/KtkpALODe433f0j1zMF-OPWi6WDfFpuc.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/amaranth/v10/KtkrALODe433f0j1zMnAJWmn42T9E4ucRY8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/amaranth/v10/KtkuALODe433f0j1zPnCF9GqwnzW.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/amaranth/v10/KtkoALODe433f0j1zMnAHdWIx2zWD4I.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/amaranth/v10/KtkpALODe433f0j1zMF-OPWi6WDfFpuc.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/amaranth/v10/KtkrALODe433f0j1zMnAJWmn42T9E4ucRY8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2589,8 +2696,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/amaticsc/v13/TUZyzwprpvBS1izr_vO0De6ecZQf1A.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/amaticsc/v13/TUZ3zwprpvBS1izr_vOMscG6eb8D3WTy-A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/amaticsc/v13/TUZyzwprpvBS1izr_vO0De6ecZQf1A.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/amaticsc/v13/TUZ3zwprpvBS1izr_vOMscG6eb8D3WTy-A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2659,7 +2768,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/amethysta/v8/rP2Fp2K15kgb_F3ibfWIGDWCBl0O8Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/amethysta/v8/rP2Fp2K15kgb_F3ibfWIGDWCBl0O8Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2728,9 +2838,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/amiko/v4/WwkQxPq1DFK04tqlc17MMZgJ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/amiko/v4/WwkdxPq1DFK04uJ9XXrEGoQAUco5.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/amiko/v4/WwkdxPq1DFK04uIZXHrEGoQAUco5.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/amiko/v4/WwkQxPq1DFK04tqlc17MMZgJ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/amiko/v4/WwkdxPq1DFK04uJ9XXrEGoQAUco5.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/amiko/v4/WwkdxPq1DFK04uIZXHrEGoQAUco5.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2799,10 +2912,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/amiri/v13/J7aRnpd8CGxBHqUpvrIw74NL.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/amiri/v13/J7afnpd8CGxBHpUrtLYS6pNLAjk.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/amiri/v13/J7acnpd8CGxBHp2VkZY4xJ9CGyAa.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/amiri/v13/J7aanpd8CGxBHpUrjAo9zptgHjAavCA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/amiri/v13/J7aRnpd8CGxBHqUpvrIw74NL.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/amiri/v13/J7afnpd8CGxBHpUrtLYS6pNLAjk.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/amiri/v13/J7acnpd8CGxBHp2VkZY4xJ9CGyAa.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/amiri/v13/J7aanpd8CGxBHpUrjAo9zptgHjAavCA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2871,8 +2988,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/amita/v5/HhyaU5si9Om7PQlvAfSKEZZL.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/amita/v5/HhyXU5si9Om7PTHTLtCCOopCTKkI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/amita/v5/HhyaU5si9Om7PQlvAfSKEZZL.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/amita/v5/HhyXU5si9Om7PTHTLtCCOopCTKkI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -2941,7 +3060,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/anaheim/v7/8vII7w042Wp87g4G0UTUEE5eK_w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/anaheim/v7/8vII7w042Wp87g4G0UTUEE5eK_w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3010,7 +3130,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/andada/v11/uK_y4riWaego3w9RCh0TMv6EXw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/andada/v11/uK_y4riWaego3w9RCh0TMv6EXw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3079,7 +3200,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/andika/v11/mem_Ya6iyW-LwqgAbbwRWrwGVA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/andika/v11/mem_Ya6iyW-LwqgAbbwRWrwGVA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3148,7 +3270,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/angkor/v12/H4cmBXyAlsPdnlb-8iw-4Lqggw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/angkor/v12/H4cmBXyAlsPdnlb-8iw-4Lqggw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3217,7 +3340,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/annieuseyourtelescope/v10/daaLSS4tI2qYYl3Jq9s_Hu74xwktnlKxH6osGVGjlDfB3UUVZA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/annieuseyourtelescope/v10/daaLSS4tI2qYYl3Jq9s_Hu74xwktnlKxH6osGVGjlDfB3UUVZA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3248,19 +3372,26 @@ class GoogleFonts {
   static TextTheme annieUseYourTelescopeTextTheme([TextTheme textTheme]) {
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(
-      display4: GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.display4),
-      display3: GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.display3),
-      display2: GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.display2),
-      display1: GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.display1),
-      headline: GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.headline),
+      display4:
+          GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.display4),
+      display3:
+          GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.display3),
+      display2:
+          GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.display2),
+      display1:
+          GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.display1),
+      headline:
+          GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.headline),
       title: GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.title),
       subhead: GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.subhead),
       body2: GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.body2),
       body1: GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.body1),
       caption: GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.caption),
       button: GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.button),
-      subtitle: GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.subtitle),
-      overline: GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.overline),
+      subtitle:
+          GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.subtitle),
+      overline:
+          GoogleFonts.annieUseYourTelescope(textStyle: textTheme?.overline),
     );
   }
 
@@ -3286,10 +3417,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/anonymouspro/v13/rP2Bp2a15UIB7Un-bOeISG3pLlw89CH98Ko.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/anonymouspro/v13/rP2fp2a15UIB7Un-bOeISG3pHl428AP44Kqr2Q.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/anonymouspro/v13/rP2cp2a15UIB7Un-bOeISG3pFuAT0CnW7KOywKo.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/anonymouspro/v13/rP2ap2a15UIB7Un-bOeISG3pHl4OTCzc6IG30KqB9Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/anonymouspro/v13/rP2Bp2a15UIB7Un-bOeISG3pLlw89CH98Ko.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/anonymouspro/v13/rP2fp2a15UIB7Un-bOeISG3pHl428AP44Kqr2Q.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/anonymouspro/v13/rP2cp2a15UIB7Un-bOeISG3pFuAT0CnW7KOywKo.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/anonymouspro/v13/rP2ap2a15UIB7Un-bOeISG3pHl4OTCzc6IG30KqB9Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3358,7 +3493,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/antic/v11/TuGfUVB8XY5DRaZLodgzydtk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/antic/v11/TuGfUVB8XY5DRaZLodgzydtk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3427,7 +3563,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/anticdidone/v8/RWmPoKKX6u8sp8fIWdnDKqDiqYsGBGBzCw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/anticdidone/v8/RWmPoKKX6u8sp8fIWdnDKqDiqYsGBGBzCw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3496,7 +3633,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/anticslab/v8/bWt97fPFfRzkCa9Jlp6IWcJWXW5p5Qo.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/anticslab/v8/bWt97fPFfRzkCa9Jlp6IWcJWXW5p5Qo.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3565,7 +3703,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/anton/v11/1Ptgg87LROyAm0K08i4gS7lu.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/anton/v11/1Ptgg87LROyAm0K08i4gS7lu.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3634,8 +3773,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/arapey/v8/-W__XJn-UDDA2RC6Z9AcZkIzeg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/arapey/v8/-W_9XJn-UDDA2RCKZdoYREcjeo0k.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/arapey/v8/-W__XJn-UDDA2RC6Z9AcZkIzeg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/arapey/v8/-W_9XJn-UDDA2RCKZdoYREcjeo0k.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3704,7 +3845,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/arbutus/v9/NaPYcZ7dG_5J3poob9JtryO8fMU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/arbutus/v9/NaPYcZ7dG_5J3poob9JtryO8fMU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3773,7 +3915,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/arbutusslab/v8/oY1Z8e7OuLXkJGbXtr5ba7ZVa68dJlaFAQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/arbutusslab/v8/oY1Z8e7OuLXkJGbXtr5ba7ZVa68dJlaFAQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3842,7 +3985,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/architectsdaughter/v10/KtkxAKiDZI_td1Lkx62xHZHDtgO_Y-bvfY5q4szgE-Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/architectsdaughter/v10/KtkxAKiDZI_td1Lkx62xHZHDtgO_Y-bvfY5q4szgE-Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3911,14 +4055,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/archivo/v6/k3kQo8UDI-1M0wlSTd7iL0nAMaM.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/archivo/v6/k3kSo8UDI-1M0wlSfdzoK2vFIaOV8A.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/archivo/v6/k3kVo8UDI-1M0wlSdSrLC0HrLaqM6Q4.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/archivo/v6/k3kXo8UDI-1M0wlSfdzQ30LhKYiJ-Q7m8w.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/archivo/v6/k3kVo8UDI-1M0wlSdQbMC0HrLaqM6Q4.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/archivo/v6/k3kXo8UDI-1M0wlSfdzQ80XhKYiJ-Q7m8w.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/archivo/v6/k3kVo8UDI-1M0wlSdWLNC0HrLaqM6Q4.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/archivo/v6/k3kXo8UDI-1M0wlSfdzQl0ThKYiJ-Q7m8w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/archivo/v6/k3kQo8UDI-1M0wlSTd7iL0nAMaM.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/archivo/v6/k3kSo8UDI-1M0wlSfdzoK2vFIaOV8A.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/archivo/v6/k3kVo8UDI-1M0wlSdSrLC0HrLaqM6Q4.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/archivo/v6/k3kXo8UDI-1M0wlSfdzQ30LhKYiJ-Q7m8w.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/archivo/v6/k3kVo8UDI-1M0wlSdQbMC0HrLaqM6Q4.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/archivo/v6/k3kXo8UDI-1M0wlSfdzQ80XhKYiJ-Q7m8w.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/archivo/v6/k3kVo8UDI-1M0wlSdWLNC0HrLaqM6Q4.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/archivo/v6/k3kXo8UDI-1M0wlSfdzQl0ThKYiJ-Q7m8w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -3987,7 +4139,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/archivoblack/v9/HTxqL289NzCGg4MzN6KJ7eW6OYuP_x7yx3A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/archivoblack/v9/HTxqL289NzCGg4MzN6KJ7eW6OYuP_x7yx3A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4056,14 +4209,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/archivonarrow/v11/tss0ApVBdCYD5Q7hcxTE1ArZ0Yb3g31S2s8p.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/archivonarrow/v11/tss2ApVBdCYD5Q7hcxTE1ArZ0bb1iXlw398pJxk.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/archivonarrow/v11/tss3ApVBdCYD5Q7hcxTE1ArZ0b4Dqlla8dMgPgBu.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/archivonarrow/v11/tssxApVBdCYD5Q7hcxTE1ArZ0bb1sY1Z-9cCOxBu_BM.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/archivonarrow/v11/tss3ApVBdCYD5Q7hcxTE1ArZ0b4vrVla8dMgPgBu.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/archivonarrow/v11/tssxApVBdCYD5Q7hcxTE1ArZ0bb1saFe-9cCOxBu_BM.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/archivonarrow/v11/tss3ApVBdCYD5Q7hcxTE1ArZ0b5LrFla8dMgPgBu.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/archivonarrow/v11/tssxApVBdCYD5Q7hcxTE1ArZ0bb1scVf-9cCOxBu_BM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/archivonarrow/v11/tss0ApVBdCYD5Q7hcxTE1ArZ0Yb3g31S2s8p.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/archivonarrow/v11/tss2ApVBdCYD5Q7hcxTE1ArZ0bb1iXlw398pJxk.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/archivonarrow/v11/tss3ApVBdCYD5Q7hcxTE1ArZ0b4Dqlla8dMgPgBu.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/archivonarrow/v11/tssxApVBdCYD5Q7hcxTE1ArZ0bb1sY1Z-9cCOxBu_BM.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/archivonarrow/v11/tss3ApVBdCYD5Q7hcxTE1ArZ0b4vrVla8dMgPgBu.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/archivonarrow/v11/tssxApVBdCYD5Q7hcxTE1ArZ0bb1saFe-9cCOxBu_BM.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/archivonarrow/v11/tss3ApVBdCYD5Q7hcxTE1ArZ0b5LrFla8dMgPgBu.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/archivonarrow/v11/tssxApVBdCYD5Q7hcxTE1ArZ0bb1scVf-9cCOxBu_BM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4132,8 +4293,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/arefruqaa/v8/WwkbxPW1E165rajQKDulEIAiVNo5xNY.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/arefruqaa/v8/WwkYxPW1E165rajQKDulKDwNcNIS2N_7Bdk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/arefruqaa/v8/WwkbxPW1E165rajQKDulEIAiVNo5xNY.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/arefruqaa/v8/WwkYxPW1E165rajQKDulKDwNcNIS2N_7Bdk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4202,14 +4365,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/arimamadurai/v5/t5t4IRoeKYORG0WNMgnC3seB1V3PqrGCch4Drg.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/arimamadurai/v5/t5t7IRoeKYORG0WNMgnC3seB1fHuipusfhcat2c.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/arimamadurai/v5/t5t7IRoeKYORG0WNMgnC3seB1ZXtipusfhcat2c.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/arimamadurai/v5/t5tmIRoeKYORG0WNMgnC3seB7TnFrpOHYh4.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/arimamadurai/v5/t5t7IRoeKYORG0WNMgnC3seB1c3sipusfhcat2c.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/arimamadurai/v5/t5t7IRoeKYORG0WNMgnC3seB1YXqipusfhcat2c.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/arimamadurai/v5/t5t7IRoeKYORG0WNMgnC3seB1Znpipusfhcat2c.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/arimamadurai/v5/t5t7IRoeKYORG0WNMgnC3seB1b3oipusfhcat2c.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/arimamadurai/v5/t5t4IRoeKYORG0WNMgnC3seB1V3PqrGCch4Drg.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/arimamadurai/v5/t5t7IRoeKYORG0WNMgnC3seB1fHuipusfhcat2c.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/arimamadurai/v5/t5t7IRoeKYORG0WNMgnC3seB1ZXtipusfhcat2c.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/arimamadurai/v5/t5tmIRoeKYORG0WNMgnC3seB7TnFrpOHYh4.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/arimamadurai/v5/t5t7IRoeKYORG0WNMgnC3seB1c3sipusfhcat2c.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/arimamadurai/v5/t5t7IRoeKYORG0WNMgnC3seB1YXqipusfhcat2c.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/arimamadurai/v5/t5t7IRoeKYORG0WNMgnC3seB1Znpipusfhcat2c.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/arimamadurai/v5/t5t7IRoeKYORG0WNMgnC3seB1b3oipusfhcat2c.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4278,10 +4449,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/arimo/v13/P5sMzZCDf9_T_20eziBMjI-u.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/arimo/v13/P5sCzZCDf9_T_10cxCRuiZ-uydg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/arimo/v13/P5sBzZCDf9_T_1Wi4QREp5On0ME2.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/arimo/v13/P5sHzZCDf9_T_10c_JhBrZeF1dE2PY4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/arimo/v13/P5sMzZCDf9_T_20eziBMjI-u.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/arimo/v13/P5sCzZCDf9_T_10cxCRuiZ-uydg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/arimo/v13/P5sBzZCDf9_T_1Wi4QREp5On0ME2.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/arimo/v13/P5sHzZCDf9_T_10c_JhBrZeF1dE2PY4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4350,7 +4525,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/arizonia/v10/neIIzCemt4A5qa7mv6WGHK06UY30.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/arizonia/v10/neIIzCemt4A5qa7mv6WGHK06UY30.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4419,7 +4595,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/armata/v11/gokvH63_HV5jQ-E9lD53Q2u_mQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/armata/v11/gokvH63_HV5jQ-E9lD53Q2u_mQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4488,10 +4665,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/arsenal/v4/wXKrE3kQtZQ4pF3D11_WAewrhXY.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/arsenal/v4/wXKpE3kQtZQ4pF3D513cBc4ulXYrtA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/arsenal/v4/wXKuE3kQtZQ4pF3D7-P5JeQAmX8yrdk.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/arsenal/v4/wXKsE3kQtZQ4pF3D513kueEKnV03vdnKjw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/arsenal/v4/wXKrE3kQtZQ4pF3D11_WAewrhXY.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/arsenal/v4/wXKpE3kQtZQ4pF3D513cBc4ulXYrtA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/arsenal/v4/wXKuE3kQtZQ4pF3D7-P5JeQAmX8yrdk.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/arsenal/v4/wXKsE3kQtZQ4pF3D513kueEKnV03vdnKjw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4560,7 +4741,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/artifika/v10/VEMyRoxzronptCuxu6Wt5jDtreOL.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/artifika/v10/VEMyRoxzronptCuxu6Wt5jDtreOL.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4629,10 +4811,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/arvo/v13/tDbD2oWUg0MKmSAa7Lzr7vs.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/arvo/v13/tDbN2oWUg0MKqSIQ6J7u_vvijQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/arvo/v13/tDbM2oWUg0MKoZw1yLTA8vL7lAE.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/arvo/v13/tDbO2oWUg0MKqSIoVLHK9tD-hAHkGg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/arvo/v13/tDbD2oWUg0MKmSAa7Lzr7vs.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/arvo/v13/tDbN2oWUg0MKqSIQ6J7u_vvijQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/arvo/v13/tDbM2oWUg0MKoZw1yLTA8vL7lAE.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/arvo/v13/tDbO2oWUg0MKqSIoVLHK9tD-hAHkGg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4701,8 +4887,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/arya/v5/ga6CawNG-HJd9Ub1-beqdFE.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/arya/v5/ga6NawNG-HJdzfra3b-BaFg3dRE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/arya/v5/ga6CawNG-HJd9Ub1-beqdFE.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/arya/v5/ga6NawNG-HJdzfra3b-BaFg3dRE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4771,14 +4959,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/asap/v11/KFOoCniXp96a-zwU4UROGzY.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/asap/v11/KFOmCniXp96ayz4e5WZLCzYlKw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/asap/v11/KFOnCniXp96aw8g9xUxlBz88MsA.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/asap/v11/KFOlCniXp96ayz4mEU9vAx05IsDqlA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/asap/v11/KFOnCniXp96aw-Q6xUxlBz88MsA.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/asap/v11/KFOlCniXp96ayz4mPUhvAx05IsDqlA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/asap/v11/KFOnCniXp96aw4A7xUxlBz88MsA.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/asap/v11/KFOlCniXp96ayz4mWUlvAx05IsDqlA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/asap/v11/KFOoCniXp96a-zwU4UROGzY.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/asap/v11/KFOmCniXp96ayz4e5WZLCzYlKw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/asap/v11/KFOnCniXp96aw8g9xUxlBz88MsA.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/asap/v11/KFOlCniXp96ayz4mEU9vAx05IsDqlA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/asap/v11/KFOnCniXp96aw-Q6xUxlBz88MsA.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/asap/v11/KFOlCniXp96ayz4mPUhvAx05IsDqlA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/asap/v11/KFOnCniXp96aw4A7xUxlBz88MsA.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/asap/v11/KFOlCniXp96ayz4mWUlvAx05IsDqlA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4847,14 +5043,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/asapcondensed/v5/pxidypY1o9NHyXh3WvSbGSggdNeLYk1Mq3ap.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/asapcondensed/v5/pxifypY1o9NHyXh3WvSbGSggdOeJaElurmapvvM.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/asapcondensed/v5/pxieypY1o9NHyXh3WvSbGSggdO9_S2lEgGqgp-pO.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/asapcondensed/v5/pxiYypY1o9NHyXh3WvSbGSggdOeJUL1Him6CovpOkXA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/asapcondensed/v5/pxieypY1o9NHyXh3WvSbGSggdO9TTGlEgGqgp-pO.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/asapcondensed/v5/pxiYypY1o9NHyXh3WvSbGSggdOeJUJFAim6CovpOkXA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/asapcondensed/v5/pxieypY1o9NHyXh3WvSbGSggdO83TWlEgGqgp-pO.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/asapcondensed/v5/pxiYypY1o9NHyXh3WvSbGSggdOeJUPVBim6CovpOkXA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/asapcondensed/v5/pxidypY1o9NHyXh3WvSbGSggdNeLYk1Mq3ap.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/asapcondensed/v5/pxifypY1o9NHyXh3WvSbGSggdOeJaElurmapvvM.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/asapcondensed/v5/pxieypY1o9NHyXh3WvSbGSggdO9_S2lEgGqgp-pO.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/asapcondensed/v5/pxiYypY1o9NHyXh3WvSbGSggdOeJUL1Him6CovpOkXA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/asapcondensed/v5/pxieypY1o9NHyXh3WvSbGSggdO9TTGlEgGqgp-pO.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/asapcondensed/v5/pxiYypY1o9NHyXh3WvSbGSggdOeJUJFAim6CovpOkXA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/asapcondensed/v5/pxieypY1o9NHyXh3WvSbGSggdO83TWlEgGqgp-pO.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/asapcondensed/v5/pxiYypY1o9NHyXh3WvSbGSggdOeJUPVBim6CovpOkXA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4923,7 +5127,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/asar/v7/sZlLdRyI6TBIXkYQDLlTW6E.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/asar/v7/sZlLdRyI6TBIXkYQDLlTW6E.ttf',
     };
 
     return googleFontsTextStyle(
@@ -4992,7 +5197,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/asset/v10/SLXGc1na-mM4cWImRJqExst1.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/asset/v10/SLXGc1na-mM4cWImRJqExst1.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5061,12 +5267,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/assistant/v4/2sDZZGJYnIjSi6H75xk7p0ScA5cZbCjItw.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/assistant/v4/2sDZZGJYnIjSi6H75xk7w0ecA5cZbCjItw.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/assistant/v4/2sDcZGJYnIjSi6H75xkDb2-4C7wFZQ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/assistant/v4/2sDZZGJYnIjSi6H75xk7t0GcA5cZbCjItw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/assistant/v4/2sDZZGJYnIjSi6H75xk700CcA5cZbCjItw.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/assistant/v4/2sDZZGJYnIjSi6H75xk7z0OcA5cZbCjItw.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/assistant/v4/2sDZZGJYnIjSi6H75xk7p0ScA5cZbCjItw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/assistant/v4/2sDZZGJYnIjSi6H75xk7w0ecA5cZbCjItw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/assistant/v4/2sDcZGJYnIjSi6H75xkDb2-4C7wFZQ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/assistant/v4/2sDZZGJYnIjSi6H75xk7t0GcA5cZbCjItw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/assistant/v4/2sDZZGJYnIjSi6H75xk700CcA5cZbCjItw.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/assistant/v4/2sDZZGJYnIjSi6H75xk7z0OcA5cZbCjItw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5135,8 +5347,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/astloch/v11/TuGRUVJ8QI5GSeUjq9wRzMtkH1Q.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/astloch/v11/TuGUUVJ8QI5GSeUjk2A-6MNPA10xLMQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/astloch/v11/TuGRUVJ8QI5GSeUjq9wRzMtkH1Q.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/astloch/v11/TuGUUVJ8QI5GSeUjk2A-6MNPA10xLMQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5205,8 +5419,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/asul/v9/VuJ-dNjKxYr46fMFXK78JIg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/asul/v9/VuJxdNjKxYr40U8qeKbXOIFneRo.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/asul/v9/VuJ-dNjKxYr46fMFXK78JIg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/asul/v9/VuJxdNjKxYr40U8qeKbXOIFneRo.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5275,12 +5491,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/athiti/v4/pe0sMISdLIZIv1wAxDNyAv2-C99ycg.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/athiti/v4/pe0sMISdLIZIv1wAoDByAv2-C99ycg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/athiti/v4/pe0vMISdLIZIv1w4DBhWCtaiAg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/athiti/v4/pe0sMISdLIZIv1wA-DFyAv2-C99ycg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/athiti/v4/pe0sMISdLIZIv1wA1DZyAv2-C99ycg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/athiti/v4/pe0sMISdLIZIv1wAsDdyAv2-C99ycg.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/athiti/v4/pe0sMISdLIZIv1wAxDNyAv2-C99ycg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/athiti/v4/pe0sMISdLIZIv1wAoDByAv2-C99ycg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/athiti/v4/pe0vMISdLIZIv1w4DBhWCtaiAg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/athiti/v4/pe0sMISdLIZIv1wA-DFyAv2-C99ycg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/athiti/v4/pe0sMISdLIZIv1wA1DZyAv2-C99ycg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/athiti/v4/pe0sMISdLIZIv1wAsDdyAv2-C99ycg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5349,11 +5571,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/atma/v5/uK_z4rqWc-Eoo8JzKjc9PvedRkM.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/atma/v5/uK_84rqWc-Eom25bDj8WIv4.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/atma/v5/uK_z4rqWc-Eoo5pyKjc9PvedRkM.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/atma/v5/uK_z4rqWc-Eoo7Z1Kjc9PvedRkM.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/atma/v5/uK_z4rqWc-Eoo9J0Kjc9PvedRkM.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/atma/v5/uK_z4rqWc-Eoo8JzKjc9PvedRkM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/atma/v5/uK_84rqWc-Eom25bDj8WIv4.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/atma/v5/uK_z4rqWc-Eoo5pyKjc9PvedRkM.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/atma/v5/uK_z4rqWc-Eoo7Z1Kjc9PvedRkM.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/atma/v5/uK_z4rqWc-Eoo9J0Kjc9PvedRkM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5422,7 +5649,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/atomicage/v12/f0Xz0eug6sdmRFkYZZGL58Ht9a8GYeA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/atomicage/v12/f0Xz0eug6sdmRFkYZZGL58Ht9a8GYeA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5491,7 +5719,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/aubrey/v12/q5uGsou7NPBw-p7vugNsCxVEgA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/aubrey/v12/q5uGsou7NPBw-p7vugNsCxVEgA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5560,7 +5789,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/audiowide/v8/l7gdbjpo0cum0ckerWCtkQXPExpQBw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/audiowide/v8/l7gdbjpo0cum0ckerWCtkQXPExpQBw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5629,7 +5859,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/autourone/v9/UqyVK80cP25l3fJgbdfbk5lWVscxdKE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/autourone/v9/UqyVK80cP25l3fJgbdfbk5lWVscxdKE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5698,7 +5929,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/average/v8/fC1hPYBHe23MxA7rIeJwVWytTyk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/average/v8/fC1hPYBHe23MxA7rIeJwVWytTyk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5767,7 +5999,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/averagesans/v8/1Ptpg8fLXP2dlAXR-HlJJNJPBdqazVoK4A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/averagesans/v8/1Ptpg8fLXP2dlAXR-HlJJNJPBdqazVoK4A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5836,7 +6069,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/averiagruesalibre/v8/NGSov4nEGEktOaDRKsY-1dhh8eEtIx3ZUmmJw0SLRA8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/averiagruesalibre/v8/NGSov4nEGEktOaDRKsY-1dhh8eEtIx3ZUmmJw0SLRA8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5905,12 +6139,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/averialibre/v8/2V0FKIcMGZEnV6xygz7eNjEarovtb07t-pQgTw.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/averialibre/v8/2V0HKIcMGZEnV6xygz7eNjESAJFhbUTp2JEwT4Sk.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/averialibre/v8/2V0aKIcMGZEnV6xygz7eNjEiAqPJZ2Xx8w.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/averialibre/v8/2V0EKIcMGZEnV6xygz7eNjESAKnNRWDh8405.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/averialibre/v8/2V0FKIcMGZEnV6xygz7eNjEavoztb07t-pQgTw.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/averialibre/v8/2V0HKIcMGZEnV6xygz7eNjESAJFxakTp2JEwT4Sk.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/averialibre/v8/2V0FKIcMGZEnV6xygz7eNjEarovtb07t-pQgTw.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/averialibre/v8/2V0HKIcMGZEnV6xygz7eNjESAJFhbUTp2JEwT4Sk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/averialibre/v8/2V0aKIcMGZEnV6xygz7eNjEiAqPJZ2Xx8w.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/averialibre/v8/2V0EKIcMGZEnV6xygz7eNjESAKnNRWDh8405.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/averialibre/v8/2V0FKIcMGZEnV6xygz7eNjEavoztb07t-pQgTw.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/averialibre/v8/2V0HKIcMGZEnV6xygz7eNjESAJFxakTp2JEwT4Sk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -5979,12 +6219,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/averiasanslibre/v8/ga6SaxZG_G5OvCf_rt7FH3B6BHLMEd3lMKcQJZP1LmD9.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/averiasanslibre/v8/ga6caxZG_G5OvCf_rt7FH3B6BHLMEdVLKisSL5fXK3D9qtg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/averiasanslibre/v8/ga6XaxZG_G5OvCf_rt7FH3B6BHLMEeVJGIMYDo_8.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/averiasanslibre/v8/ga6RaxZG_G5OvCf_rt7FH3B6BHLMEdVLEoc6C5_8N3k.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/averiasanslibre/v8/ga6SaxZG_G5OvCf_rt7FH3B6BHLMEd31N6cQJZP1LmD9.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/averiasanslibre/v8/ga6caxZG_G5OvCf_rt7FH3B6BHLMEdVLKjsVL5fXK3D9qtg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/averiasanslibre/v8/ga6SaxZG_G5OvCf_rt7FH3B6BHLMEd3lMKcQJZP1LmD9.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/averiasanslibre/v8/ga6caxZG_G5OvCf_rt7FH3B6BHLMEdVLKisSL5fXK3D9qtg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/averiasanslibre/v8/ga6XaxZG_G5OvCf_rt7FH3B6BHLMEeVJGIMYDo_8.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/averiasanslibre/v8/ga6RaxZG_G5OvCf_rt7FH3B6BHLMEdVLEoc6C5_8N3k.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/averiasanslibre/v8/ga6SaxZG_G5OvCf_rt7FH3B6BHLMEd31N6cQJZP1LmD9.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/averiasanslibre/v8/ga6caxZG_G5OvCf_rt7FH3B6BHLMEdVLKjsVL5fXK3D9qtg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6053,12 +6299,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/averiaseriflibre/v9/neIVzD2ms4wxr6GvjeD0X88SHPyX2xYGCSmqwacqdrKvbQ.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/averiaseriflibre/v9/neIbzD2ms4wxr6GvjeD0X88SHPyX2xYOpzMmw60uVLe_bXHq.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/averiaseriflibre/v9/neIWzD2ms4wxr6GvjeD0X88SHPyX2xY-pQGOyYw2fw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/averiaseriflibre/v9/neIUzD2ms4wxr6GvjeD0X88SHPyX2xYOpwuK64kmf6u2.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/averiaseriflibre/v9/neIVzD2ms4wxr6GvjeD0X88SHPyX2xYGGS6qwacqdrKvbQ.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/averiaseriflibre/v9/neIbzD2ms4wxr6GvjeD0X88SHPyX2xYOpzM2xK0uVLe_bXHq.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/averiaseriflibre/v9/neIVzD2ms4wxr6GvjeD0X88SHPyX2xYGCSmqwacqdrKvbQ.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/averiaseriflibre/v9/neIbzD2ms4wxr6GvjeD0X88SHPyX2xYOpzMmw60uVLe_bXHq.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/averiaseriflibre/v9/neIWzD2ms4wxr6GvjeD0X88SHPyX2xY-pQGOyYw2fw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/averiaseriflibre/v9/neIUzD2ms4wxr6GvjeD0X88SHPyX2xYOpwuK64kmf6u2.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/averiaseriflibre/v9/neIVzD2ms4wxr6GvjeD0X88SHPyX2xYGGS6qwacqdrKvbQ.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/averiaseriflibre/v9/neIbzD2ms4wxr6GvjeD0X88SHPyX2xYOpzM2xK0uVLe_bXHq.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6127,10 +6379,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/b612/v4/3JnySDDxiSz32jm4GDigUXw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/b612/v4/3Jn8SDDxiSz36juyHBqlQXwdVw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/b612/v4/3Jn9SDDxiSz34oWXPDCLTXUETuE.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/b612/v4/3Jn_SDDxiSz36juKoDWBSVcBXuFb0Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/b612/v4/3JnySDDxiSz32jm4GDigUXw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/b612/v4/3Jn8SDDxiSz36juyHBqlQXwdVw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/b612/v4/3Jn9SDDxiSz34oWXPDCLTXUETuE.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/b612/v4/3Jn_SDDxiSz36juKoDWBSVcBXuFb0Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6199,10 +6455,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/b612mono/v4/kmK_Zq85QVWbN1eW6lJl1wTcquRTtg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/b612mono/v4/kmK5Zq85QVWbN1eW6lJV1Q7YiOFDtqtf.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/b612mono/v4/kmK6Zq85QVWbN1eW6lJdayv4os9Pv7JGSg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/b612mono/v4/kmKkZq85QVWbN1eW6lJV1TZkp8VLnbdWSg4x.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/b612mono/v4/kmK_Zq85QVWbN1eW6lJl1wTcquRTtg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/b612mono/v4/kmK5Zq85QVWbN1eW6lJV1Q7YiOFDtqtf.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/b612mono/v4/kmK6Zq85QVWbN1eW6lJdayv4os9Pv7JGSg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/b612mono/v4/kmKkZq85QVWbN1eW6lJV1TZkp8VLnbdWSg4x.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6271,7 +6531,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/badscript/v8/6NUT8F6PJgbFWQn47_x7lOwuzd1AZtw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/badscript/v8/6NUT8F6PJgbFWQn47_x7lOwuzd1AZtw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6340,7 +6601,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bahiana/v4/uU9PCBUV4YenPWJU7xPb3vyHmlI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bahiana/v4/uU9PCBUV4YenPWJU7xPb3vyHmlI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6409,7 +6671,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bahianita/v2/yYLr0hTb3vuqqsBUgxWtxTvV2NJPcA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bahianita/v2/yYLr0hTb3vuqqsBUgxWtxTvV2NJPcA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6478,18 +6741,30 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/baijamjuree/v3/LDIqapSCOBt_aeQQ7ftydoa0kePuk5A1-yiSgA.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/baijamjuree/v3/LDIoapSCOBt_aeQQ7ftydoa8W_oGkpox2S2CgOva.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/baijamjuree/v3/LDIqapSCOBt_aeQQ7ftydoa09eDuk5A1-yiSgA.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/baijamjuree/v3/LDIoapSCOBt_aeQQ7ftydoa8W_pikZox2S2CgOva.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/baijamjuree/v3/LDI1apSCOBt_aeQQ7ftydoaMWcjKm7sp8g.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/baijamjuree/v3/LDIrapSCOBt_aeQQ7ftydoa8W8LOub458jGL.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/baijamjuree/v3/LDIqapSCOBt_aeQQ7ftydoa0reHuk5A1-yiSgA.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/baijamjuree/v3/LDIoapSCOBt_aeQQ7ftydoa8W_o6kJox2S2CgOva.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/baijamjuree/v3/LDIqapSCOBt_aeQQ7ftydoa0gebuk5A1-yiSgA.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/baijamjuree/v3/LDIoapSCOBt_aeQQ7ftydoa8W_oWl5ox2S2CgOva.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/baijamjuree/v3/LDIqapSCOBt_aeQQ7ftydoa05efuk5A1-yiSgA.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/baijamjuree/v3/LDIoapSCOBt_aeQQ7ftydoa8W_pylpox2S2CgOva.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/baijamjuree/v3/LDIqapSCOBt_aeQQ7ftydoa0kePuk5A1-yiSgA.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/baijamjuree/v3/LDIoapSCOBt_aeQQ7ftydoa8W_oGkpox2S2CgOva.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/baijamjuree/v3/LDIqapSCOBt_aeQQ7ftydoa09eDuk5A1-yiSgA.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/baijamjuree/v3/LDIoapSCOBt_aeQQ7ftydoa8W_pikZox2S2CgOva.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/baijamjuree/v3/LDI1apSCOBt_aeQQ7ftydoaMWcjKm7sp8g.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/baijamjuree/v3/LDIrapSCOBt_aeQQ7ftydoa8W8LOub458jGL.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/baijamjuree/v3/LDIqapSCOBt_aeQQ7ftydoa0reHuk5A1-yiSgA.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/baijamjuree/v3/LDIoapSCOBt_aeQQ7ftydoa8W_o6kJox2S2CgOva.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/baijamjuree/v3/LDIqapSCOBt_aeQQ7ftydoa0gebuk5A1-yiSgA.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/baijamjuree/v3/LDIoapSCOBt_aeQQ7ftydoa8W_oWl5ox2S2CgOva.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/baijamjuree/v3/LDIqapSCOBt_aeQQ7ftydoa05efuk5A1-yiSgA.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/baijamjuree/v3/LDIoapSCOBt_aeQQ7ftydoa8W_pylpox2S2CgOva.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6558,7 +6833,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/baloo/v5/6xKhdSpJJ92I9PWIAG_5LWwJ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/baloo/v5/6xKhdSpJJ92I9PWIAG_5LWwJ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6627,7 +6903,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/baloobhai/v5/ZgNWjP5GM7bCUdmXgWyVjGXEM4COoE4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/baloobhai/v5/ZgNWjP5GM7bCUdmXgWyVjGXEM4COoE4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6696,7 +6973,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/baloobhaijaan/v6/RWmRoKCU5fcqq8fOWNzFLqSjx4ECJmVjC0-V.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/baloobhaijaan/v6/RWmRoKCU5fcqq8fOWNzFLqSjx4ECJmVjC0-V.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6765,7 +7043,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/baloobhaina/v5/Noa16Uzzzp2FIkfhq5vm9thxPAR9mhHobg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/baloobhaina/v5/Noa16Uzzzp2FIkfhq5vm9thxPAR9mhHobg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6834,7 +7113,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/baloochettan/v5/0QImMXRN8o2gTC2YTr4665DA07z8_ApHqqk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/baloochettan/v5/0QImMXRN8o2gTC2YTr4665DA07z8_ApHqqk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6903,7 +7183,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/balooda/v5/LhWmMVnXOfIZO795FXkfSvtVM8mZ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/balooda/v5/LhWmMVnXOfIZO795FXkfSvtVM8mZ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -6972,7 +7253,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/baloopaaji/v6/8AttGsyxM5KQQU-Y4MTwVZnToxvQBiot.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/baloopaaji/v6/8AttGsyxM5KQQU-Y4MTwVZnToxvQBiot.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7041,7 +7323,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/balootamma/v6/JTUTjIk68Cy27gWhOWIghE5B5Arr-s50.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/balootamma/v6/JTUTjIk68Cy27gWhOWIghE5B5Arr-s50.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7110,7 +7393,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/balootammudu/v6/mFT3Wb8Qza7c_Z5HTsC_5nxW8EpQl9RWxD8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/balootammudu/v6/mFT3Wb8Qza7c_Z5HTsC_5nxW8EpQl9RWxD8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7179,7 +7463,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/baloothambi/v5/va9B4kXJzNhTFoA7CYcS8sHuQR37fF3Wlg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/baloothambi/v5/va9B4kXJzNhTFoA7CYcS8sHuQR37fF3Wlg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7248,7 +7533,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/balthazar/v9/d6lKkaajS8Gm4CVQjFEvyRTo39l8hw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/balthazar/v9/d6lKkaajS8Gm4CVQjFEvyRTo39l8hw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7317,7 +7603,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bangers/v12/FeVQS0BTqb0h60ACL5la2bxii28.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bangers/v12/FeVQS0BTqb0h60ACL5la2bxii28.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7386,24 +7673,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/barlow/v4/7cHrv4kjgoGqM7E3b8s8yn4hnCci.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/barlow/v4/7cHtv4kjgoGqM7E_CfNYwHoDmTcibrA.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E3w-oc4FAtlT47dw.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfP04Voptzsrd6m9.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E3p-kc4FAtlT47dw.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfOQ4loptzsrd6m9.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/barlow/v4/7cHpv4kjgoGqM7EPC8E46HsxnA.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/barlow/v4/7cHrv4kjgoGqM7E_Ccs8yn4hnCci.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E3_-gc4FAtlT47dw.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfPI41optzsrd6m9.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E30-8c4FAtlT47dw.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfPk5Foptzsrd6m9.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E3t-4c4FAtlT47dw.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfOA5Voptzsrd6m9.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E3q-0c4FAtlT47dw.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfOc5loptzsrd6m9.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E3j-wc4FAtlT47dw.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfO451optzsrd6m9.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHrv4kjgoGqM7E3b8s8yn4hnCci.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHtv4kjgoGqM7E_CfNYwHoDmTcibrA.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E3w-oc4FAtlT47dw.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfP04Voptzsrd6m9.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E3p-kc4FAtlT47dw.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfOQ4loptzsrd6m9.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHpv4kjgoGqM7EPC8E46HsxnA.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHrv4kjgoGqM7E_Ccs8yn4hnCci.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E3_-gc4FAtlT47dw.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfPI41optzsrd6m9.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E30-8c4FAtlT47dw.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfPk5Foptzsrd6m9.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E3t-4c4FAtlT47dw.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfOA5Voptzsrd6m9.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E3q-0c4FAtlT47dw.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfOc5loptzsrd6m9.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHqv4kjgoGqM7E3j-wc4FAtlT47dw.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/barlow/v4/7cHsv4kjgoGqM7E_CfO451optzsrd6m9.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7472,24 +7777,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxxL3I-JCGChYJ8VI-L6OO_au7B43LT31vytKgbaw.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxzL3I-JCGChYJ8VI-L6OO_au7B6xTru1H2lq0La6JN.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B497y_3HcuKECcrs.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrF3DWvIMHYrtUxg.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B47rx_3HcuKECcrs.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrc3PWvIMHYrtUxg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTx3L3I-JCGChYJ8VI-L6OO_au7B2xbZ23n3pKg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxxL3I-JCGChYJ8VI-L6OO_au7B6xTT31vytKgbaw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B4-Lw_3HcuKECcrs.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrK3LWvIMHYrtUxg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B4873_3HcuKECcrs.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrB3XWvIMHYrtUxg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B46r2_3HcuKECcrs.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrY3TWvIMHYrtUxg.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B47b1_3HcuKECcrs.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrf3fWvIMHYrtUxg.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B45L0_3HcuKECcrs.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrW3bWvIMHYrtUxg.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxxL3I-JCGChYJ8VI-L6OO_au7B43LT31vytKgbaw.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxzL3I-JCGChYJ8VI-L6OO_au7B6xTru1H2lq0La6JN.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B497y_3HcuKECcrs.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrF3DWvIMHYrtUxg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B47rx_3HcuKECcrs.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrc3PWvIMHYrtUxg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTx3L3I-JCGChYJ8VI-L6OO_au7B2xbZ23n3pKg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxxL3I-JCGChYJ8VI-L6OO_au7B6xTT31vytKgbaw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B4-Lw_3HcuKECcrs.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrK3LWvIMHYrtUxg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B4873_3HcuKECcrs.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrB3XWvIMHYrtUxg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B46r2_3HcuKECcrs.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrY3TWvIMHYrtUxg.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B47b1_3HcuKECcrs.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrf3fWvIMHYrtUxg.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxwL3I-JCGChYJ8VI-L6OO_au7B45L0_3HcuKECcrs.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/barlowcondensed/v4/HTxyL3I-JCGChYJ8VI-L6OO_au7B6xTrW3bWvIMHYrtUxg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7558,24 +7881,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlphgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRfG4qvKk8ogoSP.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpjgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbLLIEsKh5SPZWs.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRft6uPAGEki52WfA.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbJnAWsgqZiGfHK5.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRf06iPAGEki52WfA.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbIDAmsgqZiGfHK5.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpvgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRnf4CrCEo4gg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlphgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfYqvKk8ogoSP.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRfi6mPAGEki52WfA.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbJbA2sgqZiGfHK5.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRfp66PAGEki52WfA.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbJ3BGsgqZiGfHK5.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRfw6-PAGEki52WfA.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbITBWsgqZiGfHK5.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRf36yPAGEki52WfA.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbIPBmsgqZiGfHK5.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRf-62PAGEki52WfA.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbIrB2sgqZiGfHK5.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlphgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRfG4qvKk8ogoSP.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpjgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbLLIEsKh5SPZWs.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRft6uPAGEki52WfA.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbJnAWsgqZiGfHK5.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRf06iPAGEki52WfA.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbIDAmsgqZiGfHK5.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpvgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRnf4CrCEo4gg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlphgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfYqvKk8ogoSP.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRfi6mPAGEki52WfA.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbJbA2sgqZiGfHK5.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRfp66PAGEki52WfA.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbJ3BGsgqZiGfHK5.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRfw6-PAGEki52WfA.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbITBWsgqZiGfHK5.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRf36yPAGEki52WfA.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbIPBmsgqZiGfHK5.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpigxjLBV1hqnzfr-F8sEYMB0Yybp0mudRf-62PAGEki52WfA.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/barlowsemicondensed/v5/wlpkgxjLBV1hqnzfr-F8sEYMB0Yybp0mudRXfbIrB2sgqZiGfHK5.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7644,7 +7985,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/barriecito/v2/WWXXlj-CbBOSLY2QTuY_KdUiYwTO0MU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/barriecito/v2/WWXXlj-CbBOSLY2QTuY_KdUiYwTO0MU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7713,7 +8055,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/barrio/v4/wEO8EBXBk8hBIDiEdQYhWdsX1Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/barrio/v4/wEO8EBXBk8hBIDiEdQYhWdsX1Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7782,7 +8125,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/basic/v9/xfu_0WLxV2_XKQN34lDVyR7D.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/basic/v9/xfu_0WLxV2_XKQN34lDVyR7D.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7851,8 +8195,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/baskervville/v1/YA9Ur0yU4l_XOrogbkun3kQgt5OohvbJ9A.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/baskervville/v1/YA9Kr0yU4l_XOrogbkun3kQQtZmspPPZ9Mlt.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/baskervville/v1/YA9Ur0yU4l_XOrogbkun3kQgt5OohvbJ9A.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/baskervville/v1/YA9Kr0yU4l_XOrogbkun3kQQtZmspPPZ9Mlt.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7921,8 +8267,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/battambang/v13/uk-mEGe7raEw-HjkzZabDnWj4yxx7o8.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/battambang/v13/uk-lEGe7raEw-HjkzZabNsmMxyRa8oZK9I0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/battambang/v13/uk-mEGe7raEw-HjkzZabDnWj4yxx7o8.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/battambang/v13/uk-lEGe7raEw-HjkzZabNsmMxyRa8oZK9I0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -7991,7 +8339,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/baumans/v9/-W_-XJj9QyTd3QfpR_oyaksqY5Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/baumans/v9/-W_-XJj9QyTd3QfpR_oyaksqY5Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8060,7 +8409,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bayon/v13/9XUrlJNmn0LPFl-pOhYEd2NJ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bayon/v13/9XUrlJNmn0LPFl-pOhYEd2NJ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8129,20 +8479,34 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVxdDflz-iPfoPuIC2iKsUn7W1hK2czPg.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVvdDflz-iPfoPuIC2iIqMfiWdlCWIjPi5p.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVwdDflz-iPfoPuIC2iKg0FzUdPJ24qJzc.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVudDflz-iPfoPuIC2iIqMfQUVFI0wvNzdwXQ.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVzdDflz-iPfoPuIC2iEqEt6U9kO2c.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVxdDflz-iPfoPuIC2iIqMn7W1hK2czPg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVwdDflz-iPfoPuIC2iKlUEzUdPJ24qJzc.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVudDflz-iPfoPuIC2iIqMfGURFI0wvNzdwXQ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVwdDflz-iPfoPuIC2iKnkDzUdPJ24qJzc.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVudDflz-iPfoPuIC2iIqMfNUNFI0wvNzdwXQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVwdDflz-iPfoPuIC2iKh0CzUdPJ24qJzc.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVudDflz-iPfoPuIC2iIqMfUUJFI0wvNzdwXQ.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVwdDflz-iPfoPuIC2iKgEBzUdPJ24qJzc.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/bevietnam/v1/FBVudDflz-iPfoPuIC2iIqMfTUFFI0wvNzdwXQ.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVxdDflz-iPfoPuIC2iKsUn7W1hK2czPg.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVvdDflz-iPfoPuIC2iIqMfiWdlCWIjPi5p.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVwdDflz-iPfoPuIC2iKg0FzUdPJ24qJzc.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVudDflz-iPfoPuIC2iIqMfQUVFI0wvNzdwXQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVzdDflz-iPfoPuIC2iEqEt6U9kO2c.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVxdDflz-iPfoPuIC2iIqMn7W1hK2czPg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVwdDflz-iPfoPuIC2iKlUEzUdPJ24qJzc.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVudDflz-iPfoPuIC2iIqMfGURFI0wvNzdwXQ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVwdDflz-iPfoPuIC2iKnkDzUdPJ24qJzc.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVudDflz-iPfoPuIC2iIqMfNUNFI0wvNzdwXQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVwdDflz-iPfoPuIC2iKh0CzUdPJ24qJzc.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVudDflz-iPfoPuIC2iIqMfUUJFI0wvNzdwXQ.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVwdDflz-iPfoPuIC2iKgEBzUdPJ24qJzc.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/bevietnam/v1/FBVudDflz-iPfoPuIC2iIqMfTUFFI0wvNzdwXQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8211,7 +8575,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bebasneue/v1/JTUSjIg69CK48gW7PXooxW5rygbi49c.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bebasneue/v1/JTUSjIg69CK48gW7PXooxW5rygbi49c.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8280,7 +8645,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/belgrano/v10/55xvey5tM9rwKWrJZcMFirl08KDJ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/belgrano/v10/55xvey5tM9rwKWrJZcMFirl08KDJ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8349,7 +8715,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bellefair/v5/kJExBuYY6AAuhiXUxG19__A2pOdvDA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bellefair/v5/kJExBuYY6AAuhiXUxG19__A2pOdvDA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8418,7 +8785,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/belleza/v8/0nkoC9_pNeMfhX4BtcbyawzruP8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/belleza/v8/0nkoC9_pNeMfhX4BtcbyawzruP8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8487,9 +8855,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/benchnine/v8/ahcev8612zF4jxrwMosT--tRhWa8q0v8ag.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/benchnine/v8/ahcbv8612zF4jxrwMosrV8N1jU2gog.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/benchnine/v8/ahcev8612zF4jxrwMosT6-xRhWa8q0v8ag.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/benchnine/v8/ahcev8612zF4jxrwMosT--tRhWa8q0v8ag.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/benchnine/v8/ahcbv8612zF4jxrwMosrV8N1jU2gog.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/benchnine/v8/ahcev8612zF4jxrwMosT6-xRhWa8q0v8ag.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8558,7 +8929,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bentham/v10/VdGeAZQPEpYfmHglKWw7CJaK_y4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bentham/v10/VdGeAZQPEpYfmHglKWw7CJaK_y4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8627,7 +8999,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/berkshireswash/v8/ptRRTi-cavZOGqCvnNJDl5m5XmNPrcQybX4pQA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/berkshireswash/v8/ptRRTi-cavZOGqCvnNJDl5m5XmNPrcQybX4pQA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8696,7 +9069,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bethellen/v1/WwkbxPW2BE-3rb_JNT-qEIAiVNo5xNY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bethellen/v1/WwkbxPW2BE-3rb_JNT-qEIAiVNo5xNY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8765,7 +9139,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bevan/v11/4iCj6KZ0a9NXjF8aUir7tlSJ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bevan/v11/4iCj6KZ0a9NXjF8aUir7tlSJ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8834,14 +9209,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1xPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1Ur9DrDJYM2lAZ.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1yPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1UZ_LLJrgA00kAdA.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1_PZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1sy9rvLpMc2g.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1yPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1UP_PLJrgA00kAdA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1yPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1UE_TLJrgA00kAdA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1yPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1Ud_XLJrgA00kAdA.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1yPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1Ua_bLJrgA00kAdA.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1yPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1UT_fLJrgA00kAdA.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1xPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1Ur9DrDJYM2lAZ.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1yPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1UZ_LLJrgA00kAdA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1_PZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1sy9rvLpMc2g.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1yPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1UP_PLJrgA00kAdA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1yPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1UE_TLJrgA00kAdA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1yPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1Ud_XLJrgA00kAdA.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1yPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1Ua_bLJrgA00kAdA.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/bigshouldersdisplay/v1/fC1yPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx1UT_fLJrgA00kAdA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8910,14 +9293,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xzezRtP9G3CGPIf49hxc8P0eytUxBU-IZ_YscCdXQB.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xyezRtP9G3CGPIf49hxc8P0eytUxBUMKRfSOkOfG0Y3A.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xxezRtP9G3CGPIf49hxc8P0eytUxBsnIx7QMISdQ.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xyezRtP9G3CGPIf49hxc8P0eytUxBUaKVfSOkOfG0Y3A.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xyezRtP9G3CGPIf49hxc8P0eytUxBURKJfSOkOfG0Y3A.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xyezRtP9G3CGPIf49hxc8P0eytUxBUIKNfSOkOfG0Y3A.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xyezRtP9G3CGPIf49hxc8P0eytUxBUPKBfSOkOfG0Y3A.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xyezRtP9G3CGPIf49hxc8P0eytUxBUGKFfSOkOfG0Y3A.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xzezRtP9G3CGPIf49hxc8P0eytUxBU-IZ_YscCdXQB.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xyezRtP9G3CGPIf49hxc8P0eytUxBUMKRfSOkOfG0Y3A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xxezRtP9G3CGPIf49hxc8P0eytUxBsnIx7QMISdQ.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xyezRtP9G3CGPIf49hxc8P0eytUxBUaKVfSOkOfG0Y3A.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xyezRtP9G3CGPIf49hxc8P0eytUxBURKJfSOkOfG0Y3A.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xyezRtP9G3CGPIf49hxc8P0eytUxBUIKNfSOkOfG0Y3A.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xyezRtP9G3CGPIf49hxc8P0eytUxBUPKBfSOkOfG0Y3A.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/bigshoulderstext/v1/55xyezRtP9G3CGPIf49hxc8P0eytUxBUGKFfSOkOfG0Y3A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -8986,7 +9377,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bigelowrules/v8/RrQWboly8iR_I3KWSzeRuN0zT4cCH8WAJVk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bigelowrules/v8/RrQWboly8iR_I3KWSzeRuN0zT4cCH8WAJVk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9055,7 +9447,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bigshotone/v10/u-470qukhRkkO6BD_7cM_gxuUQJBXv_-.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bigshotone/v10/u-470qukhRkkO6BD_7cM_gxuUQJBXv_-.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9124,7 +9517,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bilbo/v9/o-0EIpgpwWwZ210hpIRz4wxE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bilbo/v9/o-0EIpgpwWwZ210hpIRz4wxE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9193,7 +9587,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bilboswashcaps/v12/zrf-0GXbz-H3Wb4XBsGrTgq2PVmdqAPopiRfKp8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bilboswashcaps/v12/zrf-0GXbz-H3Wb4XBsGrTgq2PVmdqAPopiRfKp8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9262,11 +9657,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/biorhyme/v4/1cX3aULHBpDMsHYW_ESOjnGAq8Sk1PoH.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/biorhyme/v4/1cX3aULHBpDMsHYW_ETqjXGAq8Sk1PoH.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/biorhyme/v4/1cXwaULHBpDMsHYW_HxGpVWIgNit.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/biorhyme/v4/1cX3aULHBpDMsHYW_ET6inGAq8Sk1PoH.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/biorhyme/v4/1cX3aULHBpDMsHYW_ETmiXGAq8Sk1PoH.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/biorhyme/v4/1cX3aULHBpDMsHYW_ESOjnGAq8Sk1PoH.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/biorhyme/v4/1cX3aULHBpDMsHYW_ETqjXGAq8Sk1PoH.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/biorhyme/v4/1cXwaULHBpDMsHYW_HxGpVWIgNit.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/biorhyme/v4/1cX3aULHBpDMsHYW_ET6inGAq8Sk1PoH.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/biorhyme/v4/1cX3aULHBpDMsHYW_ETmiXGAq8Sk1PoH.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9335,11 +9735,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/biorhymeexpanded/v5/i7dVIE1zZzytGswgU577CDY9LjbffxxcblSHSdTXrb_z.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/biorhymeexpanded/v5/i7dVIE1zZzytGswgU577CDY9Ljbffxw4bVSHSdTXrb_z.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/biorhymeexpanded/v5/i7dQIE1zZzytGswgU577CDY9LjbffySURXCPYsje.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/biorhymeexpanded/v5/i7dVIE1zZzytGswgU577CDY9LjbffxwoalSHSdTXrb_z.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/biorhymeexpanded/v5/i7dVIE1zZzytGswgU577CDY9Ljbffxw0aVSHSdTXrb_z.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/biorhymeexpanded/v5/i7dVIE1zZzytGswgU577CDY9LjbffxxcblSHSdTXrb_z.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/biorhymeexpanded/v5/i7dVIE1zZzytGswgU577CDY9Ljbffxw4bVSHSdTXrb_z.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/biorhymeexpanded/v5/i7dQIE1zZzytGswgU577CDY9LjbffySURXCPYsje.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/biorhymeexpanded/v5/i7dVIE1zZzytGswgU577CDY9LjbffxwoalSHSdTXrb_z.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/biorhymeexpanded/v5/i7dVIE1zZzytGswgU577CDY9Ljbffxw0aVSHSdTXrb_z.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9408,13 +9813,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/biryani/v5/hv-TlzNxIFoO84YddYQyGTBSU-J-RxQ.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/biryani/v5/hv-TlzNxIFoO84YddeAxGTBSU-J-RxQ.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/biryani/v5/hv-WlzNxIFoO84YdTUwZPTh5T-s.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/biryani/v5/hv-TlzNxIFoO84YddZQ3GTBSU-J-RxQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/biryani/v5/hv-TlzNxIFoO84YddfA2GTBSU-J-RxQ.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/biryani/v5/hv-TlzNxIFoO84Yddew1GTBSU-J-RxQ.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/biryani/v5/hv-TlzNxIFoO84Yddcg0GTBSU-J-RxQ.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/biryani/v5/hv-TlzNxIFoO84YddYQyGTBSU-J-RxQ.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/biryani/v5/hv-TlzNxIFoO84YddeAxGTBSU-J-RxQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/biryani/v5/hv-WlzNxIFoO84YdTUwZPTh5T-s.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/biryani/v5/hv-TlzNxIFoO84YddZQ3GTBSU-J-RxQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/biryani/v5/hv-TlzNxIFoO84YddfA2GTBSU-J-RxQ.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/biryani/v5/hv-TlzNxIFoO84Yddew1GTBSU-J-RxQ.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/biryani/v5/hv-TlzNxIFoO84Yddcg0GTBSU-J-RxQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9483,9 +9895,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bitter/v15/rax8HiqOu8IVPmnLeIZoDDlCmg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/bitter/v15/rax-HiqOu8IVPmn7eoxsLjxSmlLZ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/bitter/v15/rax_HiqOu8IVPmnzxKlMBBJek0vA8A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bitter/v15/rax8HiqOu8IVPmnLeIZoDDlCmg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/bitter/v15/rax-HiqOu8IVPmn7eoxsLjxSmlLZ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/bitter/v15/rax_HiqOu8IVPmnzxKlMBBJek0vA8A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9554,7 +9969,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/blackandwhitepicture/v8/TwMe-JAERlQd3ooUHBUXGmrmioKjjnRSFO-NqI5HbcMi-yWY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/blackandwhitepicture/v8/TwMe-JAERlQd3ooUHBUXGmrmioKjjnRSFO-NqI5HbcMi-yWY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9585,19 +10001,26 @@ class GoogleFonts {
   static TextTheme blackAndWhitePictureTextTheme([TextTheme textTheme]) {
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(
-      display4: GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.display4),
-      display3: GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.display3),
-      display2: GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.display2),
-      display1: GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.display1),
-      headline: GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.headline),
+      display4:
+          GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.display4),
+      display3:
+          GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.display3),
+      display2:
+          GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.display2),
+      display1:
+          GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.display1),
+      headline:
+          GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.headline),
       title: GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.title),
       subhead: GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.subhead),
       body2: GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.body2),
       body1: GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.body1),
       caption: GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.caption),
       button: GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.button),
-      subtitle: GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.subtitle),
-      overline: GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.overline),
+      subtitle:
+          GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.subtitle),
+      overline:
+          GoogleFonts.blackAndWhitePicture(textStyle: textTheme?.overline),
     );
   }
 
@@ -9623,7 +10046,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/blackhansans/v8/ea8Aad44WunzF9a-dL6toA8r8nqVIXSkH-Hc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/blackhansans/v8/ea8Aad44WunzF9a-dL6toA8r8nqVIXSkH-Hc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9692,7 +10116,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/blackopsone/v11/qWcsB6-ypo7xBdr6Xshe96H3WDzRtjkho4M.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/blackopsone/v11/qWcsB6-ypo7xBdr6Xshe96H3WDzRtjkho4M.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9761,14 +10186,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/blinker/v3/cIf_MaFatEE-VTaP_E2hZEsCkIt9QQ.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/blinker/v3/cIf4MaFatEE-VTaP_OGARGEsnIJkWL4.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/blinker/v3/cIf4MaFatEE-VTaP_IWDRGEsnIJkWL4.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/blinker/v3/cIf9MaFatEE-VTaPxCmrYGkHgIs.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/blinker/v3/cIf4MaFatEE-VTaP_PGFRGEsnIJkWL4.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/blinker/v3/cIf4MaFatEE-VTaP_JWERGEsnIJkWL4.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/blinker/v3/cIf4MaFatEE-VTaP_ImHRGEsnIJkWL4.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/blinker/v3/cIf4MaFatEE-VTaP_K2GRGEsnIJkWL4.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/blinker/v3/cIf_MaFatEE-VTaP_E2hZEsCkIt9QQ.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/blinker/v3/cIf4MaFatEE-VTaP_OGARGEsnIJkWL4.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/blinker/v3/cIf4MaFatEE-VTaP_IWDRGEsnIJkWL4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/blinker/v3/cIf9MaFatEE-VTaPxCmrYGkHgIs.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/blinker/v3/cIf4MaFatEE-VTaP_PGFRGEsnIJkWL4.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/blinker/v3/cIf4MaFatEE-VTaP_JWERGEsnIJkWL4.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/blinker/v3/cIf4MaFatEE-VTaP_ImHRGEsnIJkWL4.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/blinker/v3/cIf4MaFatEE-VTaP_K2GRGEsnIJkWL4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9837,7 +10270,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bokor/v12/m8JcjfpeeaqTiR2WdInbcaxE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bokor/v12/m8JcjfpeeaqTiR2WdInbcaxE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9906,7 +10340,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bonbon/v11/0FlVVPeVlFec4ee_cDEAbQY5-A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bonbon/v11/0FlVVPeVlFec4ee_cDEAbQY5-A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -9975,7 +10410,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/boogaloo/v11/kmK-Zq45GAvOdnaW6x1F_SrQo_1K.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/boogaloo/v11/kmK-Zq45GAvOdnaW6x1F_SrQo_1K.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10044,7 +10480,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bowlbyone/v11/taiPGmVuC4y96PFeqp8smo6C_Z0wcK4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bowlbyone/v11/taiPGmVuC4y96PFeqp8smo6C_Z0wcK4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10113,7 +10550,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bowlbyonesc/v11/DtVlJxerQqQm37tzN3wMug9Pzgj8owhNjuE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bowlbyonesc/v11/DtVlJxerQqQm37tzN3wMug9Pzgj8owhNjuE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10182,7 +10620,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/brawler/v10/xn7gYHE3xXewAscGsgC7S9XdZN8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/brawler/v10/xn7gYHE3xXewAscGsgC7S9XdZN8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10251,7 +10690,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/breeserif/v9/4UaHrEJCrhhnVA3DgluAx63j5pN1MwI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/breeserif/v9/4UaHrEJCrhhnVA3DgluAx63j5pN1MwI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10320,7 +10760,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bubblegumsans/v8/AYCSpXb_Z9EORv1M5QTjEzMEtdaHzoPPb7R4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bubblegumsans/v8/AYCSpXb_Z9EORv1M5QTjEzMEtdaHzoPPb7R4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10389,7 +10830,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bubblerone/v8/f0Xy0eqj68ppQV9KBLmAouHH26MPePkt.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bubblerone/v8/f0Xy0eqj68ppQV9KBLmAouHH26MPePkt.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10458,7 +10900,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/buda/v10/GFDqWAN8mnyIJSSrG7UBr7pZKA0.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/buda/v10/GFDqWAN8mnyIJSSrG7UBr7pZKA0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10527,8 +10970,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/buenard/v11/OD5DuM6Cyma8FnnsPzf9qGi9HL4.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/buenard/v11/OD5GuM6Cyma8FnnsB4vSjGCWALepwss.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/buenard/v11/OD5DuM6Cyma8FnnsPzf9qGi9HL4.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/buenard/v11/OD5GuM6Cyma8FnnsB4vSjGCWALepwss.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10597,7 +11042,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bungee/v5/N0bU2SZBIuF2PU_ECn50Kd_PmA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bungee/v5/N0bU2SZBIuF2PU_ECn50Kd_PmA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10666,7 +11112,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bungeehairline/v5/snfys0G548t04270a_ljTLUVrv-7YB2dQ5ZPqQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bungeehairline/v5/snfys0G548t04270a_ljTLUVrv-7YB2dQ5ZPqQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10735,7 +11182,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bungeeinline/v5/Gg8zN58UcgnlCweMrih332VuDGJ1-FEglsc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bungeeinline/v5/Gg8zN58UcgnlCweMrih332VuDGJ1-FEglsc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10804,7 +11252,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bungeeoutline/v5/_6_mEDvmVP24UvU2MyiGDslL3Qg3YhJqPXxo.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bungeeoutline/v5/_6_mEDvmVP24UvU2MyiGDslL3Qg3YhJqPXxo.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10873,7 +11322,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/bungeeshade/v5/DtVkJxarWL0t2KdzK3oI_jks7iLSrwFUlw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/bungeeshade/v5/DtVkJxarWL0t2KdzK3oI_jks7iLSrwFUlw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -10942,7 +11392,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/butcherman/v11/2EbiL-thF0loflXUBOdb1zWzq_5uT84.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/butcherman/v11/2EbiL-thF0loflXUBOdb1zWzq_5uT84.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11011,7 +11462,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/butterflykids/v8/ll8lK2CWTjuqAsXDqlnIbMNs5S4arxFrAX1D.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/butterflykids/v8/ll8lK2CWTjuqAsXDqlnIbMNs5S4arxFrAX1D.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11080,14 +11532,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cabin/v14/u-4x0qWljRw-Pe839fxqmjRv.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/cabin/v14/u-4_0qWljRw-Pd81__hInyRvYwc.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/cabin/v14/u-480qWljRw-PdfD3NhisShmeh5I.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/cabin/v14/u-460qWljRw-Pd81xwxhuyxEfw5IR-Y.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/cabin/v14/u-480qWljRw-Pdfv29hisShmeh5I.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/cabin/v14/u-460qWljRw-Pd81xyBmuyxEfw5IR-Y.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cabin/v14/u-480qWljRw-PdeL2thisShmeh5I.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/cabin/v14/u-460qWljRw-Pd81x0RnuyxEfw5IR-Y.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cabin/v14/u-4x0qWljRw-Pe839fxqmjRv.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/cabin/v14/u-4_0qWljRw-Pd81__hInyRvYwc.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/cabin/v14/u-480qWljRw-PdfD3NhisShmeh5I.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/cabin/v14/u-460qWljRw-Pd81xwxhuyxEfw5IR-Y.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/cabin/v14/u-480qWljRw-Pdfv29hisShmeh5I.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/cabin/v14/u-460qWljRw-Pd81xyBmuyxEfw5IR-Y.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cabin/v14/u-480qWljRw-PdeL2thisShmeh5I.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/cabin/v14/u-460qWljRw-Pd81x0RnuyxEfw5IR-Y.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11156,10 +11616,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cabincondensed/v13/nwpMtK6mNhBK2err_hqkYhHRqmwaYOjZ5HZl8Q.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/cabincondensed/v13/nwpJtK6mNhBK2err_hqkYhHRqmwilMH97F15-K1oqQ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/cabincondensed/v13/nwpJtK6mNhBK2err_hqkYhHRqmwiuMb97F15-K1oqQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cabincondensed/v13/nwpJtK6mNhBK2err_hqkYhHRqmwi3Mf97F15-K1oqQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cabincondensed/v13/nwpMtK6mNhBK2err_hqkYhHRqmwaYOjZ5HZl8Q.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/cabincondensed/v13/nwpJtK6mNhBK2err_hqkYhHRqmwilMH97F15-K1oqQ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/cabincondensed/v13/nwpJtK6mNhBK2err_hqkYhHRqmwiuMb97F15-K1oqQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cabincondensed/v13/nwpJtK6mNhBK2err_hqkYhHRqmwi3Mf97F15-K1oqQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11228,8 +11692,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cabinsketch/v13/QGYpz_kZZAGCONcK2A4bGOjMn9JM6fnuKg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cabinsketch/v13/QGY2z_kZZAGCONcK2A4bGOj0I_1o4dLyI4CMFw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cabinsketch/v13/QGYpz_kZZAGCONcK2A4bGOjMn9JM6fnuKg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cabinsketch/v13/QGY2z_kZZAGCONcK2A4bGOj0I_1o4dLyI4CMFw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11298,7 +11764,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/caesardressing/v8/yYLx0hLa3vawqtwdswbotmK4vrR3cbb6LZttyg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/caesardressing/v8/yYLx0hLa3vawqtwdswbotmK4vrR3cbb6LZttyg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11367,7 +11834,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cagliostro/v8/ZgNWjP5HM73BV5amnX-TjGXEM4COoE4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cagliostro/v8/ZgNWjP5HM73BV5amnX-TjGXEM4COoE4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11436,12 +11904,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/cairo/v6/SLXLc1nY6Hkvalrub76M7dd8aGZk.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/cairo/v6/SLXLc1nY6HkvalqKbL6M7dd8aGZk.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cairo/v6/SLXGc1nY6HkvamImRJqExst1.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/cairo/v6/SLXLc1nY6Hkvalr-ar6M7dd8aGZk.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cairo/v6/SLXLc1nY6Hkvalqaa76M7dd8aGZk.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/cairo/v6/SLXLc1nY6Hkvalqiab6M7dd8aGZk.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/cairo/v6/SLXLc1nY6Hkvalrub76M7dd8aGZk.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/cairo/v6/SLXLc1nY6HkvalqKbL6M7dd8aGZk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cairo/v6/SLXGc1nY6HkvamImRJqExst1.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/cairo/v6/SLXLc1nY6Hkvalr-ar6M7dd8aGZk.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cairo/v6/SLXLc1nY6Hkvalqaa76M7dd8aGZk.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/cairo/v6/SLXLc1nY6Hkvalqiab6M7dd8aGZk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11510,7 +11984,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/calistoga/v1/6NUU8F2OJg6MeR7l4e0vtMYAwdRZfw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/calistoga/v1/6NUU8F2OJg6MeR7l4e0vtMYAwdRZfw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11579,7 +12054,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/calligraffitti/v11/46k2lbT3XjDVqJw3DCmCFjE0vnFZM5ZBpYN-.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/calligraffitti/v11/46k2lbT3XjDVqJw3DCmCFjE0vnFZM5ZBpYN-.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11648,10 +12124,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cambay/v6/SLXJc1rY6H0_ZDsGbrSIz9JsaA.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/cambay/v6/SLXLc1rY6H0_ZDs2bL6M7dd8aGZk.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cambay/v6/SLXKc1rY6H0_ZDs-0pusx_lwYX99kA.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/cambay/v6/SLXMc1rY6H0_ZDs2bIYwwvN0Q3ptkDMN.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cambay/v6/SLXJc1rY6H0_ZDsGbrSIz9JsaA.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/cambay/v6/SLXLc1rY6H0_ZDs2bL6M7dd8aGZk.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cambay/v6/SLXKc1rY6H0_ZDs-0pusx_lwYX99kA.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/cambay/v6/SLXMc1rY6H0_ZDs2bIYwwvN0Q3ptkDMN.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11720,7 +12200,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cambo/v8/IFSqHeNEk8FJk416ok7xkPm8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cambo/v8/IFSqHeNEk8FJk416ok7xkPm8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11789,7 +12270,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/candal/v9/XoHn2YH6T7-t_8cNAR4Jt9Yxlw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/candal/v9/XoHn2YH6T7-t_8cNAR4Jt9Yxlw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11858,10 +12340,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cantarell/v9/B50NF7ZDq37KMUvlO01Ji6hqHK-CLA.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/cantarell/v9/B50LF7ZDq37KMUvlO015iaJuPqqSLJYf.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cantarell/v9/B50IF7ZDq37KMUvlO01xN4dOFISeJY8GgQ.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/cantarell/v9/B50WF7ZDq37KMUvlO015iZrSEY6aB4oWgWHB.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cantarell/v9/B50NF7ZDq37KMUvlO01Ji6hqHK-CLA.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/cantarell/v9/B50LF7ZDq37KMUvlO015iaJuPqqSLJYf.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cantarell/v9/B50IF7ZDq37KMUvlO01xN4dOFISeJY8GgQ.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/cantarell/v9/B50WF7ZDq37KMUvlO015iZrSEY6aB4oWgWHB.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11930,7 +12416,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cantataone/v9/PlI5Fl60Nb5obNzNe2jslVxEt8CwfGaD.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cantataone/v9/PlI5Fl60Nb5obNzNe2jslVxEt8CwfGaD.ttf',
     };
 
     return googleFontsTextStyle(
@@ -11999,7 +12486,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cantoraone/v9/gyB4hws1JdgnKy56GB_JX6zdZ4vZVbgZ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cantoraone/v9/gyB4hws1JdgnKy56GB_JX6zdZ4vZVbgZ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12068,7 +12556,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/capriola/v7/wXKoE3YSppcvo1PDln_8L-AinG8y.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/capriola/v7/wXKoE3YSppcvo1PDln_8L-AinG8y.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12137,9 +12626,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cardo/v11/wlp_gwjKBV1pqiv_1oAZ2H5O.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/cardo/v11/wlpxgwjKBV1pqhv93IQ73W5OcCk.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cardo/v11/wlpygwjKBV1pqhND-aQR82JHaTBX.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cardo/v11/wlp_gwjKBV1pqiv_1oAZ2H5O.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/cardo/v11/wlpxgwjKBV1pqhv93IQ73W5OcCk.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cardo/v11/wlpygwjKBV1pqhND-aQR82JHaTBX.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12208,7 +12700,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/carme/v10/ptRHTiWdbvZIDOjGxLNrxfbZ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/carme/v10/ptRHTiWdbvZIDOjGxLNrxfbZ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12277,7 +12770,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/carroisgothic/v10/Z9XPDmFATg-N1PLtLOOxvIHl9ZmD3i7ajcJ-.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/carroisgothic/v10/Z9XPDmFATg-N1PLtLOOxvIHl9ZmD3i7ajcJ-.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12346,7 +12840,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/carroisgothicsc/v9/ZgNJjOVHM6jfUZCmyUqT2A2HVKjc-28nNHabY4dN.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/carroisgothicsc/v9/ZgNJjOVHM6jfUZCmyUqT2A2HVKjc-28nNHabY4dN.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12415,7 +12910,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/carterone/v11/q5uCsoe5IOB2-pXv9UcNIxR2hYxREMs.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/carterone/v11/q5uCsoe5IOB2-pXv9UcNIxR2hYxREMs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12484,15 +12980,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/catamaran/v6/o-0OIpQoyXQa2RxT7-5jhjRFSfiM7HBj.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jKhVlY9aA5Wl6PQ.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jThZlY9aA5Wl6PQ.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/catamaran/v6/o-0IIpQoyXQa2RxT7-5b4j5Ba_2c7A.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jFhdlY9aA5Wl6PQ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jOhBlY9aA5Wl6PQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jXhFlY9aA5Wl6PQ.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jQhJlY9aA5Wl6PQ.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jZhNlY9aA5Wl6PQ.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/catamaran/v6/o-0OIpQoyXQa2RxT7-5jhjRFSfiM7HBj.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jKhVlY9aA5Wl6PQ.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jThZlY9aA5Wl6PQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/catamaran/v6/o-0IIpQoyXQa2RxT7-5b4j5Ba_2c7A.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jFhdlY9aA5Wl6PQ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jOhBlY9aA5Wl6PQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jXhFlY9aA5Wl6PQ.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jQhJlY9aA5Wl6PQ.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/catamaran/v6/o-0NIpQoyXQa2RxT7-5jZhNlY9aA5Wl6PQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12561,10 +13066,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/caudex/v9/esDQ311QOP6BJUrIyviAnb4eEw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/caudex/v9/esDS311QOP6BJUr4yPKEv7sOE4in.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/caudex/v9/esDT311QOP6BJUrwdteklZUCGpG-GQ.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/caudex/v9/esDV311QOP6BJUr4yMo4kJ8GOJSuGdLB.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/caudex/v9/esDQ311QOP6BJUrIyviAnb4eEw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/caudex/v9/esDS311QOP6BJUr4yPKEv7sOE4in.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/caudex/v9/esDT311QOP6BJUrwdteklZUCGpG-GQ.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/caudex/v9/esDV311QOP6BJUr4yMo4kJ8GOJSuGdLB.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12633,8 +13142,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/caveat/v7/Wnz6HAc5bAfYB2QLYTwZqg_MPQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/caveat/v7/Wnz5HAc5bAfYB2Qz3RM9oiTQNAuxjA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/caveat/v7/Wnz6HAc5bAfYB2QLYTwZqg_MPQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/caveat/v7/Wnz5HAc5bAfYB2Qz3RM9oiTQNAuxjA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12703,7 +13214,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/caveatbrush/v5/EYq0maZfwr9S9-ETZc3fKXtMW7mT03pdQw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/caveatbrush/v5/EYq0maZfwr9S9-ETZc3fKXtMW7mT03pdQw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12772,7 +13284,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cedarvillecursive/v11/yYL00g_a2veiudhUmxjo5VKkoqA-B_neJbBxw8BeTg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cedarvillecursive/v11/yYL00g_a2veiudhUmxjo5VKkoqA-B_neJbBxw8BeTg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12841,7 +13354,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cevicheone/v10/gyB4hws1IcA6JzR-GB_JX6zdZ4vZVbgZ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cevicheone/v10/gyB4hws1IcA6JzR-GB_JX6zdZ4vZVbgZ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12910,16 +13424,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/chakrapetch/v3/cIflMapbsEk7TDLdtEz1BwkeNIhFQJXE3AY00g.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/chakrapetch/v3/cIfnMapbsEk7TDLdtEz1BwkWmpLJQp_A_gMk0izH.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/chakrapetch/v3/cIf6MapbsEk7TDLdtEz1BwkmmKBhSL7Y1Q.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/chakrapetch/v3/cIfkMapbsEk7TDLdtEz1BwkWmqplarvI1R8t.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/chakrapetch/v3/cIflMapbsEk7TDLdtEz1BwkebIlFQJXE3AY00g.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/chakrapetch/v3/cIfnMapbsEk7TDLdtEz1BwkWmpKRQ5_A_gMk0izH.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/chakrapetch/v3/cIflMapbsEk7TDLdtEz1BwkeQI5FQJXE3AY00g.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/chakrapetch/v3/cIfnMapbsEk7TDLdtEz1BwkWmpK9RJ_A_gMk0izH.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/chakrapetch/v3/cIflMapbsEk7TDLdtEz1BwkeJI9FQJXE3AY00g.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/chakrapetch/v3/cIfnMapbsEk7TDLdtEz1BwkWmpLZRZ_A_gMk0izH.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/chakrapetch/v3/cIflMapbsEk7TDLdtEz1BwkeNIhFQJXE3AY00g.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/chakrapetch/v3/cIfnMapbsEk7TDLdtEz1BwkWmpLJQp_A_gMk0izH.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/chakrapetch/v3/cIf6MapbsEk7TDLdtEz1BwkmmKBhSL7Y1Q.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/chakrapetch/v3/cIfkMapbsEk7TDLdtEz1BwkWmqplarvI1R8t.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/chakrapetch/v3/cIflMapbsEk7TDLdtEz1BwkebIlFQJXE3AY00g.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/chakrapetch/v3/cIfnMapbsEk7TDLdtEz1BwkWmpKRQ5_A_gMk0izH.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/chakrapetch/v3/cIflMapbsEk7TDLdtEz1BwkeQI5FQJXE3AY00g.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/chakrapetch/v3/cIfnMapbsEk7TDLdtEz1BwkWmpK9RJ_A_gMk0izH.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/chakrapetch/v3/cIflMapbsEk7TDLdtEz1BwkeJI9FQJXE3AY00g.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/chakrapetch/v3/cIfnMapbsEk7TDLdtEz1BwkWmpLZRZ_A_gMk0izH.ttf',
     };
 
     return googleFontsTextStyle(
@@ -12988,13 +13512,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZy2xQjDp9htf1ZM.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZ_OxQjDp9htf1ZM.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZ62xQjDp9htf1ZM.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZ5-xQjDp9htf1ZM.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZ3O2QjDp9htf1ZM.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZ0q2QjDp9htf1ZM.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZy22QjDp9htf1ZM.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZy2xQjDp9htf1ZM.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZ_OxQjDp9htf1ZM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZ62xQjDp9htf1ZM.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZ5-xQjDp9htf1ZM.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZ3O2QjDp9htf1ZM.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZ0q2QjDp9htf1ZM.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/changa/v8/2-c79JNi2YuVOUcOarRPgnNGooxCZy22QjDp9htf1ZM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13063,8 +13594,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/changaone/v12/xfu00W3wXn3QLUJXhzq46AbouLfbK64.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/changaone/v12/xfu20W3wXn3QLUJXhzq42ATivJXeO67ISw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/changaone/v12/xfu00W3wXn3QLUJXhzq46AbouLfbK64.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/changaone/v12/xfu20W3wXn3QLUJXhzq42ATivJXeO67ISw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13133,7 +13666,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/chango/v8/2V0cKI0OB5U7WaJyz324TFUaAw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/chango/v8/2V0cKI0OB5U7WaJyz324TFUaAw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13202,8 +13736,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/charm/v4/7cHmv4oii5K0MeYvIe804WIo.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/charm/v4/7cHrv4oii5K0Md6TDss8yn4hnCci.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/charm/v4/7cHmv4oii5K0MeYvIe804WIo.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/charm/v4/7cHrv4oii5K0Md6TDss8yn4hnCci.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13272,8 +13808,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/charmonman/v3/MjQDmiR3vP_nuxDv47jiWJGovLdh6OE.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/charmonman/v3/MjQAmiR3vP_nuxDv47jiYC2HmL9K9OhmGnY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/charmonman/v3/MjQDmiR3vP_nuxDv47jiWJGovLdh6OE.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/charmonman/v3/MjQAmiR3vP_nuxDv47jiYC2HmL9K9OhmGnY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13342,11 +13880,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/chathura/v5/_gP91R7-rzUuVjim42dEq0SbTvZyuDo.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/chathura/v5/_gP81R7-rzUuVjim42eMiWSxYPp7oSNy.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/chathura/v5/_gP71R7-rzUuVjim418goUC5S-Zy.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/chathura/v5/_gP81R7-rzUuVjim42ecjmSxYPp7oSNy.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/chathura/v5/_gP81R7-rzUuVjim42eAjWSxYPp7oSNy.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/chathura/v5/_gP91R7-rzUuVjim42dEq0SbTvZyuDo.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/chathura/v5/_gP81R7-rzUuVjim42eMiWSxYPp7oSNy.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/chathura/v5/_gP71R7-rzUuVjim418goUC5S-Zy.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/chathura/v5/_gP81R7-rzUuVjim42ecjmSxYPp7oSNy.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/chathura/v5/_gP81R7-rzUuVjim42eAjWSxYPp7oSNy.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13415,8 +13958,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/chauphilomeneone/v9/55xxezRsPtfie1vPY49qzdgSlJiHRQFsnIx7QMISdQ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/chauphilomeneone/v9/55xzezRsPtfie1vPY49qzdgSlJiHRQFcnoZ_YscCdXQB.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/chauphilomeneone/v9/55xxezRsPtfie1vPY49qzdgSlJiHRQFsnIx7QMISdQ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/chauphilomeneone/v9/55xzezRsPtfie1vPY49qzdgSlJiHRQFcnoZ_YscCdXQB.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13485,7 +14030,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/chelaone/v8/6ae-4KC7Uqgdz_JZdPIy31vWNTMwoQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/chelaone/v8/6ae-4KC7Uqgdz_JZdPIy31vWNTMwoQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13554,7 +14100,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/chelseamarket/v7/BCawqZsHqfr89WNP_IApC8tzKBhlLA4uKkWk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/chelseamarket/v7/BCawqZsHqfr89WNP_IApC8tzKBhlLA4uKkWk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13623,7 +14170,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/chenla/v12/SZc43FDpIKu8WZ9eXxfonUPL6Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/chenla/v12/SZc43FDpIKu8WZ9eXxfonUPL6Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13692,7 +14240,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cherrycreamsoda/v10/UMBIrOxBrW6w2FFyi9paG0fdVdRciTd6Cd47DJ7G.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cherrycreamsoda/v10/UMBIrOxBrW6w2FFyi9paG0fdVdRciTd6Cd47DJ7G.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13761,8 +14310,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cherryswash/v8/i7dNIFByZjaNAMxtZcnfAy58QHi-EwWMbg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cherryswash/v8/i7dSIFByZjaNAMxtZcnfAy5E_FeaGy6QZ3WfYg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cherryswash/v8/i7dNIFByZjaNAMxtZcnfAy58QHi-EwWMbg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cherryswash/v8/i7dSIFByZjaNAMxtZcnfAy5E_FeaGy6QZ3WfYg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13831,7 +14382,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/chewy/v11/uK_94ruUb-k-wk5xIDMfO-ed.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/chewy/v11/uK_94ruUb-k-wk5xIDMfO-ed.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13900,7 +14452,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/chicle/v8/lJwG-pw9i2dqU-BDyWKuobYSxw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/chicle/v8/lJwG-pw9i2dqU-BDyWKuobYSxw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -13969,7 +14522,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/chilanka/v5/WWXRlj2DZQiMJYaYRrJQI9EAZhTO.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/chilanka/v5/WWXRlj2DZQiMJYaYRrJQI9EAZhTO.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14038,14 +14592,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/chivo/v11/va9F4kzIxd1KFrjDY8Z_uqzGQC_-.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/chivo/v11/va9D4kzIxd1KFrBteUp9sKjkRT_-bF0.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/chivo/v11/va9I4kzIxd1KFoBvS-J3kbDP.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/chivo/v11/va9G4kzIxd1KFrBtQeZVlKDPWTY.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/chivo/v11/va9F4kzIxd1KFrjTZMZ_uqzGQC_-.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/chivo/v11/va9D4kzIxd1KFrBteVp6sKjkRT_-bF0.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/chivo/v11/va9F4kzIxd1KFrjrZsZ_uqzGQC_-.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/chivo/v11/va9D4kzIxd1KFrBteWJ4sKjkRT_-bF0.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/chivo/v11/va9F4kzIxd1KFrjDY8Z_uqzGQC_-.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/chivo/v11/va9D4kzIxd1KFrBteUp9sKjkRT_-bF0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/chivo/v11/va9I4kzIxd1KFoBvS-J3kbDP.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/chivo/v11/va9G4kzIxd1KFrBtQeZVlKDPWTY.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/chivo/v11/va9F4kzIxd1KFrjTZMZ_uqzGQC_-.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/chivo/v11/va9D4kzIxd1KFrBteVp6sKjkRT_-bF0.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/chivo/v11/va9F4kzIxd1KFrjrZsZ_uqzGQC_-.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/chivo/v11/va9D4kzIxd1KFrBteWJ4sKjkRT_-bF0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14114,7 +14676,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/chonburi/v4/8AtqGs-wOpGRTBq66IWaFr3biAfZ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/chonburi/v4/8AtqGs-wOpGRTBq66IWaFr3biAfZ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14183,9 +14746,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cinzel/v9/8vIJ7ww63mVu7gtL8W76HEdHMg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cinzel/v9/8vIK7ww63mVu7gtzTUHeFGxbO_zo-w.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/cinzel/v9/8vIK7ww63mVu7gtzdUPeFGxbO_zo-w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cinzel/v9/8vIJ7ww63mVu7gtL8W76HEdHMg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cinzel/v9/8vIK7ww63mVu7gtzTUHeFGxbO_zo-w.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/cinzel/v9/8vIK7ww63mVu7gtzdUPeFGxbO_zo-w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14254,9 +14820,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cinzeldecorative/v8/daaCSScvJGqLYhG8nNt8KPPswUAPnh7URs1LaCyC.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cinzeldecorative/v8/daaHSScvJGqLYhG8nNt8KPPswUAPniZoaelDQzCLlQXE.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/cinzeldecorative/v8/daaHSScvJGqLYhG8nNt8KPPswUAPniZQa-lDQzCLlQXE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cinzeldecorative/v8/daaCSScvJGqLYhG8nNt8KPPswUAPnh7URs1LaCyC.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cinzeldecorative/v8/daaHSScvJGqLYhG8nNt8KPPswUAPniZoaelDQzCLlQXE.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/cinzeldecorative/v8/daaHSScvJGqLYhG8nNt8KPPswUAPniZQa-lDQzCLlQXE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14325,7 +14894,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/clickerscript/v7/raxkHiKPvt8CMH6ZWP8PdlEq72rY2zqUKafv.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/clickerscript/v7/raxkHiKPvt8CMH6ZWP8PdlEq72rY2zqUKafv.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14394,8 +14964,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/coda/v15/SLXHc1jY5nQ8JUIMapaN39I.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/coda/v15/SLXIc1jY5nQ8HeIgTp6mw9t1cX8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/coda/v15/SLXHc1jY5nQ8JUIMapaN39I.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/coda/v15/SLXIc1jY5nQ8HeIgTp6mw9t1cX8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14464,7 +15036,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/codacaption/v13/ieVm2YRII2GMY7SyXSoDRiQGqcx6x_-fACIgaw.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/codacaption/v13/ieVm2YRII2GMY7SyXSoDRiQGqcx6x_-fACIgaw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14533,8 +15106,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/codystar/v7/FwZf7-Q1xVk-40qxOuYsyuyrj0e29bfC.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/codystar/v7/FwZY7-Q1xVk-40qxOt6A4sijpFu_.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/codystar/v7/FwZf7-Q1xVk-40qxOuYsyuyrj0e29bfC.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/codystar/v7/FwZY7-Q1xVk-40qxOt6A4sijpFu_.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14603,7 +15178,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/coiny/v5/gyByhwU1K989PXwbElSvO5Tc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/coiny/v5/gyByhwU1K989PXwbElSvO5Tc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14672,7 +15248,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/combo/v8/BXRlvF3Jh_fIhg0iBu9y8Hf0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/combo/v8/BXRlvF3Jh_fIhg0iBu9y8Hf0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14741,11 +15318,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/comfortaa/v27/1Pt_g8LJRfWJmhDAuUsSQamb1W0lwk4S4TbMPrQVIT9c2c8.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/comfortaa/v27/1Pt_g8LJRfWJmhDAuUsSQamb1W0lwk4S4WjMPrQVIT9c2c8.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/comfortaa/v27/1Pt_g8LJRfWJmhDAuUsSQamb1W0lwk4S4VrMPrQVIT9c2c8.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/comfortaa/v27/1Pt_g8LJRfWJmhDAuUsSQamb1W0lwk4S4bbLPrQVIT9c2c8.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/comfortaa/v27/1Pt_g8LJRfWJmhDAuUsSQamb1W0lwk4S4Y_LPrQVIT9c2c8.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/comfortaa/v27/1Pt_g8LJRfWJmhDAuUsSQamb1W0lwk4S4TbMPrQVIT9c2c8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/comfortaa/v27/1Pt_g8LJRfWJmhDAuUsSQamb1W0lwk4S4WjMPrQVIT9c2c8.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/comfortaa/v27/1Pt_g8LJRfWJmhDAuUsSQamb1W0lwk4S4VrMPrQVIT9c2c8.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/comfortaa/v27/1Pt_g8LJRfWJmhDAuUsSQamb1W0lwk4S4bbLPrQVIT9c2c8.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/comfortaa/v27/1Pt_g8LJRfWJmhDAuUsSQamb1W0lwk4S4Y_LPrQVIT9c2c8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14814,7 +15396,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/comingsoon/v11/qWcuB6mzpYL7AJ2VfdQR1u-SUjjzsykh.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/comingsoon/v11/qWcuB6mzpYL7AJ2VfdQR1u-SUjjzsykh.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14883,7 +15466,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/concertone/v10/VEM1Ro9xs5PjtzCu-srDqRTlhv-CuVAQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/concertone/v10/VEM1Ro9xs5PjtzCu-srDqRTlhv-CuVAQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -14952,7 +15536,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/condiment/v7/pONk1hggFNmwvXALyH6Sq4n4o1vyCQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/condiment/v7/pONk1hggFNmwvXALyH6Sq4n4o1vyCQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15021,8 +15606,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/content/v12/zrfl0HLayePhU_AwUaDyIiL0RCg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/content/v12/zrfg0HLayePhU_AwaRzdBirfWCHvkAI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/content/v12/zrfl0HLayePhU_AwUaDyIiL0RCg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/content/v12/zrfg0HLayePhU_AwaRzdBirfWCHvkAI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15091,7 +15678,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/contrailone/v9/eLGbP-j_JA-kG0_Zo51noafdZUvt_c092w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/contrailone/v9/eLGbP-j_JA-kG0_Zo51noafdZUvt_c092w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15160,7 +15748,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/convergence/v8/rax5HiePvdgXPmmMHcIPYRhasU7Q8Cad.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/convergence/v8/rax5HiePvdgXPmmMHcIPYRhasU7Q8Cad.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15229,7 +15818,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cookie/v11/syky-y18lb0tSbfNlQCT9tPdpw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cookie/v11/syky-y18lb0tSbfNlQCT9tPdpw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15298,7 +15888,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/copse/v9/11hPGpDKz1rGb0djHkihUb-A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/copse/v9/11hPGpDKz1rGb0djHkihUb-A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15367,8 +15958,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/corben/v13/LYjDdGzzklQtCMp9oAlEpVs3VQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/corben/v13/LYjAdGzzklQtCMpFHCZgrXArXN7HWQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/corben/v13/LYjDdGzzklQtCMp9oAlEpVs3VQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/corben/v13/LYjAdGzzklQtCMpFHCZgrXArXN7HWQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15437,16 +16030,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/cormorant/v8/H4cgBXOCl9bbnla_nHIiRLmYgoyyYzFzFw.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/cormorant/v8/H4c-BXOCl9bbnla_nHIq6qMUgIa2QTRjF8ER.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cormorant/v8/H4clBXOCl9bbnla_nHIa6JG8iqeuag.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/cormorant/v8/H4cjBXOCl9bbnla_nHIq6pu4qKK-aihq.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/cormorant/v8/H4cgBXOCl9bbnla_nHIiHLiYgoyyYzFzFw.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/cormorant/v8/H4c-BXOCl9bbnla_nHIq6qNMgYa2QTRjF8ER.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/cormorant/v8/H4cgBXOCl9bbnla_nHIiML-YgoyyYzFzFw.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/cormorant/v8/H4c-BXOCl9bbnla_nHIq6qNghoa2QTRjF8ER.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cormorant/v8/H4cgBXOCl9bbnla_nHIiVL6YgoyyYzFzFw.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/cormorant/v8/H4c-BXOCl9bbnla_nHIq6qMEh4a2QTRjF8ER.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/cormorant/v8/H4cgBXOCl9bbnla_nHIiRLmYgoyyYzFzFw.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/cormorant/v8/H4c-BXOCl9bbnla_nHIq6qMUgIa2QTRjF8ER.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cormorant/v8/H4clBXOCl9bbnla_nHIa6JG8iqeuag.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/cormorant/v8/H4cjBXOCl9bbnla_nHIq6pu4qKK-aihq.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/cormorant/v8/H4cgBXOCl9bbnla_nHIiHLiYgoyyYzFzFw.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/cormorant/v8/H4c-BXOCl9bbnla_nHIq6qNMgYa2QTRjF8ER.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/cormorant/v8/H4cgBXOCl9bbnla_nHIiML-YgoyyYzFzFw.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/cormorant/v8/H4c-BXOCl9bbnla_nHIq6qNghoa2QTRjF8ER.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cormorant/v8/H4cgBXOCl9bbnla_nHIiVL6YgoyyYzFzFw.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/cormorant/v8/H4c-BXOCl9bbnla_nHIq6qMEh4a2QTRjF8ER.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15515,16 +16118,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQAllvuQWJ5heb_w.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3WmX5slCNuHLi8bLeY9MK7whWMhyjYrEPjuw-NxBKL_y94.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3bmX5slCNuHLi8bLeY9MK7whWMhyjornFLsS6V7w.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3ZmX5slCNuHLi8bLeY9MK7whWMhyjYrHtPkyuF7w6C.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQWlhvuQWJ5heb_w.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3WmX5slCNuHLi8bLeY9MK7whWMhyjYrEO7ug-NxBKL_y94.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQdl9vuQWJ5heb_w.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3WmX5slCNuHLi8bLeY9MK7whWMhyjYrEOXvQ-NxBKL_y94.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQEl5vuQWJ5heb_w.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3WmX5slCNuHLi8bLeY9MK7whWMhyjYrEPzvA-NxBKL_y94.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQAllvuQWJ5heb_w.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3WmX5slCNuHLi8bLeY9MK7whWMhyjYrEPjuw-NxBKL_y94.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3bmX5slCNuHLi8bLeY9MK7whWMhyjornFLsS6V7w.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3ZmX5slCNuHLi8bLeY9MK7whWMhyjYrHtPkyuF7w6C.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQWlhvuQWJ5heb_w.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3WmX5slCNuHLi8bLeY9MK7whWMhyjYrEO7ug-NxBKL_y94.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQdl9vuQWJ5heb_w.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3WmX5slCNuHLi8bLeY9MK7whWMhyjYrEOXvQ-NxBKL_y94.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQEl5vuQWJ5heb_w.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/cormorantgaramond/v7/co3WmX5slCNuHLi8bLeY9MK7whWMhyjYrEPzvA-NxBKL_y94.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15593,16 +16206,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyIU44g9vKiM1sORYSiWeAsLN9951w3_DMrQqcdJrk.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyKU44g9vKiM1sORYSiWeAsLN997_ItcDEhRoUYNrn_Ig.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyPU44g9vKiM1sORYSiWeAsLN993_Af2DsAXq4.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyJU44g9vKiM1sORYSiWeAsLN997_IV3BkFTq4EPw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyIU44g9vKiM1sORYSiWeAsLN995wQ2_DMrQqcdJrk.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyKU44g9vKiM1sORYSiWeAsLN997_ItKDAhRoUYNrn_Ig.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyIU44g9vKiM1sORYSiWeAsLN995ygx_DMrQqcdJrk.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyKU44g9vKiM1sORYSiWeAsLN997_ItBDchRoUYNrn_Ig.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyIU44g9vKiM1sORYSiWeAsLN9950ww_DMrQqcdJrk.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyKU44g9vKiM1sORYSiWeAsLN997_ItYDYhRoUYNrn_Ig.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyIU44g9vKiM1sORYSiWeAsLN9951w3_DMrQqcdJrk.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyKU44g9vKiM1sORYSiWeAsLN997_ItcDEhRoUYNrn_Ig.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyPU44g9vKiM1sORYSiWeAsLN993_Af2DsAXq4.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyJU44g9vKiM1sORYSiWeAsLN997_IV3BkFTq4EPw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyIU44g9vKiM1sORYSiWeAsLN995wQ2_DMrQqcdJrk.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyKU44g9vKiM1sORYSiWeAsLN997_ItKDAhRoUYNrn_Ig.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyIU44g9vKiM1sORYSiWeAsLN995ygx_DMrQqcdJrk.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyKU44g9vKiM1sORYSiWeAsLN997_ItBDchRoUYNrn_Ig.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyIU44g9vKiM1sORYSiWeAsLN9950ww_DMrQqcdJrk.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/cormorantinfant/v8/HhyKU44g9vKiM1sORYSiWeAsLN997_ItYDYhRoUYNrn_Ig.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15671,11 +16294,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/cormorantsc/v8/0ybmGD4kxqXBmOVLG30OGwsmABIU_R3y8DOWGA.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cormorantsc/v8/0yb5GD4kxqXBmOVLG30OGwserDow9Tbu-Q.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/cormorantsc/v8/0ybmGD4kxqXBmOVLG30OGwsmWBMU_R3y8DOWGA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/cormorantsc/v8/0ybmGD4kxqXBmOVLG30OGwsmdBQU_R3y8DOWGA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cormorantsc/v8/0ybmGD4kxqXBmOVLG30OGwsmEBUU_R3y8DOWGA.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/cormorantsc/v8/0ybmGD4kxqXBmOVLG30OGwsmABIU_R3y8DOWGA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cormorantsc/v8/0yb5GD4kxqXBmOVLG30OGwserDow9Tbu-Q.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/cormorantsc/v8/0ybmGD4kxqXBmOVLG30OGwsmWBMU_R3y8DOWGA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/cormorantsc/v8/0ybmGD4kxqXBmOVLG30OGwsmdBQU_R3y8DOWGA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cormorantsc/v8/0ybmGD4kxqXBmOVLG30OGwsmEBUU_R3y8DOWGA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15744,11 +16372,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/cormorantunicase/v8/HI_ViZUaILtOqhqgDeXoF_n1_fTGX9N_tucv7Gy0DRzS.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cormorantunicase/v8/HI_QiZUaILtOqhqgDeXoF_n1_fTGX-vTnsMnx3C9.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/cormorantunicase/v8/HI_ViZUaILtOqhqgDeXoF_n1_fTGX9Mnt-cv7Gy0DRzS.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/cormorantunicase/v8/HI_ViZUaILtOqhqgDeXoF_n1_fTGX9MLsOcv7Gy0DRzS.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cormorantunicase/v8/HI_ViZUaILtOqhqgDeXoF_n1_fTGX9Nvsecv7Gy0DRzS.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/cormorantunicase/v8/HI_ViZUaILtOqhqgDeXoF_n1_fTGX9N_tucv7Gy0DRzS.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cormorantunicase/v8/HI_QiZUaILtOqhqgDeXoF_n1_fTGX-vTnsMnx3C9.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/cormorantunicase/v8/HI_ViZUaILtOqhqgDeXoF_n1_fTGX9Mnt-cv7Gy0DRzS.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/cormorantunicase/v8/HI_ViZUaILtOqhqgDeXoF_n1_fTGX9MLsOcv7Gy0DRzS.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cormorantunicase/v8/HI_ViZUaILtOqhqgDeXoF_n1_fTGX9Nvsecv7Gy0DRzS.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15817,11 +16450,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/cormorantupright/v6/VuJudM3I2Y35poFONtLdafkUCHw1y1N5phDsU9X6RPzQ.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cormorantupright/v6/VuJrdM3I2Y35poFONtLdafkUCHw1y2vVjjTkeMnz.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/cormorantupright/v6/VuJudM3I2Y35poFONtLdafkUCHw1y1MhpxDsU9X6RPzQ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/cormorantupright/v6/VuJudM3I2Y35poFONtLdafkUCHw1y1MNoBDsU9X6RPzQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cormorantupright/v6/VuJudM3I2Y35poFONtLdafkUCHw1y1NpoRDsU9X6RPzQ.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/cormorantupright/v6/VuJudM3I2Y35poFONtLdafkUCHw1y1N5phDsU9X6RPzQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cormorantupright/v6/VuJrdM3I2Y35poFONtLdafkUCHw1y2vVjjTkeMnz.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/cormorantupright/v6/VuJudM3I2Y35poFONtLdafkUCHw1y1MhpxDsU9X6RPzQ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/cormorantupright/v6/VuJudM3I2Y35poFONtLdafkUCHw1y1MNoBDsU9X6RPzQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cormorantupright/v6/VuJudM3I2Y35poFONtLdafkUCHw1y1NpoRDsU9X6RPzQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15890,7 +16528,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/courgette/v7/wEO_EBrAnc9BLjLQAUkFUfAL3EsHiA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/courgette/v7/wEO_EBrAnc9BLjLQAUkFUfAL3EsHiA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -15959,10 +16598,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/courierprime/v1/u-450q2lgwslOqpF_6gQ8kELWwZjW-_-tvg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/courierprime/v1/u-4n0q2lgwslOqpF_6gQ8kELawRpX837pvjxPA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/courierprime/v1/u-4k0q2lgwslOqpF_6gQ8kELY7pMf-fVqvHoJXw.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/courierprime/v1/u-4i0q2lgwslOqpF_6gQ8kELawRR4-LfrtPtNXyeAg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/courierprime/v1/u-450q2lgwslOqpF_6gQ8kELWwZjW-_-tvg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/courierprime/v1/u-4n0q2lgwslOqpF_6gQ8kELawRpX837pvjxPA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/courierprime/v1/u-4k0q2lgwslOqpF_6gQ8kELY7pMf-fVqvHoJXw.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/courierprime/v1/u-4i0q2lgwslOqpF_6gQ8kELawRR4-LfrtPtNXyeAg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16031,10 +16674,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cousine/v14/d6lIkaiiRdih4SpPzSMlzTbtz9k.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/cousine/v14/d6lKkaiiRdih4SpP_SEvyRTo39l8hw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cousine/v14/d6lNkaiiRdih4SpP9Z8K6T7G09BlnmQ.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/cousine/v14/d6lPkaiiRdih4SpP_SEXdTvM1_JgjmRpOA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cousine/v14/d6lIkaiiRdih4SpPzSMlzTbtz9k.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/cousine/v14/d6lKkaiiRdih4SpP_SEvyRTo39l8hw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cousine/v14/d6lNkaiiRdih4SpP9Z8K6T7G09BlnmQ.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/cousine/v14/d6lPkaiiRdih4SpP_SEXdTvM1_JgjmRpOA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16103,8 +16750,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/coustard/v10/3XFpErgg3YsZ5fqUU9UPvWXuROTd.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/coustard/v10/3XFuErgg3YsZ5fqUU-2LkEHmb_jU3eRL.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/coustard/v10/3XFpErgg3YsZ5fqUU9UPvWXuROTd.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/coustard/v10/3XFuErgg3YsZ5fqUU-2LkEHmb_jU3eRL.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16173,7 +16822,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/coveredbyyourgrace/v9/QGYwz-AZahWOJJI9kykWW9mD6opopoqXSOS0FgItq6bFIg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/coveredbyyourgrace/v9/QGYwz-AZahWOJJI9kykWW9mD6opopoqXSOS0FgItq6bFIg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16242,7 +16892,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/craftygirls/v9/va9B4kXI39VaDdlPJo8N_NvuQR37fF3Wlg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/craftygirls/v9/va9B4kXI39VaDdlPJo8N_NvuQR37fF3Wlg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16311,7 +16962,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/creepster/v8/AlZy_zVUqJz4yMrniH4hdXf4XB0Tow.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/creepster/v8/AlZy_zVUqJz4yMrniH4hdXf4XB0Tow.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16380,8 +17032,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/creteround/v8/55xoey1sJNPjPiv1ZZZrxJ1827zAKnxN.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/creteround/v8/55xqey1sJNPjPiv1ZZZrxK1-0bjiL2xNhKc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/creteround/v8/55xoey1sJNPjPiv1ZZZrxJ1827zAKnxN.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/creteround/v8/55xqey1sJNPjPiv1ZZZrxK1-0bjiL2xNhKc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16450,22 +17104,38 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZTm18OJE_VNWoyQ.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZkG18OJE_VNWoyQ.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZzm18OJE_VNWoyQ.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZ_G18OJE_VNWoyQ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZEGp8OJE_VNWoyQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZKWp8OJE_VNWoyQ.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZTmp8OJE_VNWoyQ.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZZ2p8OJE_VNWoyQ.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi4Ue5s7dtC4yZNE.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi7Ke5s7dtC4yZNE.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi6Ue5s7dtC4yZNE.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi6me5s7dtC4yZNE.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi5KfJs7dtC4yZNE.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi5zfJs7dtC4yZNE.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi4UfJs7dtC4yZNE.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi49fJs7dtC4yZNE.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZTm18OJE_VNWoyQ.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZkG18OJE_VNWoyQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZzm18OJE_VNWoyQ.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZ_G18OJE_VNWoyQ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZEGp8OJE_VNWoyQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZKWp8OJE_VNWoyQ.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZTmp8OJE_VNWoyQ.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uUsoa5M_tv7IihmnkabC5XiXCAlXGks1WZZ2p8OJE_VNWoyQ.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi4Ue5s7dtC4yZNE.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi7Ke5s7dtC4yZNE.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi6Ue5s7dtC4yZNE.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi6me5s7dtC4yZNE.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi5KfJs7dtC4yZNE.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi5zfJs7dtC4yZNE.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi4UfJs7dtC4yZNE.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/crimsonpro/v11/q5uSsoa5M_tv7IihmnkabAReu49Y_Bo-HVKMBi49fJs7dtC4yZNE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16534,12 +17204,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/crimsontext/v10/wlp2gwHKFkZgtmSR3NB0oRJvaAJSA_JN3Q.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/crimsontext/v10/wlpogwHKFkZgtmSR3NB0oRJfaghWIfdd3ahG.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/crimsontext/v10/wlppgwHKFkZgtmSR3NB0oRJXsCx2C9lR1LFffg.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/crimsontext/v10/wlprgwHKFkZgtmSR3NB0oRJfajCOD9NV9rRPfrKu.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/crimsontext/v10/wlppgwHKFkZgtmSR3NB0oRJX1C12C9lR1LFffg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/crimsontext/v10/wlprgwHKFkZgtmSR3NB0oRJfajDqDtNV9rRPfrKu.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/crimsontext/v10/wlp2gwHKFkZgtmSR3NB0oRJvaAJSA_JN3Q.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/crimsontext/v10/wlpogwHKFkZgtmSR3NB0oRJfaghWIfdd3ahG.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/crimsontext/v10/wlppgwHKFkZgtmSR3NB0oRJXsCx2C9lR1LFffg.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/crimsontext/v10/wlprgwHKFkZgtmSR3NB0oRJfajCOD9NV9rRPfrKu.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/crimsontext/v10/wlppgwHKFkZgtmSR3NB0oRJX1C12C9lR1LFffg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/crimsontext/v10/wlprgwHKFkZgtmSR3NB0oRJfajDqDtNV9rRPfrKu.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16608,7 +17284,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/croissantone/v7/3y9n6bU9bTPg4m8NDy3Kq24UM3pqn5cdJ-4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/croissantone/v7/3y9n6bU9bTPg4m8NDy3Kq24UM3pqn5cdJ-4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16677,7 +17354,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/crushed/v10/U9Mc6dym6WXImTlFT1kfuIqyLzA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/crushed/v10/U9Mc6dym6WXImTlFT1kfuIqyLzA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16746,10 +17424,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cuprum/v11/dg4k_pLmvrkcOkB9IeFDh701Sg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/cuprum/v11/dg4m_pLmvrkcOkBNI-tHpbglShon.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/cuprum/v11/dg4n_pLmvrkcOkBFnc5nj5YpQwM-gg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/cuprum/v11/dg4h_pLmvrkcOkBNI9P7ipwtYQYugjW4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cuprum/v11/dg4k_pLmvrkcOkB9IeFDh701Sg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/cuprum/v11/dg4m_pLmvrkcOkBNI-tHpbglShon.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/cuprum/v11/dg4n_pLmvrkcOkBFnc5nj5YpQwM-gg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/cuprum/v11/dg4h_pLmvrkcOkBNI9P7ipwtYQYugjW4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16818,7 +17500,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cutefont/v8/Noaw6Uny2oWPbSHMrY6vmJNVNC9hkw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cutefont/v8/Noaw6Uny2oWPbSHMrY6vmJNVNC9hkw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16887,7 +17570,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cutive/v11/NaPZcZ_fHOhV3Ip7T_hDoyqlZQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cutive/v11/NaPZcZ_fHOhV3Ip7T_hDoyqlZQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -16956,7 +17640,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/cutivemono/v8/m8JWjfRfY7WVjVi2E-K9H5RFRG-K3Mud.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/cutivemono/v8/m8JWjfRfY7WVjVi2E-K9H5RFRG-K3Mud.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17025,12 +17710,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dmsans/v4/rP2Hp2ywxg089UriOZSCHBeHFl0.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/dmsans/v4/rP2Fp2ywxg089UriCZaIGDWCBl0O8Q.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/dmsans/v4/rP2Cp2ywxg089UriAWCrOB-sClQX6Cg.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/dmsans/v4/rP2Ap2ywxg089UriCZaw7BymDnYS-Cjk6Q.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/dmsans/v4/rP2Cp2ywxg089UriASitOB-sClQX6Cg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/dmsans/v4/rP2Ap2ywxg089UriCZawpBqmDnYS-Cjk6Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dmsans/v4/rP2Hp2ywxg089UriOZSCHBeHFl0.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/dmsans/v4/rP2Fp2ywxg089UriCZaIGDWCBl0O8Q.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/dmsans/v4/rP2Cp2ywxg089UriAWCrOB-sClQX6Cg.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/dmsans/v4/rP2Ap2ywxg089UriCZaw7BymDnYS-Cjk6Q.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/dmsans/v4/rP2Cp2ywxg089UriASitOB-sClQX6Cg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/dmsans/v4/rP2Ap2ywxg089UriCZawpBqmDnYS-Cjk6Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17099,8 +17790,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dmserifdisplay/v4/-nFnOHM81r4j6k0gjAW3mujVU2B2K_d709jy92k.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/dmserifdisplay/v4/-nFhOHM81r4j6k0gjAW3mujVU2B2G_Vx1_r352np3Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dmserifdisplay/v4/-nFnOHM81r4j6k0gjAW3mujVU2B2K_d709jy92k.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/dmserifdisplay/v4/-nFhOHM81r4j6k0gjAW3mujVU2B2G_Vx1_r352np3Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17169,8 +17862,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dmseriftext/v4/rnCu-xZa_krGokauCeNq1wWyafOPXHIJErY.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/dmseriftext/v4/rnCw-xZa_krGokauCeNq1wWyWfGFWFAMArZKqQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dmseriftext/v4/rnCu-xZa_krGokauCeNq1wWyafOPXHIJErY.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/dmseriftext/v4/rnCw-xZa_krGokauCeNq1wWyWfGFWFAMArZKqQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17239,7 +17934,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/damion/v9/hv-XlzJ3KEUe_YZUbWY3MTFgVg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/damion/v9/hv-XlzJ3KEUe_YZUbWY3MTFgVg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17308,10 +18004,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dancingscript/v13/If2cXTr6YS-zF4S-kcSWSVi_sxjsohD9F50Ruu7BMSoHTeB9ptDqpw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/dancingscript/v13/If2cXTr6YS-zF4S-kcSWSVi_sxjsohD9F50Ruu7BAyoHTeB9ptDqpw.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/dancingscript/v13/If2cXTr6YS-zF4S-kcSWSVi_sxjsohD9F50Ruu7B7y0HTeB9ptDqpw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/dancingscript/v13/If2cXTr6YS-zF4S-kcSWSVi_sxjsohD9F50Ruu7B1i0HTeB9ptDqpw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dancingscript/v13/If2cXTr6YS-zF4S-kcSWSVi_sxjsohD9F50Ruu7BMSoHTeB9ptDqpw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/dancingscript/v13/If2cXTr6YS-zF4S-kcSWSVi_sxjsohD9F50Ruu7BAyoHTeB9ptDqpw.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/dancingscript/v13/If2cXTr6YS-zF4S-kcSWSVi_sxjsohD9F50Ruu7B7y0HTeB9ptDqpw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/dancingscript/v13/If2cXTr6YS-zF4S-kcSWSVi_sxjsohD9F50Ruu7B1i0HTeB9ptDqpw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17380,7 +18080,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dangrek/v11/LYjCdG30nEgoH8E2gCNqqVIuTN4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dangrek/v11/LYjCdG30nEgoH8E2gCNqqVIuTN4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17449,13 +18150,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MA6cuh-mLQlC4BKCtayOfARkSVoxr2AW8hTOsXsX0.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MH6cuh-mLQlC4BKCtayOfARkSVm7beJWcKUOI.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MA6cuh-mLQlC4BKCtayOfARkSVo0L3AW8hTOsXsX0.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MA6cuh-mLQlC4BKCtayOfARkSVo27wAW8hTOsXsX0.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MA6cuh-mLQlC4BKCtayOfARkSVowrxAW8hTOsXsX0.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MA6cuh-mLQlC4BKCtayOfARkSVoxbyAW8hTOsXsX0.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MA6cuh-mLQlC4BKCtayOfARkSVozLzAW8hTOsXsX0.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MA6cuh-mLQlC4BKCtayOfARkSVoxr2AW8hTOsXsX0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MH6cuh-mLQlC4BKCtayOfARkSVm7beJWcKUOI.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MA6cuh-mLQlC4BKCtayOfARkSVo0L3AW8hTOsXsX0.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MA6cuh-mLQlC4BKCtayOfARkSVo27wAW8hTOsXsX0.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MA6cuh-mLQlC4BKCtayOfARkSVowrxAW8hTOsXsX0.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MA6cuh-mLQlC4BKCtayOfARkSVoxbyAW8hTOsXsX0.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/darkergrotesque/v1/U9MA6cuh-mLQlC4BKCtayOfARkSVozLzAW8hTOsXsX0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17524,9 +18232,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/davidlibre/v4/snfus0W_99N64iuYSvp4W_l86p6TYS-Y.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/davidlibre/v4/snfzs0W_99N64iuYSvp4W8GIw7qbSjORSo9W.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/davidlibre/v4/snfzs0W_99N64iuYSvp4W8HAxbqbSjORSo9W.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/davidlibre/v4/snfus0W_99N64iuYSvp4W_l86p6TYS-Y.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/davidlibre/v4/snfzs0W_99N64iuYSvp4W8GIw7qbSjORSo9W.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/davidlibre/v4/snfzs0W_99N64iuYSvp4W8HAxbqbSjORSo9W.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17595,7 +18306,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dawningofanewday/v10/t5t_IQMbOp2SEwuncwLRjMfIg1yYit_nAz8bhWJGNoBE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dawningofanewday/v10/t5t_IQMbOp2SEwuncwLRjMfIg1yYit_nAz8bhWJGNoBE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17664,7 +18376,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/daysone/v9/mem9YaCnxnKRiYZOCLYVeLkWVNBt.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/daysone/v9/mem9YaCnxnKRiYZOCLYVeLkWVNBt.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17733,7 +18446,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dekko/v6/46khlb_wWjfSrttFR0vsfl1B.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dekko/v6/46khlb_wWjfSrttFR0vsfl1B.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17802,7 +18516,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/delius/v9/PN_xRfK0pW_9e1rtYcI-jT3L_w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/delius/v9/PN_xRfK0pW_9e1rtYcI-jT3L_w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17871,7 +18586,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/deliusswashcaps/v11/oY1E8fPLr7v4JWCExZpWebxVKORpXXedKmeBvEYs.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/deliusswashcaps/v11/oY1E8fPLr7v4JWCExZpWebxVKORpXXedKmeBvEYs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -17940,8 +18656,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/deliusunicase/v13/845BNMEwEIOVT8BmgfSzIr_6mmLHd-73LXWs.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/deliusunicase/v13/845CNMEwEIOVT8BmgfSzIr_6mlp7WMr_BmmlS5aw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/deliusunicase/v13/845BNMEwEIOVT8BmgfSzIr_6mmLHd-73LXWs.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/deliusunicase/v13/845CNMEwEIOVT8BmgfSzIr_6mlp7WMr_BmmlS5aw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18010,7 +18728,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dellarespira/v7/RLp5K5v44KaueWI6iEJQBiGPRfkSu6EuTHo.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dellarespira/v7/RLp5K5v44KaueWI6iEJQBiGPRfkSu6EuTHo.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18079,7 +18798,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/denkone/v7/dg4m_pzhrqcFb2IzROtHpbglShon.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/denkone/v7/dg4m_pzhrqcFb2IzROtHpbglShon.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18148,7 +18868,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/devonshire/v8/46kqlbDwWirWr4gtBD2BX0Vq01lYAZM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/devonshire/v8/46kqlbDwWirWr4gtBD2BX0Vq01lYAZM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18217,7 +18938,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dhurjati/v7/_6_8ED3gSeatXfFiFX3ySKQtuTA2.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dhurjati/v7/_6_8ED3gSeatXfFiFX3ySKQtuTA2.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18286,7 +19008,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/didactgothic/v13/ahcfv8qz1zt6hCC5G4F_P4ASpUySp0LlcyQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/didactgothic/v13/ahcfv8qz1zt6hCC5G4F_P4ASpUySp0LlcyQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18355,7 +19078,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/diplomata/v11/Cn-0JtiMXwhNwp-wKxyfYGxYrdM9Sg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/diplomata/v11/Cn-0JtiMXwhNwp-wKxyfYGxYrdM9Sg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18424,7 +19148,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/diplomatasc/v8/buExpoi3ecvs3kidKgBJo2kf-P5Oaiw4cw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/diplomatasc/v8/buExpoi3ecvs3kidKgBJo2kf-P5Oaiw4cw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18493,7 +19218,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dohyeon/v11/TwMN-I8CRRU2zM86HFE3ZwaH__-C.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dohyeon/v11/TwMN-I8CRRU2zM86HFE3ZwaH__-C.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18562,7 +19288,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dokdo/v8/esDf315XNuCBLxLo4NaMlKcH.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dokdo/v8/esDf315XNuCBLxLo4NaMlKcH.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18631,8 +19358,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/domine/v7/L0x8DFMnlVwD4h3RvPCmRSlUig.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/domine/v7/L0x_DFMnlVwD4h3pAN-CTQJIg3uuXg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/domine/v7/L0x8DFMnlVwD4h3RvPCmRSlUig.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/domine/v7/L0x_DFMnlVwD4h3pAN-CTQJIg3uuXg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18701,7 +19430,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/donegalone/v7/m8JWjfRYea-ZnFz6fsK9FZRFRG-K3Mud.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/donegalone/v7/m8JWjfRYea-ZnFz6fsK9FZRFRG-K3Mud.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18770,7 +19500,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/doppioone/v7/Gg8wN5gSaBfyBw2MqCh-lgshKGpe5Fg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/doppioone/v7/Gg8wN5gSaBfyBw2MqCh-lgshKGpe5Fg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18839,7 +19570,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dorsa/v10/yYLn0hjd0OGwqo493XCFxAnQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dorsa/v10/yYLn0hjd0OGwqo493XCFxAnQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18908,13 +19640,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJt7MV3BkFTq4EPw.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJabMV3BkFTq4EPw.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJN7MV3BkFTq4EPw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJBbMV3BkFTq4EPw.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJ6bQV3BkFTq4EPw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJ0LQV3BkFTq4EPw.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJt7QV3BkFTq4EPw.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJt7MV3BkFTq4EPw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJabMV3BkFTq4EPw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJN7MV3BkFTq4EPw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJBbMV3BkFTq4EPw.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJ6bQV3BkFTq4EPw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJ0LQV3BkFTq4EPw.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/dosis/v16/HhyJU5sn9vOmLxNkIwRSjTVNWLEJt7QV3BkFTq4EPw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -18983,7 +19722,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/drsugiyama/v9/HTxoL2k4N3O9n5I1boGI7abRM4-t-g7y.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/drsugiyama/v9/HTxoL2k4N3O9n5I1boGI7abRM4-t-g7y.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19052,7 +19792,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/durusans/v13/xn7iYH8xwmSyTvEV_HOxT_fYdN-WZw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/durusans/v13/xn7iYH8xwmSyTvEV_HOxT_fYdN-WZw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19121,7 +19862,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/dynalight/v8/1Ptsg8LOU_aOmQvTsF4ISotrDfGGxA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/dynalight/v8/1Ptsg8LOU_aOmQvTsF4ISotrDfGGxA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19190,16 +19932,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ebgaramond/v12/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-6_RUA4V-e6yHgQ.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/ebgaramond/v12/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-2fRUA4V-e6yHgQ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/ebgaramond/v12/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-NfNUA4V-e6yHgQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ebgaramond/v12/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUA4V-e6yHgQ.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/ebgaramond/v12/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-a_NUA4V-e6yHgQ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/ebgaramond/v12/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7e8QI96WamXgXFI.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/ebgaramond/v12/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7eOQI96WamXgXFI.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/ebgaramond/v12/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7diR496WamXgXFI.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/ebgaramond/v12/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7dbR496WamXgXFI.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/ebgaramond/v12/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7c8R496WamXgXFI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ebgaramond/v12/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-6_RUA4V-e6yHgQ.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/ebgaramond/v12/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-2fRUA4V-e6yHgQ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/ebgaramond/v12/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-NfNUA4V-e6yHgQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ebgaramond/v12/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUA4V-e6yHgQ.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/ebgaramond/v12/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-a_NUA4V-e6yHgQ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/ebgaramond/v12/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7e8QI96WamXgXFI.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/ebgaramond/v12/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7eOQI96WamXgXFI.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/ebgaramond/v12/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7diR496WamXgXFI.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/ebgaramond/v12/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7dbR496WamXgXFI.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/ebgaramond/v12/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7c8R496WamXgXFI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19268,7 +20020,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/eaglelake/v7/ptRMTiqbbuNJDOiKj9wG5O7yKQNute8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/eaglelake/v7/ptRMTiqbbuNJDOiKj9wG5O7yKQNute8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19337,7 +20090,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/eastseadokdo/v8/xfuo0Wn2V2_KanASqXSZp22m05_aGavYS18y.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/eastseadokdo/v8/xfuo0Wn2V2_KanASqXSZp22m05_aGavYS18y.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19406,7 +20160,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/eater/v8/mtG04_FCK7bOvpu2u3FwsXsR.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/eater/v8/mtG04_FCK7bOvpu2u3FwsXsR.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19475,10 +20230,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/economica/v7/Qw3fZQZaHCLgIWa29ZBrMcgAAl1lfQ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/economica/v7/Qw3ZZQZaHCLgIWa29ZBbM8IEIFh1fWUl.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/economica/v7/Qw3aZQZaHCLgIWa29ZBTjeckCnZ5dHw8iw.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/economica/v7/Qw3EZQZaHCLgIWa29ZBbM_q4D3x9Vnksi4M7.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/economica/v7/Qw3fZQZaHCLgIWa29ZBrMcgAAl1lfQ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/economica/v7/Qw3ZZQZaHCLgIWa29ZBbM8IEIFh1fWUl.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/economica/v7/Qw3aZQZaHCLgIWa29ZBTjeckCnZ5dHw8iw.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/economica/v7/Qw3EZQZaHCLgIWa29ZBbM_q4D3x9Vnksi4M7.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19547,11 +20306,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/eczar/v8/BXRlvF3Pi-DLmw0iBu9y8Hf0.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/eczar/v8/BXRovF3Pi-DLmzXWL8t622v9WNjW.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/eczar/v8/BXRovF3Pi-DLmzX6KMt622v9WNjW.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/eczar/v8/BXRovF3Pi-DLmzWeKct622v9WNjW.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/eczar/v8/BXRovF3Pi-DLmzWCKst622v9WNjW.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/eczar/v8/BXRlvF3Pi-DLmw0iBu9y8Hf0.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/eczar/v8/BXRovF3Pi-DLmzXWL8t622v9WNjW.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/eczar/v8/BXRovF3Pi-DLmzX6KMt622v9WNjW.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/eczar/v8/BXRovF3Pi-DLmzWeKct622v9WNjW.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/eczar/v8/BXRovF3Pi-DLmzWCKst622v9WNjW.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19620,10 +20384,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/elmessiri/v6/K2F0fZBRmr9vQ1pHEey6AoqKAyLzfWo.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/elmessiri/v6/K2F3fZBRmr9vQ1pHEey6On6jJyrYYWOMluQ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/elmessiri/v6/K2F3fZBRmr9vQ1pHEey6OlKkJyrYYWOMluQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/elmessiri/v6/K2F3fZBRmr9vQ1pHEey6OjalJyrYYWOMluQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/elmessiri/v6/K2F0fZBRmr9vQ1pHEey6AoqKAyLzfWo.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/elmessiri/v6/K2F3fZBRmr9vQ1pHEey6On6jJyrYYWOMluQ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/elmessiri/v6/K2F3fZBRmr9vQ1pHEey6OlKkJyrYYWOMluQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/elmessiri/v6/K2F3fZBRmr9vQ1pHEey6OjalJyrYYWOMluQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19692,7 +20460,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/electrolize/v8/cIf5Ma1dtE0zSiGSiED7AUEGso5tQafB.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/electrolize/v8/cIf5Ma1dtE0zSiGSiED7AUEGso5tQafB.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19761,8 +20530,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/elsie/v9/BCanqZABrez54yYu9slAeLgX.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/elsie/v9/BCaqqZABrez54x6q2-1IU6QeXSBk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/elsie/v9/BCanqZABrez54yYu9slAeLgX.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/elsie/v9/BCaqqZABrez54x6q2-1IU6QeXSBk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19831,8 +20602,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/elsieswashcaps/v8/845DNN8xGZyVX5MVo_upKf7KnjK0ferVKGWsUo8.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/elsieswashcaps/v8/845ENN8xGZyVX5MVo_upKf7KnjK0RW74DG2HToawrdU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/elsieswashcaps/v8/845DNN8xGZyVX5MVo_upKf7KnjK0ferVKGWsUo8.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/elsieswashcaps/v8/845ENN8xGZyVX5MVo_upKf7KnjK0RW74DG2HToawrdU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19901,7 +20674,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/emblemaone/v8/nKKT-GQ0F5dSY8vzG0rOEIRBHl57G_f_.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/emblemaone/v8/nKKT-GQ0F5dSY8vzG0rOEIRBHl57G_f_.ttf',
     };
 
     return googleFontsTextStyle(
@@ -19970,7 +20744,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/emilyscandy/v7/2EbgL-1mD1Rnb0OGKudbk0y5r9xrX84JjA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/emilyscandy/v7/2EbgL-1mD1Rnb0OGKudbk0y5r9xrX84JjA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20039,15 +20814,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/encodesans/v4/LDI0apOFNxEwR-Bd1O9uYPvIeeLkl7Iw6yg.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPtkWMLOub458jGL.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPsAW8LOub458jGL.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/encodesans/v4/LDI2apOFNxEwR-Bd1O9uYMOsc-bGkqIw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPtYWsLOub458jGL.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPt0XcLOub458jGL.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPsQXMLOub458jGL.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPsMX8LOub458jGL.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPsoXsLOub458jGL.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/encodesans/v4/LDI0apOFNxEwR-Bd1O9uYPvIeeLkl7Iw6yg.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPtkWMLOub458jGL.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPsAW8LOub458jGL.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/encodesans/v4/LDI2apOFNxEwR-Bd1O9uYMOsc-bGkqIw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPtYWsLOub458jGL.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPt0XcLOub458jGL.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPsQXMLOub458jGL.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPsMX8LOub458jGL.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/encodesans/v4/LDIrapOFNxEwR-Bd1O9uYPsoXsLOub458jGL.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20116,15 +20900,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_76_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-5a-JLQoFI2KR.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-SY6pByQJKnuIFA.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-LY2pByQJKnuIFA.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_16_LD37rqfuwxyIuaZhE6cRXOLtm2gfTGgaWNDw8VIw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-dYypByQJKnuIFA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-WYupByQJKnuIFA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-PYqpByQJKnuIFA.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-IYmpByQJKnuIFA.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-BYipByQJKnuIFA.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_76_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-5a-JLQoFI2KR.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-SY6pByQJKnuIFA.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-LY2pByQJKnuIFA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_16_LD37rqfuwxyIuaZhE6cRXOLtm2gfTGgaWNDw8VIw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-dYypByQJKnuIFA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-WYupByQJKnuIFA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-PYqpByQJKnuIFA.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-IYmpByQJKnuIFA.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/encodesanscondensed/v4/j8_46_LD37rqfuwxyIuaZhE6cRXOLtm2gfT-BYipByQJKnuIFA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20193,15 +20986,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mx1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpJGKQNicoAbJlw.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpLqCCNIXIwSP0XD.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpKOCyNIXIwSP0XD.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4m_1mF4GcnstG_Jh1QH6ac4hNLeNyeYUqoiIwdAd5Ab.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpLWCiNIXIwSP0XD.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpL6DSNIXIwSP0XD.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpKeDCNIXIwSP0XD.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpKCDyNIXIwSP0XD.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpKmDiNIXIwSP0XD.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mx1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpJGKQNicoAbJlw.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpLqCCNIXIwSP0XD.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpKOCyNIXIwSP0XD.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4m_1mF4GcnstG_Jh1QH6ac4hNLeNyeYUqoiIwdAd5Ab.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpLWCiNIXIwSP0XD.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpL6DSNIXIwSP0XD.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpKeDCNIXIwSP0XD.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpKCDyNIXIwSP0XD.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/encodesansexpanded/v4/c4mw1mF4GcnstG_Jh1QH6ac4hNLeNyeYUpKmDiNIXIwSP0XD.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20270,15 +21072,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT6oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1T19MFtQ9jpVUA.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1RZ1eFHbdTgTFmr.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1Q91uFHbdTgTFmr.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT4oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG2yR_sVPRsjp.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1Rl1-FHbdTgTFmr.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1RJ0OFHbdTgTFmr.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1Qt0eFHbdTgTFmr.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1Qx0uFHbdTgTFmr.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1QV0-FHbdTgTFmr.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT6oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1T19MFtQ9jpVUA.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1RZ1eFHbdTgTFmr.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1Q91uFHbdTgTFmr.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT4oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG2yR_sVPRsjp.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1Rl1-FHbdTgTFmr.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1RJ0OFHbdTgTFmr.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1Qt0eFHbdTgTFmr.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1Qx0uFHbdTgTFmr.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/encodesanssemicondensed/v4/3qT7oiKqnDuUtQUEHMoXcmspmy55SFWrXFRp9FTOG1QV0-FHbdTgTFmr.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20309,19 +21120,28 @@ class GoogleFonts {
   static TextTheme encodeSansSemiCondensedTextTheme([TextTheme textTheme]) {
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(
-      display4: GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.display4),
-      display3: GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.display3),
-      display2: GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.display2),
-      display1: GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.display1),
-      headline: GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.headline),
+      display4:
+          GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.display4),
+      display3:
+          GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.display3),
+      display2:
+          GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.display2),
+      display1:
+          GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.display1),
+      headline:
+          GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.headline),
       title: GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.title),
-      subhead: GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.subhead),
+      subhead:
+          GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.subhead),
       body2: GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.body2),
       body1: GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.body1),
-      caption: GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.caption),
+      caption:
+          GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.caption),
       button: GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.button),
-      subtitle: GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.subtitle),
-      overline: GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.overline),
+      subtitle:
+          GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.subtitle),
+      overline:
+          GoogleFonts.encodeSansSemiCondensed(textStyle: textTheme?.overline),
     );
   }
 
@@ -20347,15 +21167,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8xOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TM-41KwrlKXeOEA.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TM0IUCyDLJX6XCWU.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TMyYXCyDLJX6XCWU.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke83OhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TC4o_LyjgOXc.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TM34WCyDLJX6XCWU.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TM1IRCyDLJX6XCWU.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TMzYQCyDLJX6XCWU.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TMyoTCyDLJX6XCWU.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TMw4SCyDLJX6XCWU.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8xOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TM-41KwrlKXeOEA.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TM0IUCyDLJX6XCWU.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TMyYXCyDLJX6XCWU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke83OhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TC4o_LyjgOXc.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TM34WCyDLJX6XCWU.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TM1IRCyDLJX6XCWU.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TMzYQCyDLJX6XCWU.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TMyoTCyDLJX6XCWU.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/encodesanssemiexpanded/v5/ke8yOhAPMEZs-BDuzwftTNJ85JvwMOzE9d9Cca5TMw4SCyDLJX6XCWU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20386,19 +21215,28 @@ class GoogleFonts {
   static TextTheme encodeSansSemiExpandedTextTheme([TextTheme textTheme]) {
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(
-      display4: GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.display4),
-      display3: GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.display3),
-      display2: GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.display2),
-      display1: GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.display1),
-      headline: GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.headline),
+      display4:
+          GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.display4),
+      display3:
+          GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.display3),
+      display2:
+          GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.display2),
+      display1:
+          GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.display1),
+      headline:
+          GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.headline),
       title: GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.title),
-      subhead: GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.subhead),
+      subhead:
+          GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.subhead),
       body2: GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.body2),
       body1: GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.body1),
-      caption: GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.caption),
+      caption:
+          GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.caption),
       button: GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.button),
-      subtitle: GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.subtitle),
-      overline: GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.overline),
+      subtitle:
+          GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.subtitle),
+      overline:
+          GoogleFonts.encodeSansSemiExpanded(textStyle: textTheme?.overline),
     );
   }
 
@@ -20424,7 +21262,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/engagement/v9/x3dlckLDZbqa7RUs9MFVXNossybsHQI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/engagement/v9/x3dlckLDZbqa7RUs9MFVXNossybsHQI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20493,7 +21332,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/englebert/v7/xn7iYH8w2XGrC8AR4HSxT_fYdN-WZw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/englebert/v7/xn7iYH8w2XGrC8AR4HSxT_fYdN-WZw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20562,10 +21402,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/enriqueta/v9/goksH6L7AUFrRvV44HVTS0CjkP1Yog.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/enriqueta/v9/gokpH6L7AUFrRvV44HVrv2mHmNZEq6TTFw.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/enriqueta/v9/gokpH6L7AUFrRvV44HVrk26HmNZEq6TTFw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/enriqueta/v9/gokpH6L7AUFrRvV44HVr92-HmNZEq6TTFw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/enriqueta/v9/goksH6L7AUFrRvV44HVTS0CjkP1Yog.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/enriqueta/v9/gokpH6L7AUFrRvV44HVrv2mHmNZEq6TTFw.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/enriqueta/v9/gokpH6L7AUFrRvV44HVrk26HmNZEq6TTFw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/enriqueta/v9/gokpH6L7AUFrRvV44HVr92-HmNZEq6TTFw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20634,7 +21478,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ericaone/v10/WBLnrEXccV9VGrOKmGD1W0_MJMGxiQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ericaone/v10/WBLnrEXccV9VGrOKmGD1W0_MJMGxiQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20703,7 +21548,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/esteban/v8/r05bGLZE-bdGdN-GdOuD5jokU8E.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/esteban/v8/r05bGLZE-bdGdN-GdOuD5jokU8E.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20772,7 +21618,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/euphoriascript/v8/mFTpWb0X2bLb_cx6To2B8GpKoD5ak_ZT1D8x7Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/euphoriascript/v8/mFTpWb0X2bLb_cx6To2B8GpKoD5ak_ZT1D8x7Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20841,7 +21688,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ewert/v7/va9I4kzO2tFODYBvS-J3kbDP.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ewert/v7/va9I4kzO2tFODYBvS-J3kbDP.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20910,24 +21758,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/exo/v9/4UaMrEtFpBIaEH6m2jbu5rXI.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/exo/v9/4UaCrEtFpBISdkbC0DLM46XI-po.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIavF-G8Bji76zR4w.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkZu8RLmzanB44N1.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIa2FyG8Bji76zR4w.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkYK8hLmzanB44N1.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/exo/v9/4UaOrEtFpBIidHSi-DP-5g.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/exo/v9/4UaMrEtFpBISdn6m2jbu5rXI.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIagF2G8Bji76zR4w.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkZS8xLmzanB44N1.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIarFqG8Bji76zR4w.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkZ-9BLmzanB44N1.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIayFuG8Bji76zR4w.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkYa9RLmzanB44N1.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIa1FiG8Bji76zR4w.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkYG9hLmzanB44N1.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIa8FmG8Bji76zR4w.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkYi9xLmzanB44N1.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaMrEtFpBIaEH6m2jbu5rXI.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaCrEtFpBISdkbC0DLM46XI-po.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIavF-G8Bji76zR4w.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkZu8RLmzanB44N1.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIa2FyG8Bji76zR4w.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkYK8hLmzanB44N1.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaOrEtFpBIidHSi-DP-5g.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaMrEtFpBISdn6m2jbu5rXI.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIagF2G8Bji76zR4w.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkZS8xLmzanB44N1.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIarFqG8Bji76zR4w.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkZ-9BLmzanB44N1.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIayFuG8Bji76zR4w.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkYa9RLmzanB44N1.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIa1FiG8Bji76zR4w.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkYG9hLmzanB44N1.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaDrEtFpBIa8FmG8Bji76zR4w.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/exo/v9/4UaBrEtFpBISdkYi9xLmzanB44N1.ttf',
     };
 
     return googleFontsTextStyle(
@@ -20996,24 +21862,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/exo2/v7/7cHov4okm5zmbt5LK-sW5HIohT4.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/exo2/v7/7cHqv4okm5zmbtYtE48c4FAtlT47dw.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt7nCss8yn4hnCci.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtEyM9wHoDmTcibrA.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt6DCcs8yn4hnCci.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtE0c-wHoDmTcibrA.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/exo2/v7/7cHmv4okm5zmbuYvIe804WIo.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/exo2/v7/7cHov4okm5zmbtYtK-sW5HIohT4.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt7bCMs8yn4hnCci.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtEx8_wHoDmTcibrA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt73D8s8yn4hnCci.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtEzM4wHoDmTcibrA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt6TDss8yn4hnCci.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtE1c5wHoDmTcibrA.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt6PDcs8yn4hnCci.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtE0s6wHoDmTcibrA.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt6rDMs8yn4hnCci.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtE287wHoDmTcibrA.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHov4okm5zmbt5LK-sW5HIohT4.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHqv4okm5zmbtYtE48c4FAtlT47dw.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt7nCss8yn4hnCci.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtEyM9wHoDmTcibrA.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt6DCcs8yn4hnCci.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtE0c-wHoDmTcibrA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHmv4okm5zmbuYvIe804WIo.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHov4okm5zmbtYtK-sW5HIohT4.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt7bCMs8yn4hnCci.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtEx8_wHoDmTcibrA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt73D8s8yn4hnCci.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtEzM4wHoDmTcibrA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt6TDss8yn4hnCci.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtE1c5wHoDmTcibrA.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt6PDcs8yn4hnCci.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtE0s6wHoDmTcibrA.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHrv4okm5zmbt6rDMs8yn4hnCci.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/exo2/v7/7cHtv4okm5zmbtYtE287wHoDmTcibrA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -21082,14 +21966,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/expletussans/v13/RLp5K5v5_bqufTYdnhFzDj2dRfkSu6EuTHo.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/expletussans/v13/RLpnK5v5_bqufTYdnhFzDj2ddfsYv4MrXHrRDA.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/expletussans/v13/RLpkK5v5_bqufTYdnhFzDj2dfQ07n6kFUHPIFaU.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/expletussans/v13/RLpiK5v5_bqufTYdnhFzDj2ddfsgS6oPVFHNBaVImA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/expletussans/v13/RLpkK5v5_bqufTYdnhFzDj2dfSE8n6kFUHPIFaU.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/expletussans/v13/RLpiK5v5_bqufTYdnhFzDj2ddfsgZ60PVFHNBaVImA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/expletussans/v13/RLpkK5v5_bqufTYdnhFzDj2dfUU9n6kFUHPIFaU.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/expletussans/v13/RLpiK5v5_bqufTYdnhFzDj2ddfsgA6wPVFHNBaVImA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/expletussans/v13/RLp5K5v5_bqufTYdnhFzDj2dRfkSu6EuTHo.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/expletussans/v13/RLpnK5v5_bqufTYdnhFzDj2ddfsYv4MrXHrRDA.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/expletussans/v13/RLpkK5v5_bqufTYdnhFzDj2dfQ07n6kFUHPIFaU.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/expletussans/v13/RLpiK5v5_bqufTYdnhFzDj2ddfsgS6oPVFHNBaVImA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/expletussans/v13/RLpkK5v5_bqufTYdnhFzDj2dfSE8n6kFUHPIFaU.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/expletussans/v13/RLpiK5v5_bqufTYdnhFzDj2ddfsgZ60PVFHNBaVImA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/expletussans/v13/RLpkK5v5_bqufTYdnhFzDj2dfUU9n6kFUHPIFaU.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/expletussans/v13/RLpiK5v5_bqufTYdnhFzDj2ddfsgA6wPVFHNBaVImA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -21158,18 +22050,30 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/fahkwang/v3/Noa26Uj3zpmBOgbNpOJHmZlRFipxkwjx.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/fahkwang/v3/Noa06Uj3zpmBOgbNpOqNgHFQHC5Tlhjxdw4.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/fahkwang/v3/Noa26Uj3zpmBOgbNpOIjmplRFipxkwjx.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/fahkwang/v3/Noa06Uj3zpmBOgbNpOqNgBVTHC5Tlhjxdw4.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fahkwang/v3/Noax6Uj3zpmBOgbNpNqPsr1ZPTZ4.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/fahkwang/v3/Noa36Uj3zpmBOgbNpOqNuLl7OCZ4ihE.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/fahkwang/v3/Noa26Uj3zpmBOgbNpOJ7m5lRFipxkwjx.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/fahkwang/v3/Noa06Uj3zpmBOgbNpOqNgE1SHC5Tlhjxdw4.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/fahkwang/v3/Noa26Uj3zpmBOgbNpOJXnJlRFipxkwjx.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/fahkwang/v3/Noa06Uj3zpmBOgbNpOqNgGFVHC5Tlhjxdw4.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/fahkwang/v3/Noa26Uj3zpmBOgbNpOIznZlRFipxkwjx.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/fahkwang/v3/Noa06Uj3zpmBOgbNpOqNgAVUHC5Tlhjxdw4.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/fahkwang/v3/Noa26Uj3zpmBOgbNpOJHmZlRFipxkwjx.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/fahkwang/v3/Noa06Uj3zpmBOgbNpOqNgHFQHC5Tlhjxdw4.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/fahkwang/v3/Noa26Uj3zpmBOgbNpOIjmplRFipxkwjx.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/fahkwang/v3/Noa06Uj3zpmBOgbNpOqNgBVTHC5Tlhjxdw4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fahkwang/v3/Noax6Uj3zpmBOgbNpNqPsr1ZPTZ4.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/fahkwang/v3/Noa36Uj3zpmBOgbNpOqNuLl7OCZ4ihE.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/fahkwang/v3/Noa26Uj3zpmBOgbNpOJ7m5lRFipxkwjx.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/fahkwang/v3/Noa06Uj3zpmBOgbNpOqNgE1SHC5Tlhjxdw4.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/fahkwang/v3/Noa26Uj3zpmBOgbNpOJXnJlRFipxkwjx.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/fahkwang/v3/Noa06Uj3zpmBOgbNpOqNgGFVHC5Tlhjxdw4.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/fahkwang/v3/Noa26Uj3zpmBOgbNpOIznZlRFipxkwjx.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/fahkwang/v3/Noa06Uj3zpmBOgbNpOqNgAVUHC5Tlhjxdw4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -21238,8 +22142,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fanwoodtext/v9/3XFtErwl05Ad_vSCF6Fq7xXGRdbY1P1Sbg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/fanwoodtext/v9/3XFzErwl05Ad_vSCF6Fq7xX2R9zc9vhCblye.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fanwoodtext/v9/3XFtErwl05Ad_vSCF6Fq7xXGRdbY1P1Sbg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/fanwoodtext/v9/3XFzErwl05Ad_vSCF6Fq7xX2R9zc9vhCblye.ttf',
     };
 
     return googleFontsTextStyle(
@@ -21308,10 +22214,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/farro/v1/i7dJIFl3byGNHa3hNJ6-WkJUQUq7.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/farro/v1/i7dEIFl3byGNHZVNHLq2cV5d.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/farro/v1/i7dJIFl3byGNHa25NZ6-WkJUQUq7.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/farro/v1/i7dJIFl3byGNHa3xM56-WkJUQUq7.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/farro/v1/i7dJIFl3byGNHa3hNJ6-WkJUQUq7.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/farro/v1/i7dEIFl3byGNHZVNHLq2cV5d.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/farro/v1/i7dJIFl3byGNHa25NZ6-WkJUQUq7.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/farro/v1/i7dJIFl3byGNHa3xM56-WkJUQUq7.ttf',
     };
 
     return googleFontsTextStyle(
@@ -21380,7 +22290,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/farsan/v5/VEMwRoJ0vY_zsyz62q-pxDX9rQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/farsan/v5/VEMwRoJ0vY_zsyz62q-pxDX9rQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -21449,7 +22360,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fascinate/v8/z7NWdRrufC8XJK0IIEli1LbQRPyNrw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fascinate/v8/z7NWdRrufC8XJK0IIEli1LbQRPyNrw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -21518,7 +22430,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fascinateinline/v9/jVyR7mzzB3zc-jp6QCAu60poNqIy1g3CfRXxWZQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fascinateinline/v9/jVyR7mzzB3zc-jp6QCAu60poNqIy1g3CfRXxWZQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -21587,7 +22500,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fasterone/v11/H4ciBXCHmdfClFb-vWhfyLuShq63czE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fasterone/v11/H4ciBXCHmdfClFb-vWhfyLuShq63czE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -21656,7 +22570,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fasthand/v10/0yb9GDohyKTYn_ZEESkuYkw2rQg1.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fasthand/v10/0yb9GDohyKTYn_ZEESkuYkw2rQg1.ttf',
     };
 
     return googleFontsTextStyle(
@@ -21725,7 +22640,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/faunaone/v7/wlpzgwTPBVpjpCuwkuEx2UxLYClOCg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/faunaone/v7/wlpzgwTPBVpjpCuwkuEx2UxLYClOCg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -21794,14 +22710,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/faustina/v5/XLY4IZPxYpJfTbZAFXWzNT2SO8wpWHlsgoEvGVWWe8tbEg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/faustina/v5/XLY4IZPxYpJfTbZAFXWzNT2SO8wpWHlssIEvGVWWe8tbEg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/faustina/v5/XLY4IZPxYpJfTbZAFXWzNT2SO8wpWHlsXIYvGVWWe8tbEg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/faustina/v5/XLY4IZPxYpJfTbZAFXWzNT2SO8wpWHlsZYYvGVWWe8tbEg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/faustina/v5/XLY2IZPxYpJfTbZAFV-6B8JKUqez9n55SsLHWl-SWc5LEnoF.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/faustina/v5/XLY2IZPxYpJfTbZAFV-6B8JKUqez9n55SsL1Wl-SWc5LEnoF.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/faustina/v5/XLY2IZPxYpJfTbZAFV-6B8JKUqez9n55SsIZXV-SWc5LEnoF.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/faustina/v5/XLY2IZPxYpJfTbZAFV-6B8JKUqez9n55SsIgXV-SWc5LEnoF.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/faustina/v5/XLY4IZPxYpJfTbZAFXWzNT2SO8wpWHlsgoEvGVWWe8tbEg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/faustina/v5/XLY4IZPxYpJfTbZAFXWzNT2SO8wpWHlssIEvGVWWe8tbEg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/faustina/v5/XLY4IZPxYpJfTbZAFXWzNT2SO8wpWHlsXIYvGVWWe8tbEg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/faustina/v5/XLY4IZPxYpJfTbZAFXWzNT2SO8wpWHlsZYYvGVWWe8tbEg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/faustina/v5/XLY2IZPxYpJfTbZAFV-6B8JKUqez9n55SsLHWl-SWc5LEnoF.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/faustina/v5/XLY2IZPxYpJfTbZAFV-6B8JKUqez9n55SsL1Wl-SWc5LEnoF.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/faustina/v5/XLY2IZPxYpJfTbZAFV-6B8JKUqez9n55SsIZXV-SWc5LEnoF.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/faustina/v5/XLY2IZPxYpJfTbZAFV-6B8JKUqez9n55SsIgXV-SWc5LEnoF.ttf',
     };
 
     return googleFontsTextStyle(
@@ -21870,7 +22794,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/federant/v12/2sDdZGNfip_eirT0_U0jRUG0AqUc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/federant/v12/2sDdZGNfip_eirT0_U0jRUG0AqUc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -21939,7 +22864,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/federo/v11/iJWFBX-cbD_ETsbmjVOe2WTG7Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/federo/v11/iJWFBX-cbD_ETsbmjVOe2WTG7Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22008,7 +22934,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/felipa/v7/FwZa7-owz1Eu4F_wSNSEwM2zpA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/felipa/v7/FwZa7-owz1Eu4F_wSNSEwM2zpA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22077,7 +23004,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fenix/v7/XoHo2YL_S7-g5ostKzAFvs8o.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fenix/v7/XoHo2YL_S7-g5ostKzAFvs8o.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22146,7 +23074,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fingerpaint/v9/0QInMXVJ-o-oRn_7dron8YWO85bS8ANesw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fingerpaint/v9/0QInMXVJ-o-oRn_7dron8YWO85bS8ANesw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22215,11 +23144,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/firacode/v7/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_GNsFVfxN87gsj0.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/firacode/v7/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_D1sFVfxN87gsj0.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/firacode/v7/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_A9sFVfxN87gsj0.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/firacode/v7/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_ONrFVfxN87gsj0.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/firacode/v7/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_NprFVfxN87gsj0.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/firacode/v7/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_GNsFVfxN87gsj0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/firacode/v7/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_D1sFVfxN87gsj0.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/firacode/v7/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_A9sFVfxN87gsj0.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/firacode/v7/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_ONrFVfxN87gsj0.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/firacode/v7/uU9eCBsR6Z2vfE9aq3bL0fxyUs4tcw4W_NprFVfxN87gsj0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22288,9 +23222,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/firamono/v8/N0bX2SlFPv1weGeLZDtQIfTTkdbJYA.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/firamono/v8/N0bS2SlFPv1weGeLZDto1d33mf3VaZBRBQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/firamono/v8/N0bS2SlFPv1weGeLZDtondv3mf3VaZBRBQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/firamono/v8/N0bX2SlFPv1weGeLZDtQIfTTkdbJYA.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/firamono/v8/N0bS2SlFPv1weGeLZDto1d33mf3VaZBRBQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/firamono/v8/N0bS2SlFPv1weGeLZDtondv3mf3VaZBRBQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22359,24 +23296,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/firasans/v10/va9C4kDNxMZdWfMOD5Vn9IjOazP3dUTP.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/firasans/v10/va9A4kDNxMZdWfMOD5VvkrCqYTfVcFTPj0s.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnWKnuQR37fF3Wlg.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrAGQBf_XljGllLX.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnPKruQR37fF3Wlg.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrBiQxf_XljGllLX.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/firasans/v10/va9E4kDNxMZdWfMOD5VfkILKSTbndQ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/firasans/v10/va9C4kDNxMZdWfMOD5VvkojOazP3dUTP.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnZKvuQR37fF3Wlg.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrA6Qhf_XljGllLX.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnSKzuQR37fF3Wlg.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrAWRRf_XljGllLX.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnLK3uQR37fF3Wlg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrByRBf_XljGllLX.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnMK7uQR37fF3Wlg.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrBuRxf_XljGllLX.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnFK_uQR37fF3Wlg.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrBKRhf_XljGllLX.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9C4kDNxMZdWfMOD5Vn9IjOazP3dUTP.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9A4kDNxMZdWfMOD5VvkrCqYTfVcFTPj0s.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnWKnuQR37fF3Wlg.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrAGQBf_XljGllLX.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnPKruQR37fF3Wlg.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrBiQxf_XljGllLX.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9E4kDNxMZdWfMOD5VfkILKSTbndQ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9C4kDNxMZdWfMOD5VvkojOazP3dUTP.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnZKvuQR37fF3Wlg.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrA6Qhf_XljGllLX.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnSKzuQR37fF3Wlg.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrAWRRf_XljGllLX.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnLK3uQR37fF3Wlg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrByRBf_XljGllLX.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnMK7uQR37fF3Wlg.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrBuRxf_XljGllLX.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9B4kDNxMZdWfMOD5VnFK_uQR37fF3Wlg.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/firasans/v10/va9f4kDNxMZdWfMOD5VvkrBKRhf_XljGllLX.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22445,24 +23400,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOjEADFm8hSaQTFG18FErVhsC9x-tarWZXtqOlQfx9CjA.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOtEADFm8hSaQTFG18FErVhsC9x-tarUfPVzONUXRpSjJcu.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWTnMiMN-cxZblY4.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVYMJ0dzRehY43EA.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWV3PiMN-cxZblY4.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVBMF0dzRehY43EA.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOhEADFm8hSaQTFG18FErVhsC9x-tarYfHnrMtVbx8.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOjEADFm8hSaQTFG18FErVhsC9x-tarUfPtqOlQfx9CjA.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWQXOiMN-cxZblY4.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVXMB0dzRehY43EA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWSnJiMN-cxZblY4.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVcMd0dzRehY43EA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWU3IiMN-cxZblY4.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVFMZ0dzRehY43EA.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWVHLiMN-cxZblY4.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVCMV0dzRehY43EA.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWXXKiMN-cxZblY4.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVLMR0dzRehY43EA.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOjEADFm8hSaQTFG18FErVhsC9x-tarWZXtqOlQfx9CjA.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOtEADFm8hSaQTFG18FErVhsC9x-tarUfPVzONUXRpSjJcu.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWTnMiMN-cxZblY4.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVYMJ0dzRehY43EA.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWV3PiMN-cxZblY4.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVBMF0dzRehY43EA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOhEADFm8hSaQTFG18FErVhsC9x-tarYfHnrMtVbx8.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOjEADFm8hSaQTFG18FErVhsC9x-tarUfPtqOlQfx9CjA.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWQXOiMN-cxZblY4.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVXMB0dzRehY43EA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWSnJiMN-cxZblY4.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVcMd0dzRehY43EA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWU3IiMN-cxZblY4.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVFMZ0dzRehY43EA.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWVHLiMN-cxZblY4.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVCMV0dzRehY43EA.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOsEADFm8hSaQTFG18FErVhsC9x-tarWXXKiMN-cxZblY4.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/firasanscondensed/v4/wEOuEADFm8hSaQTFG18FErVhsC9x-tarUfPVLMR0dzRehY43EA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22531,24 +23504,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPMcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3Zyuv1WarE9ncg.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPOcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqW21-ejkp3cn22.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3TCPn3-0oEZ-a2Q.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWd36-pGR7e2SvJQ.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3VSMn3-0oEZ-a2Q.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWE32-pGR7e2SvJQ.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPKcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda5fiku3efvE8.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPMcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fquv1WarE9ncg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3QyNn3-0oEZ-a2Q.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWS3y-pGR7e2SvJQ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3SCKn3-0oEZ-a2Q.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWZ3u-pGR7e2SvJQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3USLn3-0oEZ-a2Q.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWA3q-pGR7e2SvJQ.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3ViIn3-0oEZ-a2Q.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWH3m-pGR7e2SvJQ.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3XyJn3-0oEZ-a2Q.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWO3i-pGR7e2SvJQ.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPMcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3Zyuv1WarE9ncg.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPOcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqW21-ejkp3cn22.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3TCPn3-0oEZ-a2Q.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWd36-pGR7e2SvJQ.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3VSMn3-0oEZ-a2Q.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWE32-pGR7e2SvJQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPKcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda5fiku3efvE8.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPMcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fquv1WarE9ncg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3QyNn3-0oEZ-a2Q.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWS3y-pGR7e2SvJQ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3SCKn3-0oEZ-a2Q.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWZ3u-pGR7e2SvJQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3USLn3-0oEZ-a2Q.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWA3q-pGR7e2SvJQ.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3ViIn3-0oEZ-a2Q.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWH3m-pGR7e2SvJQ.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPPcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda3XyJn3-0oEZ-a2Q.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/firasansextracondensed/v4/NaPxcYDaAO5dirw6IaFn7lPJFqXmS-M9Atn3wgda1fqWO3i-pGR7e2SvJQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22579,19 +23570,28 @@ class GoogleFonts {
   static TextTheme firaSansExtraCondensedTextTheme([TextTheme textTheme]) {
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(
-      display4: GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.display4),
-      display3: GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.display3),
-      display2: GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.display2),
-      display1: GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.display1),
-      headline: GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.headline),
+      display4:
+          GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.display4),
+      display3:
+          GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.display3),
+      display2:
+          GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.display2),
+      display1:
+          GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.display1),
+      headline:
+          GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.headline),
       title: GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.title),
-      subhead: GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.subhead),
+      subhead:
+          GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.subhead),
       body2: GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.body2),
       body1: GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.body1),
-      caption: GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.caption),
+      caption:
+          GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.caption),
       button: GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.button),
-      subtitle: GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.subtitle),
-      overline: GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.overline),
+      subtitle:
+          GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.subtitle),
+      overline:
+          GoogleFonts.firaSansExtraCondensed(textStyle: textTheme?.overline),
     );
   }
 
@@ -22617,7 +23617,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fjallaone/v7/Yq6R-LCAWCX3-6Ky7FAFnOZwkxgtUb8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fjallaone/v7/Yq6R-LCAWCX3-6Ky7FAFnOZwkxgtUb8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22686,7 +23687,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fjordone/v8/zOL-4pbEnKBY_9S1jNKr6e5As-FeiQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fjordone/v8/zOL-4pbEnKBY_9S1jNKr6e5As-FeiQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22755,8 +23757,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/flamenco/v10/neIPzCehqYguo67ssZ0qNIkyepH9qGsf.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/flamenco/v10/neIIzCehqYguo67ssaWGHK06UY30.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/flamenco/v10/neIPzCehqYguo67ssZ0qNIkyepH9qGsf.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/flamenco/v10/neIIzCehqYguo67ssaWGHK06UY30.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22825,7 +23829,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/flavors/v9/FBV2dDrhxqmveJTpbkzlNqkG9UY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/flavors/v9/FBV2dDrhxqmveJTpbkzlNqkG9UY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22894,8 +23899,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fondamento/v10/4UaHrEJGsxNmFTPDnkaJx63j5pN1MwI.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/fondamento/v10/4UaFrEJGsxNmFTPDnkaJ96_p4rFwIwJePw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fondamento/v10/4UaHrEJGsxNmFTPDnkaJx63j5pN1MwI.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/fondamento/v10/4UaFrEJGsxNmFTPDnkaJ96_p4rFwIwJePw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -22964,7 +23971,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fontdinerswanky/v10/ijwOs4XgRNsiaI5-hcVb4hQgMvCD4uEfKiGvxts.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fontdinerswanky/v10/ijwOs4XgRNsiaI5-hcVb4hQgMvCD4uEfKiGvxts.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23033,7 +24041,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/forum/v10/6aey4Ky-Vb8Ew_IWMJMa3mnT.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/forum/v10/6aey4Ky-Vb8Ew_IWMJMa3mnT.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23102,7 +24111,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/francoisone/v14/_Xmr-H4zszafZw3A-KPSZutNxgKQu_avAg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/francoisone/v14/_Xmr-H4zszafZw3A-KPSZutNxgKQu_avAg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23171,11 +24181,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/frankruhllibre/v5/j8_36_fAw7jrcalD7oKYNX0QfAnPUxvHxJDMhYeIHw8.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/frankruhllibre/v5/j8_w6_fAw7jrcalD7oKYNX0QfAnPa7fv4JjnmY4.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/frankruhllibre/v5/j8_36_fAw7jrcalD7oKYNX0QfAnPU0PGxJDMhYeIHw8.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/frankruhllibre/v5/j8_36_fAw7jrcalD7oKYNX0QfAnPUwvAxJDMhYeIHw8.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/frankruhllibre/v5/j8_36_fAw7jrcalD7oKYNX0QfAnPUzPCxJDMhYeIHw8.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/frankruhllibre/v5/j8_36_fAw7jrcalD7oKYNX0QfAnPUxvHxJDMhYeIHw8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/frankruhllibre/v5/j8_w6_fAw7jrcalD7oKYNX0QfAnPa7fv4JjnmY4.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/frankruhllibre/v5/j8_36_fAw7jrcalD7oKYNX0QfAnPU0PGxJDMhYeIHw8.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/frankruhllibre/v5/j8_36_fAw7jrcalD7oKYNX0QfAnPUwvAxJDMhYeIHw8.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/frankruhllibre/v5/j8_36_fAw7jrcalD7oKYNX0QfAnPUzPCxJDMhYeIHw8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23244,7 +24259,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/freckleface/v8/AMOWz4SXrmKHCvXTohxY-YI0U1K2w9lb4g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/freckleface/v8/AMOWz4SXrmKHCvXTohxY-YI0U1K2w9lb4g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23313,7 +24329,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/frederickathegreat/v9/9Bt33CxNwt7aOctW2xjbCstzwVKsIBVV-9Skz7Ylch2L.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/frederickathegreat/v9/9Bt33CxNwt7aOctW2xjbCstzwVKsIBVV-9Skz7Ylch2L.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23382,7 +24399,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fredokaone/v7/k3kUo8kEI-tA1RRcTZGmTmHBA6aF8Bf_.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fredokaone/v7/k3kUo8kEI-tA1RRcTZGmTmHBA6aF8Bf_.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23451,7 +24469,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/freehand/v11/cIf-Ma5eqk01VjKTgAmBTmUOmZJk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/freehand/v11/cIf-Ma5eqk01VjKTgAmBTmUOmZJk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23520,7 +24539,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fresca/v8/6ae94K--SKgCzbM2Gr0W13DKPA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fresca/v8/6ae94K--SKgCzbM2Gr0W13DKPA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23589,7 +24609,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/frijole/v8/uU9PCBUR8oakM2BQ7xPb3vyHmlI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/frijole/v8/uU9PCBUR8oakM2BQ7xPb3vyHmlI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23658,7 +24679,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fruktur/v12/SZc53FHsOru5QYsMfz3GkUrS8DI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fruktur/v12/SZc53FHsOru5QYsMfz3GkUrS8DI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23727,7 +24749,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/fugazone/v9/rax_HiWKp9EAITukFslMBBJek0vA8A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/fugazone/v9/rax_HiWKp9EAITukFslMBBJek0vA8A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23796,7 +24819,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gfsdidot/v9/Jqzh5TybZ9vZMWFssvwiF-fGFSCGAA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gfsdidot/v9/Jqzh5TybZ9vZMWFssvwiF-fGFSCGAA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23865,10 +24889,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gfsneohellenic/v12/8QIRdiDOrfiq0b7R8O1Iw9WLcY5TLahP46UDUw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/gfsneohellenic/v12/8QITdiDOrfiq0b7R8O1Iw9WLcY5jL6JLwaATU91X.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/gfsneohellenic/v12/8QIUdiDOrfiq0b7R8O1Iw9WLcY5rkYdr644fWsRO9w.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/gfsneohellenic/v12/8QIWdiDOrfiq0b7R8O1Iw9WLcY5jL5r37oQbeMFe985V.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gfsneohellenic/v12/8QIRdiDOrfiq0b7R8O1Iw9WLcY5TLahP46UDUw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/gfsneohellenic/v12/8QITdiDOrfiq0b7R8O1Iw9WLcY5jL6JLwaATU91X.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/gfsneohellenic/v12/8QIUdiDOrfiq0b7R8O1Iw9WLcY5rkYdr644fWsRO9w.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/gfsneohellenic/v12/8QIWdiDOrfiq0b7R8O1Iw9WLcY5jL5r37oQbeMFe985V.ttf',
     };
 
     return googleFontsTextStyle(
@@ -23937,7 +24965,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gabriela/v8/qkBWXvsO6sreR8E-b_m-zrpHmRzC.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gabriela/v8/qkBWXvsO6sreR8E-b_m-zrpHmRzC.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24006,9 +25035,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/gaegu/v8/TuGSUVB6Up9NU57nifw74sdtBk0x.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gaegu/v8/TuGfUVB6Up9NU6ZLodgzydtk.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/gaegu/v8/TuGSUVB6Up9NU573jvw74sdtBk0x.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/gaegu/v8/TuGSUVB6Up9NU57nifw74sdtBk0x.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gaegu/v8/TuGfUVB6Up9NU6ZLodgzydtk.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/gaegu/v8/TuGSUVB6Up9NU573jvw74sdtBk0x.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24077,7 +25109,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gafata/v8/XRXV3I6Cn0VJKon4MuyAbsrVcA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gafata/v8/XRXV3I6Cn0VJKon4MuyAbsrVcA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24146,7 +25179,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/galada/v5/H4cmBXyGmcjXlUX-8iw-4Lqggw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/galada/v5/H4cmBXyGmcjXlUX-8iw-4Lqggw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24215,7 +25249,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/galdeano/v9/uU9MCBoQ4YOqOW1boDPx8PCOg0uX.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/galdeano/v9/uU9MCBoQ4YOqOW1boDPx8PCOg0uX.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24284,7 +25319,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/galindo/v7/HI_KiYMeLqVKqwyuQ5HiRp-dhpQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/galindo/v7/HI_KiYMeLqVKqwyuQ5HiRp-dhpQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24353,7 +25389,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gamjaflower/v8/6NUR8FiKJg-Pa0rM6uN40Z4kyf9Fdty2ew.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gamjaflower/v8/6NUR8FiKJg-Pa0rM6uN40Z4kyf9Fdty2ew.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24422,9 +25459,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/gayathri/v1/MCoWzAb429DbBilWLLhc-pvSA_gA2W8.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gayathri/v1/MCoQzAb429DbBilWLIA48J_wBugA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/gayathri/v1/MCoXzAb429DbBilWLLiE37v4LfQJwHbn.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/gayathri/v1/MCoWzAb429DbBilWLLhc-pvSA_gA2W8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gayathri/v1/MCoQzAb429DbBilWLIA48J_wBugA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/gayathri/v1/MCoXzAb429DbBilWLLiE37v4LfQJwHbn.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24493,14 +25533,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gelasio/v1/cIf9MaFfvUQxTTqSxCmrYGkHgIs.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/gelasio/v1/cIf_MaFfvUQxTTqS9CuhZEsCkIt9QQ.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/gelasio/v1/cIf4MaFfvUQxTTqS_N2CRGEsnIJkWL4.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/gelasio/v1/cIf6MaFfvUQxTTqS9CuZkGImmKBhSL7Y1Q.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/gelasio/v1/cIf4MaFfvUQxTTqS_PGFRGEsnIJkWL4.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/gelasio/v1/cIf6MaFfvUQxTTqS9CuZvGUmmKBhSL7Y1Q.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/gelasio/v1/cIf4MaFfvUQxTTqS_JWERGEsnIJkWL4.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/gelasio/v1/cIf6MaFfvUQxTTqS9CuZ2GQmmKBhSL7Y1Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gelasio/v1/cIf9MaFfvUQxTTqSxCmrYGkHgIs.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/gelasio/v1/cIf_MaFfvUQxTTqS9CuhZEsCkIt9QQ.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/gelasio/v1/cIf4MaFfvUQxTTqS_N2CRGEsnIJkWL4.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/gelasio/v1/cIf6MaFfvUQxTTqS9CuZkGImmKBhSL7Y1Q.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/gelasio/v1/cIf4MaFfvUQxTTqS_PGFRGEsnIJkWL4.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/gelasio/v1/cIf6MaFfvUQxTTqS9CuZvGUmmKBhSL7Y1Q.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/gelasio/v1/cIf4MaFfvUQxTTqS_JWERGEsnIJkWL4.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/gelasio/v1/cIf6MaFfvUQxTTqS9CuZ2GQmmKBhSL7Y1Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24569,10 +25617,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gentiumbasic/v11/Wnz9HAw9aB_JD2VGQVR80We3HAqDiTI_cIM.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/gentiumbasic/v11/WnzjHAw9aB_JD2VGQVR80We3LAiJjRA6YIORZQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/gentiumbasic/v11/WnzgHAw9aB_JD2VGQVR80We3JLasrToUbIqIfBU.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/gentiumbasic/v11/WnzmHAw9aB_JD2VGQVR80We3LAixMT8eaKiNbBVWkw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gentiumbasic/v11/Wnz9HAw9aB_JD2VGQVR80We3HAqDiTI_cIM.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/gentiumbasic/v11/WnzjHAw9aB_JD2VGQVR80We3LAiJjRA6YIORZQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/gentiumbasic/v11/WnzgHAw9aB_JD2VGQVR80We3JLasrToUbIqIfBU.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/gentiumbasic/v11/WnzmHAw9aB_JD2VGQVR80We3LAixMT8eaKiNbBVWkw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24641,10 +25693,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gentiumbookbasic/v10/pe0zMJCbPYBVokB1LHA9bbyaQb8ZGjcIV7t7w6bE2A.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/gentiumbookbasic/v10/pe0xMJCbPYBVokB1LHA9bbyaQb8ZGjc4VbF_4aPU2Ec9.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/gentiumbookbasic/v10/pe0wMJCbPYBVokB1LHA9bbyaQb8ZGjcw65Rfy43Y0V4kvg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/gentiumbookbasic/v10/pe0-MJCbPYBVokB1LHA9bbyaQb8ZGjc4VYnDzofc81s0voO3.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gentiumbookbasic/v10/pe0zMJCbPYBVokB1LHA9bbyaQb8ZGjcIV7t7w6bE2A.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/gentiumbookbasic/v10/pe0xMJCbPYBVokB1LHA9bbyaQb8ZGjc4VbF_4aPU2Ec9.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/gentiumbookbasic/v10/pe0wMJCbPYBVokB1LHA9bbyaQb8ZGjcw65Rfy43Y0V4kvg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/gentiumbookbasic/v10/pe0-MJCbPYBVokB1LHA9bbyaQb8ZGjc4VYnDzofc81s0voO3.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24713,8 +25769,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/geo/v11/CSRz4zRZlufVL3BmQjlCbQ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/geo/v11/CSRx4zRZluflLXpiYDxSbf8r.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/geo/v11/CSRz4zRZlufVL3BmQjlCbQ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/geo/v11/CSRx4zRZluflLXpiYDxSbf8r.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24783,7 +25841,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/geostar/v10/sykz-yx4n701VLOftSq9-trEvlQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/geostar/v10/sykz-yx4n701VLOftSq9-trEvlQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24852,7 +25911,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/geostarfill/v10/AMOWz4SWuWiXFfjEohxQ9os0U1K2w9lb4g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/geostarfill/v10/AMOWz4SWuWiXFfjEohxQ9os0U1K2w9lb4g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24921,7 +25981,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/germaniaone/v7/Fh4yPjrqIyv2ucM2qzBjeS3ezAJONau6ew.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/germaniaone/v7/Fh4yPjrqIyv2ucM2qzBjeS3ezAJONau6ew.ttf',
     };
 
     return googleFontsTextStyle(
@@ -24990,7 +26051,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gidugu/v6/L0x8DFMkk1Uf6w3RvPCmRSlUig.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gidugu/v6/L0x8DFMkk1Uf6w3RvPCmRSlUig.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25059,7 +26121,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gildadisplay/v7/t5tmIRoYMoaYG0WEOh7HwMeR7TnFrpOHYh4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gildadisplay/v7/t5tmIRoYMoaYG0WEOh7HwMeR7TnFrpOHYh4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25128,7 +26191,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/girassol/v1/JTUUjIo_-DK48laaNC9Nz2pJzxbi.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/girassol/v1/JTUUjIo_-DK48laaNC9Nz2pJzxbi.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25197,7 +26261,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/giveyouglory/v9/8QIQdiHOgt3vv4LR7ahjw9-XYc1zB4ZD6rwa.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/giveyouglory/v9/8QIQdiHOgt3vv4LR7ahjw9-XYc1zB4ZD6rwa.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25266,7 +26331,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/glassantiqua/v7/xfu30Wr0Wn3NOQM2piC0uXOjnL_wN6fRUkY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/glassantiqua/v7/xfu30Wr0Wn3NOQM2piC0uXOjnL_wN6fRUkY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25335,8 +26401,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/glegoo/v9/_Xmt-HQyrTKWaw2Ji6mZAI91xw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/glegoo/v9/_Xmu-HQyrTKWaw2xN4a9CKRpzimMsg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/glegoo/v9/_Xmt-HQyrTKWaw2Ji6mZAI91xw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/glegoo/v9/_Xmu-HQyrTKWaw2xN4a9CKRpzimMsg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25405,7 +26473,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gloriahallelujah/v11/LYjYdHv3kUk9BMV96EIswT9DIbW-MLSy3TKEvkCF.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gloriahallelujah/v11/LYjYdHv3kUk9BMV96EIswT9DIbW-MLSy3TKEvkCF.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25474,7 +26543,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/goblinone/v9/CSR64z1ZnOqZRjRCBVY_TOcATNt_pOU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/goblinone/v9/CSR64z1ZnOqZRjRCBVY_TOcATNt_pOU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25543,7 +26613,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gochihand/v10/hES06XlsOjtJsgCkx1PkTo71-n0nXWA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gochihand/v10/hES06XlsOjtJsgCkx1PkTo71-n0nXWA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25612,8 +26683,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gorditas/v7/ll8_K2aTVD26DsPEtQDoDa4AlxYb.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/gorditas/v7/ll84K2aTVD26DsPEtThUIooIvAoShA1i.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gorditas/v7/ll8_K2aTVD26DsPEtQDoDa4AlxYb.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/gorditas/v7/ll84K2aTVD26DsPEtThUIooIvAoShA1i.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25682,15 +26755,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/gothica1/v8/CSR74z5ZnPydRjlCCwlCCMcqYtd2vfwk.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlCpOYKSPl6tOU9Eg.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlCwOUKSPl6tOU9Eg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gothica1/v8/CSR94z5ZnPydRjlCCwl6bM0uQNJmvQ.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlCmOQKSPl6tOU9Eg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlCtOMKSPl6tOU9Eg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlC0OIKSPl6tOU9Eg.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlCzOEKSPl6tOU9Eg.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlC6OAKSPl6tOU9Eg.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/gothica1/v8/CSR74z5ZnPydRjlCCwlCCMcqYtd2vfwk.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlCpOYKSPl6tOU9Eg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlCwOUKSPl6tOU9Eg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gothica1/v8/CSR94z5ZnPydRjlCCwl6bM0uQNJmvQ.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlCmOQKSPl6tOU9Eg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlCtOMKSPl6tOU9Eg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlC0OIKSPl6tOU9Eg.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlCzOEKSPl6tOU9Eg.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/gothica1/v8/CSR44z5ZnPydRjlCCwlC6OAKSPl6tOU9Eg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25759,7 +26841,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/goudybookletter1911/v9/sykt-z54laciWfKv-kX8krex0jDiD2HbY6I5tRbXZ4IXAA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/goudybookletter1911/v9/sykt-z54laciWfKv-kX8krex0jDiD2HbY6I5tRbXZ4IXAA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25828,7 +26911,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/graduate/v7/C8cg4cs3o2n15t_2YxgR6X2NZAn2.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/graduate/v7/C8cg4cs3o2n15t_2YxgR6X2NZAn2.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25897,7 +26981,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/grandhotel/v7/7Au7p_IgjDKdCRWuR1azpmQNEl0O0kEx.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/grandhotel/v7/7Au7p_IgjDKdCRWuR1azpmQNEl0O0kEx.ttf',
     };
 
     return googleFontsTextStyle(
@@ -25966,7 +27051,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gravitasone/v9/5h1diZ4hJ3cblKy3LWakKQmaDWRNr3DzbQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gravitasone/v9/5h1diZ4hJ3cblKy3LWakKQmaDWRNr3DzbQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26035,7 +27121,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/greatvibes/v7/RWmMoKWR9v4ksMfaWd_JN-XCg6UKDXlq.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/greatvibes/v7/RWmMoKWR9v4ksMfaWd_JN-XCg6UKDXlq.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26104,24 +27191,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZRFGb7hR12BxqPm2IjuAkalnmd.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZXFGb7hR12BxqH_VpHsg04k2md0kI.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPN0MDkicWn2CEyw.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_Vrrky0SvWWUy1uW.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPU0ADkicWn2CEyw.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_VqPkC0SvWWUy1uW.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZTFGb7hR12Bxq3_2gnmgwKlg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZRFGb7hR12BxqH_WIjuAkalnmd.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPC0EDkicWn2CEyw.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_VrXkS0SvWWUy1uW.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPJ0YDkicWn2CEyw.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_Vr7li0SvWWUy1uW.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPQ0cDkicWn2CEyw.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_Vqfly0SvWWUy1uW.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPX0QDkicWn2CEyw.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_VqDlC0SvWWUy1uW.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPe0UDkicWn2CEyw.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_VqnlS0SvWWUy1uW.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZRFGb7hR12BxqPm2IjuAkalnmd.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZXFGb7hR12BxqH_VpHsg04k2md0kI.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPN0MDkicWn2CEyw.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_Vrrky0SvWWUy1uW.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPU0ADkicWn2CEyw.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_VqPkC0SvWWUy1uW.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZTFGb7hR12Bxq3_2gnmgwKlg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZRFGb7hR12BxqH_WIjuAkalnmd.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPC0EDkicWn2CEyw.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_VrXkS0SvWWUy1uW.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPJ0YDkicWn2CEyw.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_Vr7li0SvWWUy1uW.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPQ0cDkicWn2CEyw.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_Vqfly0SvWWUy1uW.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPX0QDkicWn2CEyw.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_VqDlC0SvWWUy1uW.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZQFGb7hR12BxqPe0UDkicWn2CEyw.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/grenze/v1/O4ZWFGb7hR12BxqH_VqnlS0SvWWUy1uW.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26190,7 +27295,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/griffy/v8/FwZa7-ox2FQh9kfwSNSEwM2zpA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/griffy/v8/FwZa7-ox2FQh9kfwSNSEwM2zpA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26259,7 +27365,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gruppo/v10/WwkfxPmzE06v_ZWFWXDAOIEQUQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gruppo/v10/WwkfxPmzE06v_ZWFWXDAOIEQUQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26328,9 +27435,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gudea/v9/neIFzCqgsI0mp-CP9IGON7Ez.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/gudea/v9/neILzCqgsI0mp9CN_oWsMqEzSJQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/gudea/v9/neIIzCqgsI0mp9gz26WGHK06UY30.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gudea/v9/neIFzCqgsI0mp-CP9IGON7Ez.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/gudea/v9/neILzCqgsI0mp9CN_oWsMqEzSJQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/gudea/v9/neIIzCqgsI0mp9gz26WGHK06UY30.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26399,7 +27509,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gugi/v8/A2BVn5dXywshVA6A9DEfgqM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gugi/v8/A2BVn5dXywshVA6A9DEfgqM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26468,9 +27579,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gupter/v1/2-cm9JNmxJqPO1QUYZa_Wu_lpA.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/gupter/v1/2-cl9JNmxJqPO1Qslb-bUsT5rZhaZg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/gupter/v1/2-cl9JNmxJqPO1Qs3bmbUsT5rZhaZg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gupter/v1/2-cm9JNmxJqPO1QUYZa_Wu_lpA.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/gupter/v1/2-cl9JNmxJqPO1Qslb-bUsT5rZhaZg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/gupter/v1/2-cl9JNmxJqPO1Qs3bmbUsT5rZhaZg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26539,7 +27653,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/gurajada/v7/FwZY7-Qx308m-l-0Kd6A4sijpFu_.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/gurajada/v7/FwZY7-Qx308m-l-0Kd6A4sijpFu_.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26608,7 +27723,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/habibi/v8/CSR-4zFWkuqcTTNCShJeZOYySQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/habibi/v8/CSR-4zFWkuqcTTNCShJeZOYySQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26677,11 +27793,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/halant/v7/u-490qaujRI2Pbsvc_pCmwZqcwdRXg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/halant/v7/u-4-0qaujRI2PbsX39Jmky12eg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/halant/v7/u-490qaujRI2PbsvK_tCmwZqcwdRXg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/halant/v7/u-490qaujRI2PbsvB_xCmwZqcwdRXg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/halant/v7/u-490qaujRI2PbsvY_1CmwZqcwdRXg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/halant/v7/u-490qaujRI2Pbsvc_pCmwZqcwdRXg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/halant/v7/u-4-0qaujRI2PbsX39Jmky12eg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/halant/v7/u-490qaujRI2PbsvK_tCmwZqcwdRXg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/halant/v7/u-490qaujRI2PbsvB_xCmwZqcwdRXg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/halant/v7/u-490qaujRI2PbsvY_1CmwZqcwdRXg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26750,7 +27871,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/hammersmithone/v10/qWcyB624q4L_C4jGQ9IK0O_dFlnbshsks4MRXw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/hammersmithone/v10/qWcyB624q4L_C4jGQ9IK0O_dFlnbshsks4MRXw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26819,7 +27941,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/hanalei/v10/E21n_dD8iufIjBRHXzgmVydREus.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/hanalei/v10/E21n_dD8iufIjBRHXzgmVydREus.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26888,7 +28011,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/hanaleifill/v8/fC1mPYtObGbfyQznIaQzPQiMVwLBplm9aw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/hanaleifill/v8/fC1mPYtObGbfyQznIaQzPQiMVwLBplm9aw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -26957,7 +28081,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/handlee/v8/-F6xfjBsISg9aMakDmr6oilJ3ik.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/handlee/v8/-F6xfjBsISg9aMakDmr6oilJ3ik.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27026,8 +28151,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/hanuman/v13/VuJxdNvD15HhpJJBeKbXOIFneRo.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/hanuman/v13/VuJ0dNvD15HhpJJBQBr4HIlMZRNcp0o.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/hanuman/v13/VuJxdNvD15HhpJJBeKbXOIFneRo.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/hanuman/v13/VuJ0dNvD15HhpJJBQBr4HIlMZRNcp0o.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27096,7 +28223,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/happymonkey/v8/K2F2fZZcl-9SXwl5F_C4R_OABwD2bWqVjw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/happymonkey/v8/K2F2fZZcl-9SXwl5F_C4R_OABwD2bWqVjw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27165,7 +28293,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/harmattan/v6/goksH6L2DkFvVvRp9XpTS0CjkP1Yog.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/harmattan/v6/goksH6L2DkFvVvRp9XpTS0CjkP1Yog.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27234,7 +28363,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/headlandone/v7/yYLu0hHR2vKnp89Tk1TCq3Tx0PlTeZ3mJA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/headlandone/v7/yYLu0hHR2vKnp89Tk1TCq3Tx0PlTeZ3mJA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27303,13 +28433,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/heebo/v5/NGS0v5_NC0k9P9mVTbRhtKMByaw.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/heebo/v5/NGS3v5_NC0k9P9ldb5RLmq8I0LVF.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/heebo/v5/NGS6v5_NC0k9P-HxR7BDsbMB.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/heebo/v5/NGS3v5_NC0k9P9kFbpRLmq8I0LVF.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/heebo/v5/NGS3v5_NC0k9P9lNaJRLmq8I0LVF.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/heebo/v5/NGS3v5_NC0k9P9lRa5RLmq8I0LVF.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/heebo/v5/NGS3v5_NC0k9P9l1apRLmq8I0LVF.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/heebo/v5/NGS0v5_NC0k9P9mVTbRhtKMByaw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/heebo/v5/NGS3v5_NC0k9P9ldb5RLmq8I0LVF.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/heebo/v5/NGS6v5_NC0k9P-HxR7BDsbMB.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/heebo/v5/NGS3v5_NC0k9P9kFbpRLmq8I0LVF.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/heebo/v5/NGS3v5_NC0k9P9lNaJRLmq8I0LVF.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/heebo/v5/NGS3v5_NC0k9P9lRa5RLmq8I0LVF.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/heebo/v5/NGS3v5_NC0k9P9l1apRLmq8I0LVF.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27378,7 +28515,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/hennypenny/v7/wXKvE3UZookzsxz_kjGSfMQqt3M7tMDT.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/hennypenny/v7/wXKvE3UZookzsxz_kjGSfMQqt3M7tMDT.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27447,15 +28585,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5HvkV5jfbY5B0NBkz.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5HvmV5zfbY5B0NBkz.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5HvlL5zfbY5B0NBkz.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5HvkV5zfbY5B0NBkz.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5Hvkn5zfbY5B0NBkz.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5HvnL4DfbY5B0NBkz.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5Hvny4DfbY5B0NBkz.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5HvmV4DfbY5B0NBkz.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5Hvm84DfbY5B0NBkz.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5HvkV5jfbY5B0NBkz.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5HvmV5zfbY5B0NBkz.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5HvlL5zfbY5B0NBkz.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5HvkV5zfbY5B0NBkz.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5Hvkn5zfbY5B0NBkz.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5HvnL4DfbY5B0NBkz.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5Hvny4DfbY5B0NBkz.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5HvmV4DfbY5B0NBkz.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/heptaslab/v6/ea8JadoyU_jkHdalebHvyWVNdYoIsHe5Hvm84DfbY5B0NBkz.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27524,7 +28671,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/herrvonmuellerhoff/v9/WBL6rFjRZkREW8WqmCWYLgCkQKXb4CAft3c6_qJY3QPQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/herrvonmuellerhoff/v9/WBL6rFjRZkREW8WqmCWYLgCkQKXb4CAft3c6_qJY3QPQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27593,7 +28741,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/himelody/v8/46ktlbP8Vnz0pJcqCTbEf29E31BBGA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/himelody/v8/46ktlbP8Vnz0pJcqCTbEf29E31BBGA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27662,11 +28811,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/hind/v10/5aU19_a8oxmIfMJaIRuYjDpf5Vw.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/hind/v10/5aU69_a8oxmIRG5yBROzkDM.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/hind/v10/5aU19_a8oxmIfJpbIRuYjDpf5Vw.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/hind/v10/5aU19_a8oxmIfLZcIRuYjDpf5Vw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/hind/v10/5aU19_a8oxmIfNJdIRuYjDpf5Vw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/hind/v10/5aU19_a8oxmIfMJaIRuYjDpf5Vw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/hind/v10/5aU69_a8oxmIRG5yBROzkDM.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/hind/v10/5aU19_a8oxmIfJpbIRuYjDpf5Vw.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/hind/v10/5aU19_a8oxmIfLZcIRuYjDpf5Vw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/hind/v10/5aU19_a8oxmIfNJdIRuYjDpf5Vw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27735,11 +28889,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/hindguntur/v5/wXKyE3UZrok56nvamSuJd_yGn1czn9zaj5Ju.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/hindguntur/v5/wXKvE3UZrok56nvamSuJd8Qqt3M7tMDT.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/hindguntur/v5/wXKyE3UZrok56nvamSuJd_zenlczn9zaj5Ju.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/hindguntur/v5/wXKyE3UZrok56nvamSuJd_zymVczn9zaj5Ju.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/hindguntur/v5/wXKyE3UZrok56nvamSuJd_yWmFczn9zaj5Ju.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/hindguntur/v5/wXKyE3UZrok56nvamSuJd_yGn1czn9zaj5Ju.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/hindguntur/v5/wXKvE3UZrok56nvamSuJd8Qqt3M7tMDT.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/hindguntur/v5/wXKyE3UZrok56nvamSuJd_zenlczn9zaj5Ju.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/hindguntur/v5/wXKyE3UZrok56nvamSuJd_zymVczn9zaj5Ju.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/hindguntur/v5/wXKyE3UZrok56nvamSuJd_yWmFczn9zaj5Ju.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27808,11 +28967,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/hindmadurai/v5/f0Xu0e2p98ZvDXdZQIOcpqjfXaUnecsoMJ0b_g.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/hindmadurai/v5/f0Xx0e2p98ZvDXdZQIOcpqjn8Y0DceA0OQ.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/hindmadurai/v5/f0Xu0e2p98ZvDXdZQIOcpqjfBaQnecsoMJ0b_g.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/hindmadurai/v5/f0Xu0e2p98ZvDXdZQIOcpqjfKaMnecsoMJ0b_g.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/hindmadurai/v5/f0Xu0e2p98ZvDXdZQIOcpqjfTaInecsoMJ0b_g.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/hindmadurai/v5/f0Xu0e2p98ZvDXdZQIOcpqjfXaUnecsoMJ0b_g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/hindmadurai/v5/f0Xx0e2p98ZvDXdZQIOcpqjn8Y0DceA0OQ.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/hindmadurai/v5/f0Xu0e2p98ZvDXdZQIOcpqjfBaQnecsoMJ0b_g.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/hindmadurai/v5/f0Xu0e2p98ZvDXdZQIOcpqjfKaMnecsoMJ0b_g.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/hindmadurai/v5/f0Xu0e2p98ZvDXdZQIOcpqjfTaInecsoMJ0b_g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27881,11 +29045,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/hindsiliguri/v6/ijwOs5juQtsyLLR5jN4cxBEoRDf44uEfKiGvxts.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/hindsiliguri/v6/ijwTs5juQtsyLLR5jN4cxBEofJvQxuk0Nig.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/hindsiliguri/v6/ijwOs5juQtsyLLR5jN4cxBEoRG_54uEfKiGvxts.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/hindsiliguri/v6/ijwOs5juQtsyLLR5jN4cxBEoREP-4uEfKiGvxts.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/hindsiliguri/v6/ijwOs5juQtsyLLR5jN4cxBEoRCf_4uEfKiGvxts.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/hindsiliguri/v6/ijwOs5juQtsyLLR5jN4cxBEoRDf44uEfKiGvxts.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/hindsiliguri/v6/ijwTs5juQtsyLLR5jN4cxBEofJvQxuk0Nig.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/hindsiliguri/v6/ijwOs5juQtsyLLR5jN4cxBEoRG_54uEfKiGvxts.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/hindsiliguri/v6/ijwOs5juQtsyLLR5jN4cxBEoREP-4uEfKiGvxts.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/hindsiliguri/v6/ijwOs5juQtsyLLR5jN4cxBEoRCf_4uEfKiGvxts.ttf',
     };
 
     return googleFontsTextStyle(
@@ -27954,11 +29123,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/hindvadodara/v6/neIQzCKvrIcn5pbuuuriV9tTSDn3iXM0oSOL2Yw.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/hindvadodara/v6/neINzCKvrIcn5pbuuuriV9tTcJXfrXsfvSo.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/hindvadodara/v6/neIQzCKvrIcn5pbuuuriV9tTSGH2iXM0oSOL2Yw.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/hindvadodara/v6/neIQzCKvrIcn5pbuuuriV9tTSE3xiXM0oSOL2Yw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/hindvadodara/v6/neIQzCKvrIcn5pbuuuriV9tTSCnwiXM0oSOL2Yw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/hindvadodara/v6/neIQzCKvrIcn5pbuuuriV9tTSDn3iXM0oSOL2Yw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/hindvadodara/v6/neINzCKvrIcn5pbuuuriV9tTcJXfrXsfvSo.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/hindvadodara/v6/neIQzCKvrIcn5pbuuuriV9tTSGH2iXM0oSOL2Yw.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/hindvadodara/v6/neIQzCKvrIcn5pbuuuriV9tTSE3xiXM0oSOL2Yw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/hindvadodara/v6/neIQzCKvrIcn5pbuuuriV9tTSCnwiXM0oSOL2Yw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28027,7 +29201,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/holtwoodonesc/v10/yYLx0hLR0P-3vMFSk1TCq3Txg5B3cbb6LZttyg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/holtwoodonesc/v10/yYLx0hLR0P-3vMFSk1TCq3Txg5B3cbb6LZttyg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28096,7 +29271,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/homemadeapple/v10/Qw3EZQFXECDrI2q789EKQZJob3x9Vnksi4M7.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/homemadeapple/v10/Qw3EZQFXECDrI2q789EKQZJob3x9Vnksi4M7.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28165,7 +29341,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/homenaje/v9/FwZY7-Q-xVAi_l-6Ld6A4sijpFu_.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/homenaje/v9/FwZY7-Q-xVAi_l-6Ld6A4sijpFu_.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28234,20 +29411,34 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6pfjptAgt5VM-kVkqdyU8n3kwq0n1hj-sNFQ.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6rfjptAgt5VM-kVkqdyU8n1ioStndlre4dFcFh.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6qfjptAgt5VM-kVkqdyU8n3uAL8ldPg-IUDNg.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6sfjptAgt5VM-kVkqdyU8n1ioSGlZFh8ARHNh4zg.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6qfjptAgt5VM-kVkqdyU8n3oQI8ldPg-IUDNg.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6sfjptAgt5VM-kVkqdyU8n1ioSflVFh8ARHNh4zg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F63fjptAgt5VM-kVkqdyU8n5igg1l9kn-s.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6pfjptAgt5VM-kVkqdyU8n1ioq0n1hj-sNFQ.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6qfjptAgt5VM-kVkqdyU8n3twJ8ldPg-IUDNg.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6sfjptAgt5VM-kVkqdyU8n1ioSJlRFh8ARHNh4zg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6qfjptAgt5VM-kVkqdyU8n3vAO8ldPg-IUDNg.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6sfjptAgt5VM-kVkqdyU8n1ioSClNFh8ARHNh4zg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6qfjptAgt5VM-kVkqdyU8n3pQP8ldPg-IUDNg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6sfjptAgt5VM-kVkqdyU8n1ioSblJFh8ARHNh4zg.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6pfjptAgt5VM-kVkqdyU8n3kwq0n1hj-sNFQ.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6rfjptAgt5VM-kVkqdyU8n1ioStndlre4dFcFh.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6qfjptAgt5VM-kVkqdyU8n3uAL8ldPg-IUDNg.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6sfjptAgt5VM-kVkqdyU8n1ioSGlZFh8ARHNh4zg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6qfjptAgt5VM-kVkqdyU8n3oQI8ldPg-IUDNg.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6sfjptAgt5VM-kVkqdyU8n1ioSflVFh8ARHNh4zg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F63fjptAgt5VM-kVkqdyU8n5igg1l9kn-s.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6pfjptAgt5VM-kVkqdyU8n1ioq0n1hj-sNFQ.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6qfjptAgt5VM-kVkqdyU8n3twJ8ldPg-IUDNg.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6sfjptAgt5VM-kVkqdyU8n1ioSJlRFh8ARHNh4zg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6qfjptAgt5VM-kVkqdyU8n3vAO8ldPg-IUDNg.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6sfjptAgt5VM-kVkqdyU8n1ioSClNFh8ARHNh4zg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6qfjptAgt5VM-kVkqdyU8n3pQP8ldPg-IUDNg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/ibmplexmono/v5/-F6sfjptAgt5VM-kVkqdyU8n1ioSblJFh8ARHNh4zg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28316,20 +29507,34 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX-KVElMYYaJe8bpLHnCwDKjbLeEKxIedbzDw.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX8KVElMYYaJe8bpLHnCwDKhdTmdKZMW9PjD3N8.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX9KVElMYYaJe8bpLHnCwDKjR7_MIZmdd_qFmo.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX7KVElMYYaJe8bpLHnCwDKhdTm2Idscf3vBmpl8A.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX9KVElMYYaJe8bpLHnCwDKjXr8MIZmdd_qFmo.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRscf3vBmpl8A.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYXgKVElMYYaJe8bpLHnCwDKtdbUFI5NadY.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX-KVElMYYaJe8bpLHnCwDKhdTeEKxIedbzDw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX9KVElMYYaJe8bpLHnCwDKjSL9MIZmdd_qFmo.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX7KVElMYYaJe8bpLHnCwDKhdTm5IVscf3vBmpl8A.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX9KVElMYYaJe8bpLHnCwDKjQ76MIZmdd_qFmo.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJscf3vBmpl8A.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX9KVElMYYaJe8bpLHnCwDKjWr7MIZmdd_qFmo.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX7KVElMYYaJe8bpLHnCwDKhdTmrINscf3vBmpl8A.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX-KVElMYYaJe8bpLHnCwDKjbLeEKxIedbzDw.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX8KVElMYYaJe8bpLHnCwDKhdTmdKZMW9PjD3N8.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX9KVElMYYaJe8bpLHnCwDKjR7_MIZmdd_qFmo.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX7KVElMYYaJe8bpLHnCwDKhdTm2Idscf3vBmpl8A.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX9KVElMYYaJe8bpLHnCwDKjXr8MIZmdd_qFmo.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRscf3vBmpl8A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYXgKVElMYYaJe8bpLHnCwDKtdbUFI5NadY.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX-KVElMYYaJe8bpLHnCwDKhdTeEKxIedbzDw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX9KVElMYYaJe8bpLHnCwDKjSL9MIZmdd_qFmo.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX7KVElMYYaJe8bpLHnCwDKhdTm5IVscf3vBmpl8A.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX9KVElMYYaJe8bpLHnCwDKjQ76MIZmdd_qFmo.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJscf3vBmpl8A.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX9KVElMYYaJe8bpLHnCwDKjWr7MIZmdd_qFmo.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/ibmplexsans/v7/zYX7KVElMYYaJe8bpLHnCwDKhdTmrINscf3vBmpl8A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28398,20 +29603,34 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8nN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY7KyKvBgYsMDhM.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8hN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYas8M_LhakJHhOgBg.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY5m6Yvrr4cFFwq5.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8iN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYas8GPqpYMnEhq5H1w.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY4C6ovrr4cFFwq5.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8iN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYas8AfppYMnEhq5H1w.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8lN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHbauwq_jhJsM.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8nN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYasyKvBgYsMDhM.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY5a64vrr4cFFwq5.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8iN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYas8F_opYMnEhq5H1w.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY527Ivrr4cFFwq5.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8iN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYas8HPvpYMnEhq5H1w.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY4S7Yvrr4cFFwq5.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8iN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYas8BfupYMnEhq5H1w.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8nN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY7KyKvBgYsMDhM.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8hN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYas8M_LhakJHhOgBg.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY5m6Yvrr4cFFwq5.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8iN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYas8GPqpYMnEhq5H1w.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY4C6ovrr4cFFwq5.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8iN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYas8AfppYMnEhq5H1w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8lN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHbauwq_jhJsM.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8nN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYasyKvBgYsMDhM.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY5a64vrr4cFFwq5.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8iN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYas8F_opYMnEhq5H1w.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY527Ivrr4cFFwq5.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8iN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYas8HPvpYMnEhq5H1w.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY4S7Yvrr4cFFwq5.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/ibmplexsanscondensed/v6/Gg8iN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHYas8BfupYMnEhq5H1w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28442,19 +29661,26 @@ class GoogleFonts {
   static TextTheme iBMPlexSansCondensedTextTheme([TextTheme textTheme]) {
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(
-      display4: GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.display4),
-      display3: GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.display3),
-      display2: GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.display2),
-      display1: GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.display1),
-      headline: GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.headline),
+      display4:
+          GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.display4),
+      display3:
+          GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.display3),
+      display2:
+          GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.display2),
+      display1:
+          GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.display1),
+      headline:
+          GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.headline),
       title: GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.title),
       subhead: GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.subhead),
       body2: GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.body2),
       body1: GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.body1),
       caption: GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.caption),
       button: GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.button),
-      subtitle: GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.subtitle),
-      overline: GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.overline),
+      subtitle:
+          GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.subtitle),
+      overline:
+          GoogleFonts.iBMPlexSansCondensed(textStyle: textTheme?.overline),
     );
   }
 
@@ -28480,20 +29706,34 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizBREVNn1dOx-zrZ2X3pZvkTi182zIZj1bIkNo.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizHREVNn1dOx-zrZ2X3pZvkTiUa41YTi3TNgNq55w.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizAREVNn1dOx-zrZ2X3pZvkTi3Q-hIzoVrBicOg.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizGREVNn1dOx-zrZ2X3pZvkTiUa4_oyq17jjNOg_oc.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizAREVNn1dOx-zrZ2X3pZvkTi20-RIzoVrBicOg.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xq17jjNOg_oc.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizDREVNn1dOx-zrZ2X3pZvkThUY0TY7ikbI.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizBREVNn1dOx-zrZ2X3pZvkTiUa2zIZj1bIkNo.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizAREVNn1dOx-zrZ2X3pZvkTi3s-BIzoVrBicOg.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizGREVNn1dOx-zrZ2X3pZvkTiUa48Ywq17jjNOg_oc.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizAREVNn1dOx-zrZ2X3pZvkTi3A_xIzoVrBicOg.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3q17jjNOg_oc.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizAREVNn1dOx-zrZ2X3pZvkTi2k_hIzoVrBicOg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/ibmplexserif/v8/jizGREVNn1dOx-zrZ2X3pZvkTiUa4442q17jjNOg_oc.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizBREVNn1dOx-zrZ2X3pZvkTi182zIZj1bIkNo.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizHREVNn1dOx-zrZ2X3pZvkTiUa41YTi3TNgNq55w.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizAREVNn1dOx-zrZ2X3pZvkTi3Q-hIzoVrBicOg.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizGREVNn1dOx-zrZ2X3pZvkTiUa4_oyq17jjNOg_oc.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizAREVNn1dOx-zrZ2X3pZvkTi20-RIzoVrBicOg.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizGREVNn1dOx-zrZ2X3pZvkTiUa454xq17jjNOg_oc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizDREVNn1dOx-zrZ2X3pZvkThUY0TY7ikbI.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizBREVNn1dOx-zrZ2X3pZvkTiUa2zIZj1bIkNo.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizAREVNn1dOx-zrZ2X3pZvkTi3s-BIzoVrBicOg.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizGREVNn1dOx-zrZ2X3pZvkTiUa48Ywq17jjNOg_oc.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizAREVNn1dOx-zrZ2X3pZvkTi3A_xIzoVrBicOg.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizGREVNn1dOx-zrZ2X3pZvkTiUa4-o3q17jjNOg_oc.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizAREVNn1dOx-zrZ2X3pZvkTi2k_hIzoVrBicOg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/ibmplexserif/v8/jizGREVNn1dOx-zrZ2X3pZvkTiUa4442q17jjNOg_oc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28562,8 +29802,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/imfelldwpica/v9/2sDGZGRQotv9nbn2qSl0TxXVYNw9ZAPUvi88MQ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/imfelldwpica/v9/2sDEZGRQotv9nbn2qSl0TxXVYNwNZgnQnCosMXm0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/imfelldwpica/v9/2sDGZGRQotv9nbn2qSl0TxXVYNw9ZAPUvi88MQ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/imfelldwpica/v9/2sDEZGRQotv9nbn2qSl0TxXVYNwNZgnQnCosMXm0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28632,7 +29874,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/imfelldwpicasc/v9/0ybjGCAu5PfqkvtGVU15aBhXz3EUrnTW-BiKEUiBGA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/imfelldwpicasc/v9/0ybjGCAu5PfqkvtGVU15aBhXz3EUrnTW-BiKEUiBGA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28701,8 +29944,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/imfelldoublepica/v9/3XF2EqMq_94s9PeKF7Fg4gOKINyMtZ8rT0S1UL5Ayp0.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/imfelldoublepica/v9/3XF0EqMq_94s9PeKF7Fg4gOKINyMtZ8rf0a_VJxF2p2G8g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/imfelldoublepica/v9/3XF2EqMq_94s9PeKF7Fg4gOKINyMtZ8rT0S1UL5Ayp0.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/imfelldoublepica/v9/3XF0EqMq_94s9PeKF7Fg4gOKINyMtZ8rf0a_VJxF2p2G8g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28771,7 +30016,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/imfelldoublepicasc/v9/neIazDmuiMkFo6zj_sHpQ8teNbWlwBB_hXjJ4Y0Eeru2dGg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/imfelldoublepicasc/v9/neIazDmuiMkFo6zj_sHpQ8teNbWlwBB_hXjJ4Y0Eeru2dGg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28840,8 +30086,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/imfellenglish/v9/Ktk1ALSLW8zDe0rthJysWrnLsAz3F6mZVY9Y5w.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/imfellenglish/v9/Ktk3ALSLW8zDe0rthJysWrnLsAzHFaOdd4pI59zg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/imfellenglish/v9/Ktk1ALSLW8zDe0rthJysWrnLsAz3F6mZVY9Y5w.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/imfellenglish/v9/Ktk3ALSLW8zDe0rthJysWrnLsAzHFaOdd4pI59zg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28910,7 +30158,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/imfellenglishsc/v9/a8IENpD3CDX-4zrWfr1VY879qFF05pZLO4gOg0shzA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/imfellenglishsc/v9/a8IENpD3CDX-4zrWfr1VY879qFF05pZLO4gOg0shzA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -28979,8 +30228,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/imfellfrenchcanon/v9/-F6ufiNtDWYfYc-tDiyiw08rrghJszkK6coVPt1ozoPz.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/imfellfrenchcanon/v9/-F6gfiNtDWYfYc-tDiyiw08rrghJszkK6foXNNlKy5PzzrU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/imfellfrenchcanon/v9/-F6ufiNtDWYfYc-tDiyiw08rrghJszkK6coVPt1ozoPz.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/imfellfrenchcanon/v9/-F6gfiNtDWYfYc-tDiyiw08rrghJszkK6foXNNlKy5PzzrU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29049,7 +30300,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/imfellfrenchcanonsc/v9/FBVmdCru5-ifcor2bgq9V89khWcmQghEURY7H3c0UBCVIVqH.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/imfellfrenchcanonsc/v9/FBVmdCru5-ifcor2bgq9V89khWcmQghEURY7H3c0UBCVIVqH.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29118,8 +30370,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/imfellgreatprimer/v9/bx6aNwSJtayYxOkbYFsT6hMsLzX7u85rJorXvDo3SQY1.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/imfellgreatprimer/v9/bx6UNwSJtayYxOkbYFsT6hMsLzX7u85rJrrVtj4VTBY1N6U.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/imfellgreatprimer/v9/bx6aNwSJtayYxOkbYFsT6hMsLzX7u85rJorXvDo3SQY1.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/imfellgreatprimer/v9/bx6UNwSJtayYxOkbYFsT6hMsLzX7u85rJrrVtj4VTBY1N6U.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29188,7 +30442,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/imfellgreatprimersc/v9/ga6daxBOxyt6sCqz3fjZCTFCTUDMHagsQKdDTLf9BXz0s8FG.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/imfellgreatprimersc/v9/ga6daxBOxyt6sCqz3fjZCTFCTUDMHagsQKdDTLf9BXz0s8FG.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29257,12 +30512,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ibarrarealnova/v1/sZlfdQiA-DBIDCcaWtQzL4BZHoiDoHxSENxuLuE.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/ibarrarealnova/v1/sZlZdQiA-DBIDCcaWtQzL4BZHoiDkH5YFP5rPuF6EA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/ibarrarealnova/v1/sZlYdQiA-DBIDCcaWtQzL4BZHoiDmKR8NNRFMuhjCXY.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/ibarrarealnova/v1/sZladQiA-DBIDCcaWtQzL4BZHoiDkH5gzNBPNspmGXawpg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ibarrarealnova/v1/sZlYdQiA-DBIDCcaWtQzL4BZHoiDmMB9NNRFMuhjCXY.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/ibarrarealnova/v1/sZladQiA-DBIDCcaWtQzL4BZHoiDkH5gqNFPNspmGXawpg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ibarrarealnova/v1/sZlfdQiA-DBIDCcaWtQzL4BZHoiDoHxSENxuLuE.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/ibarrarealnova/v1/sZlZdQiA-DBIDCcaWtQzL4BZHoiDkH5YFP5rPuF6EA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/ibarrarealnova/v1/sZlYdQiA-DBIDCcaWtQzL4BZHoiDmKR8NNRFMuhjCXY.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/ibarrarealnova/v1/sZladQiA-DBIDCcaWtQzL4BZHoiDkH5gzNBPNspmGXawpg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ibarrarealnova/v1/sZlYdQiA-DBIDCcaWtQzL4BZHoiDmMB9NNRFMuhjCXY.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/ibarrarealnova/v1/sZladQiA-DBIDCcaWtQzL4BZHoiDkH5gqNFPNspmGXawpg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29331,7 +30592,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/iceberg/v7/8QIJdijAiM7o-qnZuIgOq7jkAOw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/iceberg/v7/8QIJdijAiM7o-qnZuIgOq7jkAOw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29400,7 +30662,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/iceland/v8/rax9HiuFsdMNOnWPWKxGADBbg0s.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/iceland/v8/rax9HiuFsdMNOnWPWKxGADBbg0s.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29469,7 +30732,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/imprima/v8/VEMxRoN7sY3yuy-7-oWHyDzktPo.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/imprima/v8/VEMxRoN7sY3yuy-7-oWHyDzktPo.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29538,8 +30802,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/inconsolata/v18/QldKNThLqRwH-OJ1UHjlKFle7KlmxuHx.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/inconsolata/v18/QldXNThLqRwH-OJ1UHjlKGHiw41u7f34DYwn.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/inconsolata/v18/QldKNThLqRwH-OJ1UHjlKFle7KlmxuHx.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/inconsolata/v18/QldXNThLqRwH-OJ1UHjlKGHiw41u7f34DYwn.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29608,7 +30874,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/inder/v8/w8gUH2YoQe8_4vq6pw-P3U4O.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/inder/v8/w8gUH2YoQe8_4vq6pw-P3U4O.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29677,7 +30944,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/indieflower/v11/m8JVjfNVeKWVnh3QMuKkFcZlbkGG1dKEDw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/indieflower/v11/m8JVjfNVeKWVnh3QMuKkFcZlbkGG1dKEDw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29746,8 +31014,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/inika/v8/rnCm-x5X3QP-phTHRcc2s2XH.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/inika/v8/rnCr-x5X3QP-pix7auM-mHnOSOuk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/inika/v8/rnCm-x5X3QP-phTHRcc2s2XH.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/inika/v8/rnCr-x5X3QP-pix7auM-mHnOSOuk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29816,13 +31086,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GRYax7VC4ot_qNB4nYpBdaKU2vwrj5bBoIYJNf.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GSYax7VC4ot_qNB4nYpBdaKXUD6pzxRwYB.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GRYax7VC4ot_qNB4nYpBdaKU33w7j5bBoIYJNf.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GRYax7VC4ot_qNB4nYpBdaKU3bxLj5bBoIYJNf.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GRYax7VC4ot_qNB4nYpBdaKU2_xbj5bBoIYJNf.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GRYax7VC4ot_qNB4nYpBdaKU2jxrj5bBoIYJNf.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GRYax7VC4ot_qNB4nYpBdaKU2Hx7j5bBoIYJNf.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GRYax7VC4ot_qNB4nYpBdaKU2vwrj5bBoIYJNf.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GSYax7VC4ot_qNB4nYpBdaKXUD6pzxRwYB.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GRYax7VC4ot_qNB4nYpBdaKU33w7j5bBoIYJNf.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GRYax7VC4ot_qNB4nYpBdaKU3bxLj5bBoIYJNf.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GRYax7VC4ot_qNB4nYpBdaKU2_xbj5bBoIYJNf.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GRYax7VC4ot_qNB4nYpBdaKU2jxrj5bBoIYJNf.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/inknutantiqua/v5/Y4GRYax7VC4ot_qNB4nYpBdaKU2Hx7j5bBoIYJNf.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29891,12 +31168,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/inriaserif/v1/fC14PYxPY3rXxEndZJAzN3wAVQjFhFyta3xN.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/inriaserif/v1/fC16PYxPY3rXxEndZJAzN3SuT4THjliPbmxN0_E.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/inriaserif/v1/fC1lPYxPY3rXxEndZJAzN0SsfSzNr0Ck.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/inriaserif/v1/fC1nPYxPY3rXxEndZJAzN3SudyjvqlCkcmU.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/inriaserif/v1/fC14PYxPY3rXxEndZJAzN3wQUgjFhFyta3xN.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/inriaserif/v1/fC16PYxPY3rXxEndZJAzN3SuT5TAjliPbmxN0_E.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/inriaserif/v1/fC14PYxPY3rXxEndZJAzN3wAVQjFhFyta3xN.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/inriaserif/v1/fC16PYxPY3rXxEndZJAzN3SuT4THjliPbmxN0_E.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/inriaserif/v1/fC1lPYxPY3rXxEndZJAzN0SsfSzNr0Ck.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/inriaserif/v1/fC1nPYxPY3rXxEndZJAzN3SudyjvqlCkcmU.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/inriaserif/v1/fC14PYxPY3rXxEndZJAzN3wQUgjFhFyta3xN.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/inriaserif/v1/fC16PYxPY3rXxEndZJAzN3SuT5TAjliPbmxN0_E.ttf',
     };
 
     return googleFontsTextStyle(
@@ -29965,7 +31248,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/irishgrover/v10/buExpoi6YtLz2QW7LA4flVgf-P5Oaiw4cw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/irishgrover/v10/buExpoi6YtLz2QW7LA4flVgf-P5Oaiw4cw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30034,10 +31318,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/istokweb/v14/3qTvojGmgSyUukBzKslZAWF-9kIIaQ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/istokweb/v14/3qTpojGmgSyUukBzKslpA2t61EcYaQ7F.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/istokweb/v14/3qTqojGmgSyUukBzKslhvU5a_mkUYBfcMw.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/istokweb/v14/3qT0ojGmgSyUukBzKslpA1PG-2MQQhLMMygN.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/istokweb/v14/3qTvojGmgSyUukBzKslZAWF-9kIIaQ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/istokweb/v14/3qTpojGmgSyUukBzKslpA2t61EcYaQ7F.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/istokweb/v14/3qTqojGmgSyUukBzKslhvU5a_mkUYBfcMw.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/istokweb/v14/3qT0ojGmgSyUukBzKslpA1PG-2MQQhLMMygN.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30106,7 +31394,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/italiana/v8/QldNNTtLsx4E__B0XTmRY31Wx7Vv.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/italiana/v8/QldNNTtLsx4E__B0XTmRY31Wx7Vv.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30175,7 +31464,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/italianno/v9/dg4n_p3sv6gCJkwzT6Rnj5YpQwM-gg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/italianno/v9/dg4n_p3sv6gCJkwzT6Rnj5YpQwM-gg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30244,7 +31534,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/itim/v4/0nknC9ziJOYewARKkc7ZdwU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/itim/v4/0nknC9ziJOYewARKkc7ZdwU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30313,7 +31604,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/jacquesfrancois/v7/ZXu9e04ZvKeOOHIe1TMahbcIU2cgmcPqoeRWfbs.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/jacquesfrancois/v7/ZXu9e04ZvKeOOHIe1TMahbcIU2cgmcPqoeRWfbs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30382,7 +31674,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/jacquesfrancoisshadow/v8/KR1FBtOz8PKTMk-kqdkLVrvR0ECFrB6Pin-2_q8VsHuV5ULS.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/jacquesfrancoisshadow/v8/KR1FBtOz8PKTMk-kqdkLVrvR0ECFrB6Pin-2_q8VsHuV5ULS.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30413,19 +31706,26 @@ class GoogleFonts {
   static TextTheme jacquesFrancoisShadowTextTheme([TextTheme textTheme]) {
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(
-      display4: GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.display4),
-      display3: GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.display3),
-      display2: GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.display2),
-      display1: GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.display1),
-      headline: GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.headline),
+      display4:
+          GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.display4),
+      display3:
+          GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.display3),
+      display2:
+          GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.display2),
+      display1:
+          GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.display1),
+      headline:
+          GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.headline),
       title: GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.title),
       subhead: GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.subhead),
       body2: GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.body2),
       body1: GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.body1),
       caption: GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.caption),
       button: GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.button),
-      subtitle: GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.subtitle),
-      overline: GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.overline),
+      subtitle:
+          GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.subtitle),
+      overline:
+          GoogleFonts.jacquesFrancoisShadow(textStyle: textTheme?.overline),
     );
   }
 
@@ -30451,8 +31751,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/jaldi/v6/or3sQ67z0_CI30NUZpD_B6g8.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/jaldi/v6/or3hQ67z0_CI33voSbT3LLQ1niPn.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/jaldi/v6/or3sQ67z0_CI30NUZpD_B6g8.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/jaldi/v6/or3hQ67z0_CI33voSbT3LLQ1niPn.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30521,7 +31823,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/jimnightshade/v7/PlIkFlu9Pb08Q8HLM1PxmB0g-OS4V3qKaMxD.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/jimnightshade/v7/PlIkFlu9Pb08Q8HLM1PxmB0g-OS4V3qKaMxD.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30590,7 +31893,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/jockeyone/v9/HTxpL2g2KjCFj4x8WI6ArIb7HYOk4xc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/jockeyone/v9/HTxpL2g2KjCFj4x8WI6ArIb7HYOk4xc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30659,7 +31963,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/jollylodger/v7/BXRsvFTAh_bGkA1uQ48dlB3VWerT3ZyuqA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/jollylodger/v7/BXRsvFTAh_bGkA1uQ48dlB3VWerT3ZyuqA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30728,7 +32033,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/jomhuria/v7/Dxxp8j-TMXf-llKur2b1MOGbC3Dh.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/jomhuria/v7/Dxxp8j-TMXf-llKur2b1MOGbC3Dh.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30797,7 +32103,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/jomolhari/v1/EvONzA1M1Iw_CBd2hsQCF1IZKq5INg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/jomolhari/v1/EvONzA1M1Iw_CBd2hsQCF1IZKq5INg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30866,16 +32173,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/josefinsans/v14/Qw3EZQNVED7rKGKxtqIqX5Ecbnx9Vnksi4M7.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/josefinsans/v14/Qw3GZQNVED7rKGKxtqIqX5EUCEQZXH0OjpM75PE.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/josefinsans/v14/Qw3FZQNVED7rKGKxtqIqX5Ecpl5dfFcggpoi_Q.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/josefinsans/v14/Qw3HZQNVED7rKGKxtqIqX5EUCETRfl0koJ8y_eiS.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/josefinsans/v14/Qw3aZQNVED7rKGKxtqIqX5EkCnZ5dHw8iw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/josefinsans/v14/Qw3EZQNVED7rKGKxtqIqX5EUCHx9Vnksi4M7.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/josefinsans/v14/Qw3FZQNVED7rKGKxtqIqX5Ec0lhdfFcggpoi_Q.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/josefinsans/v14/Qw3HZQNVED7rKGKxtqIqX5EUCESleF0koJ8y_eiS.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/josefinsans/v14/Qw3FZQNVED7rKGKxtqIqX5EctlldfFcggpoi_Q.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/josefinsans/v14/Qw3HZQNVED7rKGKxtqIqX5EUCETBeV0koJ8y_eiS.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/josefinsans/v14/Qw3EZQNVED7rKGKxtqIqX5Ecbnx9Vnksi4M7.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/josefinsans/v14/Qw3GZQNVED7rKGKxtqIqX5EUCEQZXH0OjpM75PE.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/josefinsans/v14/Qw3FZQNVED7rKGKxtqIqX5Ecpl5dfFcggpoi_Q.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/josefinsans/v14/Qw3HZQNVED7rKGKxtqIqX5EUCETRfl0koJ8y_eiS.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/josefinsans/v14/Qw3aZQNVED7rKGKxtqIqX5EkCnZ5dHw8iw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/josefinsans/v14/Qw3EZQNVED7rKGKxtqIqX5EUCHx9Vnksi4M7.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/josefinsans/v14/Qw3FZQNVED7rKGKxtqIqX5Ec0lhdfFcggpoi_Q.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/josefinsans/v14/Qw3HZQNVED7rKGKxtqIqX5EUCESleF0koJ8y_eiS.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/josefinsans/v14/Qw3FZQNVED7rKGKxtqIqX5EctlldfFcggpoi_Q.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/josefinsans/v14/Qw3HZQNVED7rKGKxtqIqX5EUCETBeV0koJ8y_eiS.ttf',
     };
 
     return googleFontsTextStyle(
@@ -30944,16 +32261,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/josefinslab/v10/lW-nwjwOK3Ps5GSJlNNkMalvyQ6qBM7oPxMX.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/josefinslab/v10/lW-lwjwOK3Ps5GSJlNNkMalnrzbODsrKOgMX95A.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/josefinslab/v10/lW-mwjwOK3Ps5GSJlNNkMalvASyKLuDkNgoO7g.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/josefinslab/v10/lW-kwjwOK3Ps5GSJlNNkMalnrzYGLOrgFA8e7onu.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/josefinslab/v10/lW-5wjwOK3Ps5GSJlNNkMalXrQSuJsv4Pw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/josefinslab/v10/lW-nwjwOK3Ps5GSJlNNkMalnrw6qBM7oPxMX.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/josefinslab/v10/lW-mwjwOK3Ps5GSJlNNkMalvdSqKLuDkNgoO7g.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/josefinslab/v10/lW-kwjwOK3Ps5GSJlNNkMalnrzZyKurgFA8e7onu.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/josefinslab/v10/lW-mwjwOK3Ps5GSJlNNkMalvESuKLuDkNgoO7g.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/josefinslab/v10/lW-kwjwOK3Ps5GSJlNNkMalnrzYWK-rgFA8e7onu.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/josefinslab/v10/lW-nwjwOK3Ps5GSJlNNkMalvyQ6qBM7oPxMX.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/josefinslab/v10/lW-lwjwOK3Ps5GSJlNNkMalnrzbODsrKOgMX95A.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/josefinslab/v10/lW-mwjwOK3Ps5GSJlNNkMalvASyKLuDkNgoO7g.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/josefinslab/v10/lW-kwjwOK3Ps5GSJlNNkMalnrzYGLOrgFA8e7onu.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/josefinslab/v10/lW-5wjwOK3Ps5GSJlNNkMalXrQSuJsv4Pw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/josefinslab/v10/lW-nwjwOK3Ps5GSJlNNkMalnrw6qBM7oPxMX.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/josefinslab/v10/lW-mwjwOK3Ps5GSJlNNkMalvdSqKLuDkNgoO7g.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/josefinslab/v10/lW-kwjwOK3Ps5GSJlNNkMalnrzZyKurgFA8e7onu.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/josefinslab/v10/lW-mwjwOK3Ps5GSJlNNkMalvESuKLuDkNgoO7g.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/josefinslab/v10/lW-kwjwOK3Ps5GSJlNNkMalnrzYWK-rgFA8e7onu.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31022,7 +32349,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/jotione/v8/Z9XVDmdJQAmWm9TwaYTe4u2El6GC.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/jotione/v8/Z9XVDmdJQAmWm9TwaYTe4u2El6GC.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31091,7 +32419,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/jua/v8/co3KmW9ljjAjc-DZCsKgsg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/jua/v8/co3KmW9ljjAjc-DZCsKgsg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31160,9 +32489,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/judson/v12/FeVRS0Fbvbc14VxRD7N01bV7kg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/judson/v12/FeVTS0Fbvbc14VxhDblw97BrknZf.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/judson/v12/FeVSS0Fbvbc14Vxps5xQ3Z5nm29Gww.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/judson/v12/FeVRS0Fbvbc14VxRD7N01bV7kg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/judson/v12/FeVTS0Fbvbc14VxhDblw97BrknZf.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/judson/v12/FeVSS0Fbvbc14Vxps5xQ3Z5nm29Gww.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31231,7 +32563,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/julee/v9/TuGfUVB3RpZPQ6ZLodgzydtk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/julee/v9/TuGfUVB3RpZPQ6ZLodgzydtk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31300,7 +32633,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/juliussansone/v8/1Pt2g8TAX_SGgBGUi0tGOYEga5W-xXEW6aGXHw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/juliussansone/v8/1Pt2g8TAX_SGgBGUi0tGOYEga5W-xXEW6aGXHw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31369,7 +32703,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/junge/v7/gokgH670Gl1lUqAdvhB7SnKm.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/junge/v7/gokgH670Gl1lUqAdvhB7SnKm.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31438,11 +32773,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/jura/v13/z7NOdRfiaC4Vd8hhoPzfb5vBTP0D7auhTfmrH_rt.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/jura/v13/z7NOdRfiaC4Vd8hhoPzfb5vBTP1d7auhTfmrH_rt.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/jura/v13/z7NOdRfiaC4Vd8hhoPzfb5vBTP1v7auhTfmrH_rt.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/jura/v13/z7NOdRfiaC4Vd8hhoPzfb5vBTP2D6quhTfmrH_rt.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/jura/v13/z7NOdRfiaC4Vd8hhoPzfb5vBTP266quhTfmrH_rt.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/jura/v13/z7NOdRfiaC4Vd8hhoPzfb5vBTP0D7auhTfmrH_rt.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/jura/v13/z7NOdRfiaC4Vd8hhoPzfb5vBTP1d7auhTfmrH_rt.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/jura/v13/z7NOdRfiaC4Vd8hhoPzfb5vBTP1v7auhTfmrH_rt.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/jura/v13/z7NOdRfiaC4Vd8hhoPzfb5vBTP2D6quhTfmrH_rt.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/jura/v13/z7NOdRfiaC4Vd8hhoPzfb5vBTP266quhTfmrH_rt.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31511,7 +32851,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/justanotherhand/v11/845CNN4-AJyIGvIou-6yJKyptyOpOcr_BmmlS5aw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/justanotherhand/v11/845CNN4-AJyIGvIou-6yJKyptyOpOcr_BmmlS5aw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31580,7 +32921,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/justmeagaindownhere/v11/MwQmbgXtz-Wc6RUEGNMc0QpRrfUh2hSdBBMoAuwHvqDwc_fg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/justmeagaindownhere/v11/MwQmbgXtz-Wc6RUEGNMc0QpRrfUh2hSdBBMoAuwHvqDwc_fg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31649,22 +32991,38 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/k2d/v3/J7aRnpF2V0ErE6UpvrIw74NL.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/k2d/v3/J7afnpF2V0EjdZ1NtLYS6pNLAjk.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/k2d/v3/J7aenpF2V0Erv4QJlJw85ppSGw.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/k2d/v3/J7acnpF2V0EjdZ3hlZY4xJ9CGyAa.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/k2d/v3/J7aenpF2V0Er24cJlJw85ppSGw.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/k2d/v3/J7acnpF2V0EjdZ2FlpY4xJ9CGyAa.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/k2d/v3/J7aTnpF2V0ETd68tnLcg7w.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/k2d/v3/J7aRnpF2V0EjdaUpvrIw74NL.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/k2d/v3/J7aenpF2V0Erg4YJlJw85ppSGw.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/k2d/v3/J7acnpF2V0EjdZ3dl5Y4xJ9CGyAa.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/k2d/v3/J7aenpF2V0Err4EJlJw85ppSGw.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/k2d/v3/J7acnpF2V0EjdZ3xkJY4xJ9CGyAa.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/k2d/v3/J7aenpF2V0Ery4AJlJw85ppSGw.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/k2d/v3/J7acnpF2V0EjdZ2VkZY4xJ9CGyAa.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/k2d/v3/J7aenpF2V0Er14MJlJw85ppSGw.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/k2d/v3/J7acnpF2V0EjdZ2JkpY4xJ9CGyAa.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7aRnpF2V0ErE6UpvrIw74NL.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7afnpF2V0EjdZ1NtLYS6pNLAjk.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7aenpF2V0Erv4QJlJw85ppSGw.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7acnpF2V0EjdZ3hlZY4xJ9CGyAa.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7aenpF2V0Er24cJlJw85ppSGw.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7acnpF2V0EjdZ2FlpY4xJ9CGyAa.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7aTnpF2V0ETd68tnLcg7w.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7aRnpF2V0EjdaUpvrIw74NL.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7aenpF2V0Erg4YJlJw85ppSGw.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7acnpF2V0EjdZ3dl5Y4xJ9CGyAa.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7aenpF2V0Err4EJlJw85ppSGw.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7acnpF2V0EjdZ3xkJY4xJ9CGyAa.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7aenpF2V0Ery4AJlJw85ppSGw.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7acnpF2V0EjdZ2VkZY4xJ9CGyAa.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7aenpF2V0Er14MJlJw85ppSGw.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/k2d/v3/J7acnpF2V0EjdZ2JkpY4xJ9CGyAa.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31733,8 +33091,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kadwa/v4/rnCm-x5V0g7iphTHRcc2s2XH.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/kadwa/v4/rnCr-x5V0g7ipix7auM-mHnOSOuk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kadwa/v4/rnCm-x5V0g7iphTHRcc2s2XH.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/kadwa/v4/rnCr-x5V0g7ipix7auM-mHnOSOuk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31803,9 +33163,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/kalam/v10/YA9Qr0Wd4kDdMtD6GgLLmCUItqGt.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kalam/v10/YA9dr0Wd4kDdMuhWMibDszkB.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/kalam/v10/YA9Qr0Wd4kDdMtDqHQLLmCUItqGt.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/kalam/v10/YA9Qr0Wd4kDdMtD6GgLLmCUItqGt.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kalam/v10/YA9dr0Wd4kDdMuhWMibDszkB.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/kalam/v10/YA9Qr0Wd4kDdMtDqHQLLmCUItqGt.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31874,8 +33237,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kameron/v10/vm82dR7vXErQxuznsL4wL-XIYH8.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/kameron/v10/vm8zdR7vXErQxuzniAIfC-3jfHb--NY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kameron/v10/vm82dR7vXErQxuznsL4wL-XIYH8.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/kameron/v10/vm8zdR7vXErQxuzniAIfC-3jfHb--NY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -31944,24 +33309,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/kanit/v5/nKKX-Go6G5tXcr72GwWKcaxALFs.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/kanit/v5/nKKV-Go6G5tXcraQI2GAdY5FPFtrGw.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr5aOiWgX6BJNUJy.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI82hVaRrMFJyAu4.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr4-OSWgX6BJNUJy.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI6miVaRrMFJyAu4.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kanit/v5/nKKZ-Go6G5tXcoaSEQGodLxA.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/kanit/v5/nKKX-Go6G5tXcraQGwWKcaxALFs.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr5mOCWgX6BJNUJy.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI_GjVaRrMFJyAu4.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr5KPyWgX6BJNUJy.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI92kVaRrMFJyAu4.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr4uPiWgX6BJNUJy.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI7mlVaRrMFJyAu4.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr4yPSWgX6BJNUJy.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI6WmVaRrMFJyAu4.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr4WPCWgX6BJNUJy.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI4GnVaRrMFJyAu4.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKX-Go6G5tXcr72GwWKcaxALFs.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKV-Go6G5tXcraQI2GAdY5FPFtrGw.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr5aOiWgX6BJNUJy.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI82hVaRrMFJyAu4.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr4-OSWgX6BJNUJy.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI6miVaRrMFJyAu4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKZ-Go6G5tXcoaSEQGodLxA.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKX-Go6G5tXcraQGwWKcaxALFs.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr5mOCWgX6BJNUJy.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI_GjVaRrMFJyAu4.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr5KPyWgX6BJNUJy.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI92kVaRrMFJyAu4.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr4uPiWgX6BJNUJy.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI7mlVaRrMFJyAu4.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr4yPSWgX6BJNUJy.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI6WmVaRrMFJyAu4.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKU-Go6G5tXcr4WPCWgX6BJNUJy.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/kanit/v5/nKKS-Go6G5tXcraQI4GnVaRrMFJyAu4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32030,9 +33413,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/kantumruy/v7/syk0-yJ0m7wyVb-f4FOPUtDlpn-UJ1H6Uw.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kantumruy/v7/sykx-yJ0m7wyVb-f4FO3_vjBrlSILg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/kantumruy/v7/syk0-yJ0m7wyVb-f4FOPQtflpn-UJ1H6Uw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/kantumruy/v7/syk0-yJ0m7wyVb-f4FOPUtDlpn-UJ1H6Uw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kantumruy/v7/sykx-yJ0m7wyVb-f4FO3_vjBrlSILg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/kantumruy/v7/syk0-yJ0m7wyVb-f4FOPQtflpn-UJ1H6Uw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32101,10 +33487,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/karla/v13/qkBbXvYC6trAT4RSJN225aZO.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/karla/v13/qkBVXvYC6trAT7RQLtmU4LZOgAU.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/karla/v13/qkBWXvYC6trAT7zuC_m-zrpHmRzC.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/karla/v13/qkBQXvYC6trAT7RQFmW7xL5lnAzCKNg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/karla/v13/qkBbXvYC6trAT4RSJN225aZO.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/karla/v13/qkBVXvYC6trAT7RQLtmU4LZOgAU.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/karla/v13/qkBWXvYC6trAT7zuC_m-zrpHmRzC.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/karla/v13/qkBQXvYC6trAT7RQFmW7xL5lnAzCKNg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32173,11 +33563,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/karma/v10/va9F4kzAzMZRGLjDY8Z_uqzGQC_-.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/karma/v10/va9I4kzAzMZRGIBvS-J3kbDP.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/karma/v10/va9F4kzAzMZRGLibYsZ_uqzGQC_-.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/karma/v10/va9F4kzAzMZRGLi3ZcZ_uqzGQC_-.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/karma/v10/va9F4kzAzMZRGLjTZMZ_uqzGQC_-.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/karma/v10/va9F4kzAzMZRGLjDY8Z_uqzGQC_-.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/karma/v10/va9I4kzAzMZRGIBvS-J3kbDP.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/karma/v10/va9F4kzAzMZRGLibYsZ_uqzGQC_-.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/karma/v10/va9F4kzAzMZRGLi3ZcZ_uqzGQC_-.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/karma/v10/va9F4kzAzMZRGLjTZMZ_uqzGQC_-.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32246,7 +33641,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/katibeh/v7/ZGjXol5MQJog4bxDaC1RVDNdGDs.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/katibeh/v7/ZGjXol5MQJog4bxDaC1RVDNdGDs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32315,7 +33711,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kaushanscript/v8/vm8vdRfvXFLG3OLnsO15WYS5DF7_ytN3M48a.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kaushanscript/v8/vm8vdRfvXFLG3OLnsO15WYS5DF7_ytN3M48a.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32384,7 +33781,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kavivanar/v5/o-0IIpQgyXYSwhxP7_Jb4j5Ba_2c7A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kavivanar/v5/o-0IIpQgyXYSwhxP7_Jb4j5Ba_2c7A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32453,7 +33851,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kavoon/v8/pxiFyp4_scRYhlU4NLr6f1pdEQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kavoon/v8/pxiFyp4_scRYhlU4NLr6f1pdEQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32522,7 +33921,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kdamthmor/v7/MwQzbhjs3veF6QwJVf0JkGMViblPtXs.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kdamthmor/v7/MwQzbhjs3veF6QwJVf0JkGMViblPtXs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32591,7 +33991,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/keaniaone/v7/zOL54pXJk65E8pXardnuycRuv-hHkOs.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/keaniaone/v7/zOL54pXJk65E8pXardnuycRuv-hHkOs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32660,7 +34061,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kellyslab/v10/-W_7XJX0Rz3cxUnJC5t6TkMBf50kbiM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kellyslab/v10/-W_7XJX0Rz3cxUnJC5t6TkMBf50kbiM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32729,7 +34131,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kenia/v11/jizURE5PuHQH9qCONUGswfGM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kenia/v11/jizURE5PuHQH9qCONUGswfGM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32798,11 +34201,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/khand/v8/TwMN-IINQlQQ0bL5cFE3ZwaH__-C.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/khand/v8/TwMA-IINQlQQ0YpVWHU_TBqO.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/khand/v8/TwMN-IINQlQQ0bKhcVE3ZwaH__-C.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/khand/v8/TwMN-IINQlQQ0bKNdlE3ZwaH__-C.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/khand/v8/TwMN-IINQlQQ0bLpd1E3ZwaH__-C.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/khand/v8/TwMN-IINQlQQ0bL5cFE3ZwaH__-C.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/khand/v8/TwMA-IINQlQQ0YpVWHU_TBqO.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/khand/v8/TwMN-IINQlQQ0bKhcVE3ZwaH__-C.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/khand/v8/TwMN-IINQlQQ0bKNdlE3ZwaH__-C.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/khand/v8/TwMN-IINQlQQ0bLpd1E3ZwaH__-C.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32871,7 +34279,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/khmer/v12/MjQImit_vPPwpF-BpN2EeYmD.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/khmer/v12/MjQImit_vPPwpF-BpN2EeYmD.ttf',
     };
 
     return googleFontsTextStyle(
@@ -32940,11 +34349,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/khula/v5/OpNPnoEOns3V7G-ljCvUrC59XwXD.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/khula/v5/OpNCnoEOns3V7FcJpA_chzJ0.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/khula/v5/OpNPnoEOns3V7G_RiivUrC59XwXD.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/khula/v5/OpNPnoEOns3V7G-1iyvUrC59XwXD.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/khula/v5/OpNPnoEOns3V7G-piCvUrC59XwXD.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/khula/v5/OpNPnoEOns3V7G-ljCvUrC59XwXD.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/khula/v5/OpNCnoEOns3V7FcJpA_chzJ0.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/khula/v5/OpNPnoEOns3V7G_RiivUrC59XwXD.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/khula/v5/OpNPnoEOns3V7G-1iyvUrC59XwXD.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/khula/v5/OpNPnoEOns3V7G-piCvUrC59XwXD.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33013,7 +34427,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kiranghaerang/v8/E21-_dn_gvvIjhYON1lpIU4-bcqvWPaJq4no.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kiranghaerang/v8/E21-_dn_gvvIjhYON1lpIU4-bcqvWPaJq4no.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33082,7 +34497,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kiteone/v7/70lQu7shLnA_E02vyq1b6HnGO4uA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kiteone/v7/70lQu7shLnA_E02vyq1b6HnGO4uA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33151,7 +34567,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/knewave/v8/sykz-yx0lLcxQaSItSq9-trEvlQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/knewave/v8/sykz-yx0lLcxQaSItSq9-trEvlQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33220,18 +34637,30 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/koho/v3/K2FxfZ5fmddNPuE1WJ75JoKhHys.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/koho/v3/K2FzfZ5fmddNNisssJ_zIqCkDyvqZA.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/koho/v3/K2FxfZ5fmddNPoU2WJ75JoKhHys.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/koho/v3/K2FzfZ5fmddNNiss1JzzIqCkDyvqZA.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/koho/v3/K2F-fZ5fmddNBikefJbSOos.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/koho/v3/K2FwfZ5fmddNNisUeLTXKou4Bg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/koho/v3/K2FxfZ5fmddNPt03WJ75JoKhHys.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/koho/v3/K2FzfZ5fmddNNissjJ3zIqCkDyvqZA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/koho/v3/K2FxfZ5fmddNPvEwWJ75JoKhHys.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/koho/v3/K2FzfZ5fmddNNissoJrzIqCkDyvqZA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/koho/v3/K2FxfZ5fmddNPpUxWJ75JoKhHys.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/koho/v3/K2FzfZ5fmddNNissxJvzIqCkDyvqZA.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/koho/v3/K2FxfZ5fmddNPuE1WJ75JoKhHys.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/koho/v3/K2FzfZ5fmddNNisssJ_zIqCkDyvqZA.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/koho/v3/K2FxfZ5fmddNPoU2WJ75JoKhHys.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/koho/v3/K2FzfZ5fmddNNiss1JzzIqCkDyvqZA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/koho/v3/K2F-fZ5fmddNBikefJbSOos.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/koho/v3/K2FwfZ5fmddNNisUeLTXKou4Bg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/koho/v3/K2FxfZ5fmddNPt03WJ75JoKhHys.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/koho/v3/K2FzfZ5fmddNNissjJ3zIqCkDyvqZA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/koho/v3/K2FxfZ5fmddNPvEwWJ75JoKhHys.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/koho/v3/K2FzfZ5fmddNNissoJrzIqCkDyvqZA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/koho/v3/K2FxfZ5fmddNPpUxWJ75JoKhHys.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/koho/v3/K2FzfZ5fmddNNissxJvzIqCkDyvqZA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33300,18 +34729,30 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/kodchasan/v3/1cX0aUPOAJv9sG4I-DJeR1Cggeqo3eMeoA.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/kodchasan/v3/1cXqaUPOAJv9sG4I-DJWjUlIgOCs_-YOoIgN.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/kodchasan/v3/1cX0aUPOAJv9sG4I-DJeI1Oggeqo3eMeoA.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/kodchasan/v3/1cXqaUPOAJv9sG4I-DJWjUksg-Cs_-YOoIgN.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kodchasan/v3/1cXxaUPOAJv9sG4I-DJmj3uEicG01A.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/kodchasan/v3/1cX3aUPOAJv9sG4I-DJWjXGAq8Sk1PoH.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/kodchasan/v3/1cX0aUPOAJv9sG4I-DJee1Kggeqo3eMeoA.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/kodchasan/v3/1cXqaUPOAJv9sG4I-DJWjUl0guCs_-YOoIgN.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/kodchasan/v3/1cX0aUPOAJv9sG4I-DJeV1Wggeqo3eMeoA.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/kodchasan/v3/1cXqaUPOAJv9sG4I-DJWjUlYheCs_-YOoIgN.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/kodchasan/v3/1cX0aUPOAJv9sG4I-DJeM1Sggeqo3eMeoA.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/kodchasan/v3/1cXqaUPOAJv9sG4I-DJWjUk8hOCs_-YOoIgN.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/kodchasan/v3/1cX0aUPOAJv9sG4I-DJeR1Cggeqo3eMeoA.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/kodchasan/v3/1cXqaUPOAJv9sG4I-DJWjUlIgOCs_-YOoIgN.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/kodchasan/v3/1cX0aUPOAJv9sG4I-DJeI1Oggeqo3eMeoA.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/kodchasan/v3/1cXqaUPOAJv9sG4I-DJWjUksg-Cs_-YOoIgN.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kodchasan/v3/1cXxaUPOAJv9sG4I-DJmj3uEicG01A.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/kodchasan/v3/1cX3aUPOAJv9sG4I-DJWjXGAq8Sk1PoH.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/kodchasan/v3/1cX0aUPOAJv9sG4I-DJee1Kggeqo3eMeoA.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/kodchasan/v3/1cXqaUPOAJv9sG4I-DJWjUl0guCs_-YOoIgN.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/kodchasan/v3/1cX0aUPOAJv9sG4I-DJeV1Wggeqo3eMeoA.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/kodchasan/v3/1cXqaUPOAJv9sG4I-DJWjUlYheCs_-YOoIgN.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/kodchasan/v3/1cX0aUPOAJv9sG4I-DJeM1Sggeqo3eMeoA.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/kodchasan/v3/1cXqaUPOAJv9sG4I-DJWjUk8hOCs_-YOoIgN.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33380,7 +34821,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kosugi/v6/pxiFyp4_v8FCjlI4NLr6f1pdEQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kosugi/v6/pxiFyp4_v8FCjlI4NLr6f1pdEQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33449,7 +34891,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kosugimaru/v6/0nksC9PgP_wGh21A2KeqGiTqivr9iBq_.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kosugimaru/v6/0nksC9PgP_wGh21A2KeqGiTqivr9iBq_.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33518,7 +34961,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kottaone/v7/S6u_w41LXzPc_jlfNWqPHA3s5dwt7w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kottaone/v7/S6u_w41LXzPc_jlfNWqPHA3s5dwt7w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33587,7 +35031,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/koulen/v13/AMOQz46as3KIBPeWgnA9kuYMUg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/koulen/v13/AMOQz46as3KIBPeWgnA9kuYMUg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33656,7 +35101,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kranky/v10/hESw6XVgJzlPsFnMpheEZo_H_w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kranky/v10/hESw6XVgJzlPsFnMpheEZo_H_w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33725,11 +35171,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/kreon/v21/t5t9IRIUKY-TFF_LW5lnMR3v2DnvPNimejUfp2dWNg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kreon/v21/t5t9IRIUKY-TFF_LW5lnMR3v2DnvYtimejUfp2dWNg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/kreon/v21/t5t9IRIUKY-TFF_LW5lnMR3v2DnvUNimejUfp2dWNg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/kreon/v21/t5t9IRIUKY-TFF_LW5lnMR3v2DnvvN-mejUfp2dWNg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/kreon/v21/t5t9IRIUKY-TFF_LW5lnMR3v2Dnvhd-mejUfp2dWNg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/kreon/v21/t5t9IRIUKY-TFF_LW5lnMR3v2DnvPNimejUfp2dWNg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kreon/v21/t5t9IRIUKY-TFF_LW5lnMR3v2DnvYtimejUfp2dWNg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/kreon/v21/t5t9IRIUKY-TFF_LW5lnMR3v2DnvUNimejUfp2dWNg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/kreon/v21/t5t9IRIUKY-TFF_LW5lnMR3v2DnvvN-mejUfp2dWNg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/kreon/v21/t5t9IRIUKY-TFF_LW5lnMR3v2Dnvhd-mejUfp2dWNg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33798,7 +35249,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kristi/v11/uK_y4ricdeU6zwdRCh0TMv6EXw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kristi/v11/uK_y4ricdeU6zwdRCh0TMv6EXw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33867,7 +35319,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kronaone/v8/jAnEgHdjHcjgfIb1ZcUCMY-h3cWkWg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kronaone/v8/jAnEgHdjHcjgfIb1ZcUCMY-h3cWkWg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -33936,18 +35389,30 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/krub/v3/sZlEdRyC6CRYZo47KLF4R6gWaf8.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/krub/v3/sZlGdRyC6CRYbkQiwLByQ4oTef_6gQ.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/krub/v3/sZlEdRyC6CRYZuo4KLF4R6gWaf8.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/krub/v3/sZlGdRyC6CRYbkQipLNyQ4oTef_6gQ.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/krub/v3/sZlLdRyC6CRYXkYQDLlTW6E.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/krub/v3/sZlFdRyC6CRYbkQaCJtWS6EPcA.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/krub/v3/sZlEdRyC6CRYZrI5KLF4R6gWaf8.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/krub/v3/sZlGdRyC6CRYbkQi_LJyQ4oTef_6gQ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/krub/v3/sZlEdRyC6CRYZp4-KLF4R6gWaf8.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/krub/v3/sZlGdRyC6CRYbkQi0LVyQ4oTef_6gQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/krub/v3/sZlEdRyC6CRYZvo_KLF4R6gWaf8.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/krub/v3/sZlGdRyC6CRYbkQitLRyQ4oTef_6gQ.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/krub/v3/sZlEdRyC6CRYZo47KLF4R6gWaf8.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/krub/v3/sZlGdRyC6CRYbkQiwLByQ4oTef_6gQ.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/krub/v3/sZlEdRyC6CRYZuo4KLF4R6gWaf8.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/krub/v3/sZlGdRyC6CRYbkQipLNyQ4oTef_6gQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/krub/v3/sZlLdRyC6CRYXkYQDLlTW6E.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/krub/v3/sZlFdRyC6CRYbkQaCJtWS6EPcA.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/krub/v3/sZlEdRyC6CRYZrI5KLF4R6gWaf8.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/krub/v3/sZlGdRyC6CRYbkQi_LJyQ4oTef_6gQ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/krub/v3/sZlEdRyC6CRYZp4-KLF4R6gWaf8.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/krub/v3/sZlGdRyC6CRYbkQi0LVyQ4oTef_6gQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/krub/v3/sZlEdRyC6CRYZvo_KLF4R6gWaf8.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/krub/v3/sZlGdRyC6CRYbkQitLRyQ4oTef_6gQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34016,16 +35481,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/kulimpark/v1/fdN49secq3hflz1Uu3IwjJYNwa5aZbUvGjU.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/kulimpark/v1/fdNm9secq3hflz1Uu3IwhFwUKa9QYZcqCjVVUA.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/kulimpark/v1/fdN49secq3hflz1Uu3IwjPIOwa5aZbUvGjU.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/kulimpark/v1/fdNm9secq3hflz1Uu3IwhFwUTaxQYZcqCjVVUA.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kulimpark/v1/fdN79secq3hflz1Uu3IwtF4m5aZxebw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/kulimpark/v1/fdN59secq3hflz1Uu3IwhFws4YR0abw2Aw.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/kulimpark/v1/fdN49secq3hflz1Uu3IwjIYIwa5aZbUvGjU.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/kulimpark/v1/fdNm9secq3hflz1Uu3IwhFwUOapQYZcqCjVVUA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/kulimpark/v1/fdN49secq3hflz1Uu3IwjOIJwa5aZbUvGjU.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/kulimpark/v1/fdNm9secq3hflz1Uu3IwhFwUXatQYZcqCjVVUA.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/kulimpark/v1/fdN49secq3hflz1Uu3IwjJYNwa5aZbUvGjU.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/kulimpark/v1/fdNm9secq3hflz1Uu3IwhFwUKa9QYZcqCjVVUA.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/kulimpark/v1/fdN49secq3hflz1Uu3IwjPIOwa5aZbUvGjU.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/kulimpark/v1/fdNm9secq3hflz1Uu3IwhFwUTaxQYZcqCjVVUA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kulimpark/v1/fdN79secq3hflz1Uu3IwtF4m5aZxebw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/kulimpark/v1/fdN59secq3hflz1Uu3IwhFws4YR0abw2Aw.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/kulimpark/v1/fdN49secq3hflz1Uu3IwjIYIwa5aZbUvGjU.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/kulimpark/v1/fdNm9secq3hflz1Uu3IwhFwUOapQYZcqCjVVUA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/kulimpark/v1/fdN49secq3hflz1Uu3IwjOIJwa5aZbUvGjU.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/kulimpark/v1/fdNm9secq3hflz1Uu3IwhFwUXatQYZcqCjVVUA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34094,7 +35569,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kumarone/v4/bMr1mS-P958wYi6YaGeGNO6WU3oT0g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kumarone/v4/bMr1mS-P958wYi6YaGeGNO6WU3oT0g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34163,7 +35639,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kumaroneoutline/v5/Noao6VH62pyLP0fsrZ-v18wlUEcX9zDwRQu8EGKF.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kumaroneoutline/v5/Noao6VH62pyLP0fsrZ-v18wlUEcX9zDwRQu8EGKF.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34232,7 +35709,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/kurale/v5/4iCs6KV9e9dXjho6eAT3v02QFg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/kurale/v5/4iCs6KV9e9dXjho6eAT3v02QFg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34301,7 +35779,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/labelleaurore/v10/RrQIbot8-mNYKnGNDkWlocovHeIIG-eFNVmULg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/labelleaurore/v10/RrQIbot8-mNYKnGNDkWlocovHeIIG-eFNVmULg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34370,7 +35849,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lacquer/v1/EYqzma1QwqpG4_BBB7-AXhttQ5I.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lacquer/v1/EYqzma1QwqpG4_BBB7-AXhttQ5I.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34439,11 +35919,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/laila/v6/LYjBdG_8nE8jDLzxogNAh14nVcfe.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/laila/v6/LYjMdG_8nE8jDIRdiidIrEIu.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/laila/v6/LYjBdG_8nE8jDLypowNAh14nVcfe.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/laila/v6/LYjBdG_8nE8jDLyFpANAh14nVcfe.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/laila/v6/LYjBdG_8nE8jDLzhpQNAh14nVcfe.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/laila/v6/LYjBdG_8nE8jDLzxogNAh14nVcfe.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/laila/v6/LYjMdG_8nE8jDIRdiidIrEIu.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/laila/v6/LYjBdG_8nE8jDLypowNAh14nVcfe.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/laila/v6/LYjBdG_8nE8jDLyFpANAh14nVcfe.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/laila/v6/LYjBdG_8nE8jDLzhpQNAh14nVcfe.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34512,7 +35997,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lakkireddy/v6/S6u5w49MUSzD9jlCPmvLZQfox9k97-xZ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lakkireddy/v6/S6u5w49MUSzD9jlCPmvLZQfox9k97-xZ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34581,7 +36067,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lalezar/v6/zrfl0HLVx-HwTP82UaDyIiL0RCg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lalezar/v6/zrfl0HLVx-HwTP82UaDyIiL0RCg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34650,7 +36137,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lancelot/v9/J7acnppxBGtQEulG4JY4xJ9CGyAa.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lancelot/v9/J7acnppxBGtQEulG4JY4xJ9CGyAa.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34719,7 +36207,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lateef/v15/hESw6XVnNCxEvkbMpheEZo_H_w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lateef/v15/hESw6XVnNCxEvkbMpheEZo_H_w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34788,16 +36277,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/lato/v16/S6u8w4BMUTPHh30wWyWrFCbw7A.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/lato/v16/S6u-w4BMUTPHjxsIPy-vNiPg7MU0.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/lato/v16/S6u9w4BMUTPHh7USew-FGC_p9dw.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/lato/v16/S6u_w4BMUTPHjxsI9w2PHA3s5dwt7w.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lato/v16/S6uyw4BMUTPHvxk6XweuBCY.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/lato/v16/S6u8w4BMUTPHjxswWyWrFCbw7A.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/lato/v16/S6u9w4BMUTPHh6UVew-FGC_p9dw.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/lato/v16/S6u_w4BMUTPHjxsI5wqPHA3s5dwt7w.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/lato/v16/S6u9w4BMUTPHh50Xew-FGC_p9dw.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/lato/v16/S6u_w4BMUTPHjxsI3wiPHA3s5dwt7w.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/lato/v16/S6u8w4BMUTPHh30wWyWrFCbw7A.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/lato/v16/S6u-w4BMUTPHjxsIPy-vNiPg7MU0.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/lato/v16/S6u9w4BMUTPHh7USew-FGC_p9dw.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/lato/v16/S6u_w4BMUTPHjxsI9w2PHA3s5dwt7w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lato/v16/S6uyw4BMUTPHvxk6XweuBCY.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/lato/v16/S6u8w4BMUTPHjxswWyWrFCbw7A.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/lato/v16/S6u9w4BMUTPHh6UVew-FGC_p9dw.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/lato/v16/S6u_w4BMUTPHjxsI5wqPHA3s5dwt7w.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/lato/v16/S6u9w4BMUTPHh50Xew-FGC_p9dw.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/lato/v16/S6u_w4BMUTPHjxsI3wiPHA3s5dwt7w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34866,7 +36365,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/leaguescript/v11/CSR54zpSlumSWj9CGVsoBZdeaNNUuOwkC2s.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/leaguescript/v11/CSR54zpSlumSWj9CGVsoBZdeaNNUuOwkC2s.ttf',
     };
 
     return googleFontsTextStyle(
@@ -34935,7 +36435,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/leckerlione/v10/V8mCoQH8VCsNttEnxnGQ-1itLZxcBtItFw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/leckerlione/v10/V8mCoQH8VCsNttEnxnGQ-1itLZxcBtItFw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35004,7 +36505,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ledger/v7/j8_q6-HK1L3if_sxm8DwHTBhHw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ledger/v7/j8_q6-HK1L3if_sxm8DwHTBhHw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35073,9 +36575,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lekton/v10/SZc43FDmLaWmWpBeXxfonUPL6Q.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/lekton/v10/SZc63FDmLaWmWpBuXR3sv0bb6StO.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/lekton/v10/SZc73FDmLaWmWpBm4zjMlWjX4DJXgQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lekton/v10/SZc43FDmLaWmWpBeXxfonUPL6Q.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/lekton/v10/SZc63FDmLaWmWpBuXR3sv0bb6StO.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/lekton/v10/SZc73FDmLaWmWpBm4zjMlWjX4DJXgQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35144,7 +36649,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lemon/v8/HI_EiYEVKqRMq0jBSZXAQ4-d.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lemon/v8/HI_EiYEVKqRMq0jBSZXAQ4-d.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35213,11 +36719,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/lemonada/v8/0QI-MXFD9oygTWy_R-FFlwV-bgfR7QJGJOt2mfWc3Z2pTg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lemonada/v8/0QI-MXFD9oygTWy_R-FFlwV-bgfR7QJGeut2mfWc3Z2pTg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/lemonada/v8/0QI-MXFD9oygTWy_R-FFlwV-bgfR7QJGSOt2mfWc3Z2pTg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/lemonada/v8/0QI-MXFD9oygTWy_R-FFlwV-bgfR7QJGpOx2mfWc3Z2pTg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/lemonada/v8/0QI-MXFD9oygTWy_R-FFlwV-bgfR7QJGnex2mfWc3Z2pTg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/lemonada/v8/0QI-MXFD9oygTWy_R-FFlwV-bgfR7QJGJOt2mfWc3Z2pTg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lemonada/v8/0QI-MXFD9oygTWy_R-FFlwV-bgfR7QJGeut2mfWc3Z2pTg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/lemonada/v8/0QI-MXFD9oygTWy_R-FFlwV-bgfR7QJGSOt2mfWc3Z2pTg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/lemonada/v8/0QI-MXFD9oygTWy_R-FFlwV-bgfR7QJGpOx2mfWc3Z2pTg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/lemonada/v8/0QI-MXFD9oygTWy_R-FFlwV-bgfR7QJGnex2mfWc3Z2pTg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35286,7 +36797,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lexenddeca/v1/K2F1fZFYk-dHSE0UPPuwQ6qgLS76ZHOM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lexenddeca/v1/K2F1fZFYk-dHSE0UPPuwQ6qgLS76ZHOM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35355,7 +36867,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lexendexa/v1/UMBXrPdOoHOnxExyjdBeWirXArM58BY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lexendexa/v1/UMBXrPdOoHOnxExyjdBeWirXArM58BY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35424,7 +36937,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lexendgiga/v1/PlI5Fl67Mah5Y8yMHE7lkVxEt8CwfGaD.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lexendgiga/v1/PlI5Fl67Mah5Y8yMHE7lkVxEt8CwfGaD.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35493,7 +37007,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lexendmega/v1/qFdA35aBi5JtHD41zSTFEv7K6BsAikI7.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lexendmega/v1/qFdA35aBi5JtHD41zSTFEv7K6BsAikI7.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35562,7 +37077,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lexendpeta/v1/BXRvvFPGjeLPh0kCfI4OkE_1c8Tf1IW3.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lexendpeta/v1/BXRvvFPGjeLPh0kCfI4OkE_1c8Tf1IW3.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35631,7 +37147,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lexendtera/v1/RrQUbo98_jt_IXnBPwCWtZhARYMgGtWA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lexendtera/v1/RrQUbo98_jt_IXnBPwCWtZhARYMgGtWA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35700,7 +37217,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lexendzetta/v1/ll87K2KYXje7CdOFnEWcU8soliQejRR7AQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lexendzetta/v1/ll87K2KYXje7CdOFnEWcU8soliQejRR7AQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35769,7 +37287,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/librebarcode128/v9/cIfnMbdUsUoiW3O_hVviCwVjuLtXeJ_A_gMk0izH.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/librebarcode128/v9/cIfnMbdUsUoiW3O_hVviCwVjuLtXeJ_A_gMk0izH.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35838,7 +37357,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/librebarcode128text/v9/fdNv9tubt3ZEnz1Gu3I4-zppwZ9CWZ16Z0w5cV3Y6M90w4k.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/librebarcode128text/v9/fdNv9tubt3ZEnz1Gu3I4-zppwZ9CWZ16Z0w5cV3Y6M90w4k.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35907,7 +37427,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/librebarcode39/v9/-nFnOHM08vwC6h8Li1eQnP_AHzI2K_d709jy92k.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/librebarcode39/v9/-nFnOHM08vwC6h8Li1eQnP_AHzI2K_d709jy92k.ttf',
     };
 
     return googleFontsTextStyle(
@@ -35976,7 +37497,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/librebarcode39extended/v8/8At7Gt6_O5yNS0-K4Nf5U922qSzhJ3dUdfJpwNUgfNRCOZ1GOBw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/librebarcode39extended/v8/8At7Gt6_O5yNS0-K4Nf5U922qSzhJ3dUdfJpwNUgfNRCOZ1GOBw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36007,19 +37529,28 @@ class GoogleFonts {
   static TextTheme libreBarcode39ExtendedTextTheme([TextTheme textTheme]) {
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(
-      display4: GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.display4),
-      display3: GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.display3),
-      display2: GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.display2),
-      display1: GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.display1),
-      headline: GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.headline),
+      display4:
+          GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.display4),
+      display3:
+          GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.display3),
+      display2:
+          GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.display2),
+      display1:
+          GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.display1),
+      headline:
+          GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.headline),
       title: GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.title),
-      subhead: GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.subhead),
+      subhead:
+          GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.subhead),
       body2: GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.body2),
       body1: GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.body1),
-      caption: GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.caption),
+      caption:
+          GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.caption),
       button: GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.button),
-      subtitle: GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.subtitle),
-      overline: GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.overline),
+      subtitle:
+          GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.subtitle),
+      overline:
+          GoogleFonts.libreBarcode39Extended(textStyle: textTheme?.overline),
     );
   }
 
@@ -36045,7 +37576,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/librebarcode39extendedtext/v8/eLG1P_rwIgOiDA7yrs9LoKaYRVLQ1YldrrOnnL7xPO4jNP68fLIiPopNNA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/librebarcode39extendedtext/v8/eLG1P_rwIgOiDA7yrs9LoKaYRVLQ1YldrrOnnL7xPO4jNP68fLIiPopNNA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36076,19 +37608,32 @@ class GoogleFonts {
   static TextTheme libreBarcode39ExtendedTextTextTheme([TextTheme textTheme]) {
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(
-      display4: GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.display4),
-      display3: GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.display3),
-      display2: GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.display2),
-      display1: GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.display1),
-      headline: GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.headline),
-      title: GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.title),
-      subhead: GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.subhead),
-      body2: GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.body2),
-      body1: GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.body1),
-      caption: GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.caption),
-      button: GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.button),
-      subtitle: GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.subtitle),
-      overline: GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.overline),
+      display4: GoogleFonts.libreBarcode39ExtendedText(
+          textStyle: textTheme?.display4),
+      display3: GoogleFonts.libreBarcode39ExtendedText(
+          textStyle: textTheme?.display3),
+      display2: GoogleFonts.libreBarcode39ExtendedText(
+          textStyle: textTheme?.display2),
+      display1: GoogleFonts.libreBarcode39ExtendedText(
+          textStyle: textTheme?.display1),
+      headline: GoogleFonts.libreBarcode39ExtendedText(
+          textStyle: textTheme?.headline),
+      title:
+          GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.title),
+      subhead:
+          GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.subhead),
+      body2:
+          GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.body2),
+      body1:
+          GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.body1),
+      caption:
+          GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.caption),
+      button:
+          GoogleFonts.libreBarcode39ExtendedText(textStyle: textTheme?.button),
+      subtitle: GoogleFonts.libreBarcode39ExtendedText(
+          textStyle: textTheme?.subtitle),
+      overline: GoogleFonts.libreBarcode39ExtendedText(
+          textStyle: textTheme?.overline),
     );
   }
 
@@ -36114,7 +37659,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/librebarcode39text/v9/sJoa3KhViNKANw_E3LwoDXvs5Un0HQ1vT-031RRL-9rYaw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/librebarcode39text/v9/sJoa3KhViNKANw_E3LwoDXvs5Un0HQ1vT-031RRL-9rYaw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36183,9 +37729,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/librebaskerville/v7/kmKnZrc3Hgbbcjq75U4uslyuy4kn0pNeYRI4CN2V.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/librebaskerville/v7/kmKhZrc3Hgbbcjq75U4uslyuy4kn0qNcaxYaDc2V2ro.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/librebaskerville/v7/kmKiZrc3Hgbbcjq75U4uslyuy4kn0qviTjYwI8Gcw6Oi.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/librebaskerville/v7/kmKnZrc3Hgbbcjq75U4uslyuy4kn0pNeYRI4CN2V.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/librebaskerville/v7/kmKhZrc3Hgbbcjq75U4uslyuy4kn0qNcaxYaDc2V2ro.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/librebaskerville/v7/kmKiZrc3Hgbbcjq75U4uslyuy4kn0qviTjYwI8Gcw6Oi.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36254,7 +37803,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/librecaslondisplay/v1/TuGOUUFxWphYQ6YI6q9Xp61FQzxDRKmzr2lRdRhtCC4d.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/librecaslondisplay/v1/TuGOUUFxWphYQ6YI6q9Xp61FQzxDRKmzr2lRdRhtCC4d.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36323,9 +37873,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/librecaslontext/v1/DdT878IGsGw1aF1JU10PUbTvNNaDMcq_3eNrHgO1.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/librecaslontext/v1/DdT678IGsGw1aF1JU10PUbTvNNaDMfq91-dJGxO1q9o.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/librecaslontext/v1/DdT578IGsGw1aF1JU10PUbTvNNaDMfID8sdjNR-8ssPt.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/librecaslontext/v1/DdT878IGsGw1aF1JU10PUbTvNNaDMcq_3eNrHgO1.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/librecaslontext/v1/DdT678IGsGw1aF1JU10PUbTvNNaDMfq91-dJGxO1q9o.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/librecaslontext/v1/DdT578IGsGw1aF1JU10PUbTvNNaDMfID8sdjNR-8ssPt.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36394,24 +37947,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizBREVItHgc8qDIbSTKq4XkRi182zIZj1bIkNo.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizHREVItHgc8qDIbSTKq4XkRiUa41YTi3TNgNq55w.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi3Q-hIzoVrBicOg.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa4_oyq17jjNOg_oc.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi20-RIzoVrBicOg.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa454xq17jjNOg_oc.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizDREVItHgc8qDIbSTKq4XkRhUY0TY7ikbI.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizBREVItHgc8qDIbSTKq4XkRiUa2zIZj1bIkNo.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi3s-BIzoVrBicOg.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa48Ywq17jjNOg_oc.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi3A_xIzoVrBicOg.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa4-o3q17jjNOg_oc.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi2k_hIzoVrBicOg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa4442q17jjNOg_oc.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi24_RIzoVrBicOg.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa45I1q17jjNOg_oc.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi2c_BIzoVrBicOg.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa47Y0q17jjNOg_oc.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizBREVItHgc8qDIbSTKq4XkRi182zIZj1bIkNo.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizHREVItHgc8qDIbSTKq4XkRiUa41YTi3TNgNq55w.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi3Q-hIzoVrBicOg.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa4_oyq17jjNOg_oc.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi20-RIzoVrBicOg.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa454xq17jjNOg_oc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizDREVItHgc8qDIbSTKq4XkRhUY0TY7ikbI.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizBREVItHgc8qDIbSTKq4XkRiUa2zIZj1bIkNo.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi3s-BIzoVrBicOg.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa48Ywq17jjNOg_oc.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi3A_xIzoVrBicOg.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa4-o3q17jjNOg_oc.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi2k_hIzoVrBicOg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa4442q17jjNOg_oc.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi24_RIzoVrBicOg.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa45I1q17jjNOg_oc.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizAREVItHgc8qDIbSTKq4XkRi2c_BIzoVrBicOg.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/librefranklin/v4/jizGREVItHgc8qDIbSTKq4XkRiUa47Y0q17jjNOg_oc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36480,9 +38051,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lifesavers/v10/ZXuie1UftKKabUQMgxAal_lrFgpbuNvB.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/lifesavers/v10/ZXu_e1UftKKabUQMgxAal8HXOS5Tk8fIpPRW.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/lifesavers/v10/ZXu_e1UftKKabUQMgxAal8HLOi5Tk8fIpPRW.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lifesavers/v10/ZXuie1UftKKabUQMgxAal_lrFgpbuNvB.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/lifesavers/v10/ZXu_e1UftKKabUQMgxAal8HXOS5Tk8fIpPRW.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/lifesavers/v10/ZXu_e1UftKKabUQMgxAal8HLOi5Tk8fIpPRW.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36551,7 +38125,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lilitaone/v7/i7dPIFZ9Zz-WBtRtedDbUEZ2RFq7AwU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lilitaone/v7/i7dPIFZ9Zz-WBtRtedDbUEZ2RFq7AwU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36620,7 +38195,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lilyscriptone/v7/LhW9MV7ZMfIPdMxeBjBvFN8SXLS4gsSjQNsRMg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lilyscriptone/v7/LhW9MV7ZMfIPdMxeBjBvFN8SXLS4gsSjQNsRMg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36689,7 +38265,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/limelight/v10/XLYkIZL7aopJVbZJHDuYPeNGrnY2TA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/limelight/v10/XLYkIZL7aopJVbZJHDuYPeNGrnY2TA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36758,8 +38335,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lindenhill/v9/-F61fjxoKSg9Yc3hZgO8ygFI7CwC009k.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/lindenhill/v9/-F63fjxoKSg9Yc3hZgO8yjFK5igg1l9kn-s.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lindenhill/v9/-F61fjxoKSg9Yc3hZgO8ygFI7CwC009k.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/lindenhill/v9/-F63fjxoKSg9Yc3hZgO8yjFK5igg1l9kn-s.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36828,14 +38407,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/literata/v14/or38Q6P12-iJxAIgLa78DkTtAoDhk0oVpaLVa5RXzC1KOw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/literata/v14/or38Q6P12-iJxAIgLa78DkTtAoDhk0oVl6LVa5RXzC1KOw.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/literata/v14/or38Q6P12-iJxAIgLa78DkTtAoDhk0oVe6XVa5RXzC1KOw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/literata/v14/or38Q6P12-iJxAIgLa78DkTtAoDhk0oVQqXVa5RXzC1KOw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/literata/v14/or3yQ6P12-iJxAIgLYT1PLs1a-t7PU0AbeE9KJ5T7ihaO_CS.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/literata/v14/or3yQ6P12-iJxAIgLYT1PLs1a-t7PU0AbeEPKJ5T7ihaO_CS.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/literata/v14/or3yQ6P12-iJxAIgLYT1PLs1a-t7PU0AbeHjL55T7ihaO_CS.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/literata/v14/or3yQ6P12-iJxAIgLYT1PLs1a-t7PU0AbeHaL55T7ihaO_CS.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/literata/v14/or38Q6P12-iJxAIgLa78DkTtAoDhk0oVpaLVa5RXzC1KOw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/literata/v14/or38Q6P12-iJxAIgLa78DkTtAoDhk0oVl6LVa5RXzC1KOw.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/literata/v14/or38Q6P12-iJxAIgLa78DkTtAoDhk0oVe6XVa5RXzC1KOw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/literata/v14/or38Q6P12-iJxAIgLa78DkTtAoDhk0oVQqXVa5RXzC1KOw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/literata/v14/or3yQ6P12-iJxAIgLYT1PLs1a-t7PU0AbeE9KJ5T7ihaO_CS.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/literata/v14/or3yQ6P12-iJxAIgLYT1PLs1a-t7PU0AbeEPKJ5T7ihaO_CS.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/literata/v14/or3yQ6P12-iJxAIgLYT1PLs1a-t7PU0AbeHjL55T7ihaO_CS.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/literata/v14/or3yQ6P12-iJxAIgLYT1PLs1a-t7PU0AbeHaL55T7ihaO_CS.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36904,7 +38491,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/liujianmaocao/v5/845DNN84HJrccNonurqXILGpvCOoferVKGWsUo8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/liujianmaocao/v5/845DNN84HJrccNonurqXILGpvCOoferVKGWsUo8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -36973,22 +38561,38 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/livvic/v3/rnCr-x1S2hzjrlffC-M-mHnOSOuk.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/livvic/v3/rnCt-x1S2hzjrlfXbdtakn3sTfukQHs.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/livvic/v3/rnCq-x1S2hzjrlffp8IeslfCQfK9WQ.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/livvic/v3/rnCs-x1S2hzjrlfXbdv2s13GY_etWWIJ.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/livvic/v3/rnCq-x1S2hzjrlffw8EeslfCQfK9WQ.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/livvic/v3/rnCs-x1S2hzjrlfXbduSsF3GY_etWWIJ.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/livvic/v3/rnCp-x1S2hzjrlfnb-k6unzeSA.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/livvic/v3/rnCr-x1S2hzjrlfXbeM-mHnOSOuk.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/livvic/v3/rnCq-x1S2hzjrlffm8AeslfCQfK9WQ.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/livvic/v3/rnCs-x1S2hzjrlfXbdvKsV3GY_etWWIJ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/livvic/v3/rnCq-x1S2hzjrlfft8ceslfCQfK9WQ.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/livvic/v3/rnCs-x1S2hzjrlfXbdvmtl3GY_etWWIJ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/livvic/v3/rnCq-x1S2hzjrlff08YeslfCQfK9WQ.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/livvic/v3/rnCs-x1S2hzjrlfXbduCt13GY_etWWIJ.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/livvic/v3/rnCq-x1S2hzjrlff68QeslfCQfK9WQ.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/livvic/v3/rnCs-x1S2hzjrlfXbdu6tV3GY_etWWIJ.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCr-x1S2hzjrlffC-M-mHnOSOuk.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCt-x1S2hzjrlfXbdtakn3sTfukQHs.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCq-x1S2hzjrlffp8IeslfCQfK9WQ.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCs-x1S2hzjrlfXbdv2s13GY_etWWIJ.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCq-x1S2hzjrlffw8EeslfCQfK9WQ.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCs-x1S2hzjrlfXbduSsF3GY_etWWIJ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCp-x1S2hzjrlfnb-k6unzeSA.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCr-x1S2hzjrlfXbeM-mHnOSOuk.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCq-x1S2hzjrlffm8AeslfCQfK9WQ.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCs-x1S2hzjrlfXbdvKsV3GY_etWWIJ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCq-x1S2hzjrlfft8ceslfCQfK9WQ.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCs-x1S2hzjrlfXbdvmtl3GY_etWWIJ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCq-x1S2hzjrlff08YeslfCQfK9WQ.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCs-x1S2hzjrlfXbduCt13GY_etWWIJ.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCq-x1S2hzjrlff68QeslfCQfK9WQ.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/livvic/v3/rnCs-x1S2hzjrlfXbdu6tV3GY_etWWIJ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37057,7 +38661,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lobster/v22/neILzCirqoswsqX9_oWsMqEzSJQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lobster/v22/neILzCirqoswsqX9_oWsMqEzSJQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37126,10 +38731,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lobstertwo/v12/BngMUXZGTXPUvIoyV6yN59fK7KSJ4ACD.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/lobstertwo/v12/BngOUXZGTXPUvIoyV6yN5-fI5qCr5RCDY_k.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/lobstertwo/v12/BngRUXZGTXPUvIoyV6yN5-92w4CByxyKeuDp.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/lobstertwo/v12/BngTUXZGTXPUvIoyV6yN5-fI3hyEwRiof_DpXMY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lobstertwo/v12/BngMUXZGTXPUvIoyV6yN59fK7KSJ4ACD.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/lobstertwo/v12/BngOUXZGTXPUvIoyV6yN5-fI5qCr5RCDY_k.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/lobstertwo/v12/BngRUXZGTXPUvIoyV6yN5-92w4CByxyKeuDp.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/lobstertwo/v12/BngTUXZGTXPUvIoyV6yN5-fI3hyEwRiof_DpXMY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37198,7 +38807,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/londrinaoutline/v10/C8c44dM8vmb14dfsZxhetg3pDH-SfuoxrSKMDvI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/londrinaoutline/v10/C8c44dM8vmb14dfsZxhetg3pDH-SfuoxrSKMDvI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37267,7 +38877,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/londrinashadow/v9/oPWX_kB4kOQoWNJmjxLV5JuoCUlXRlaSxkrMCQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/londrinashadow/v9/oPWX_kB4kOQoWNJmjxLV5JuoCUlXRlaSxkrMCQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37336,7 +38947,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/londrinasketch/v8/c4m41npxGMTnomOHtRU68eIJn8qfWWn5Pos6CA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/londrinasketch/v8/c4m41npxGMTnomOHtRU68eIJn8qfWWn5Pos6CA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37405,10 +39017,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/londrinasolid/v9/flUjRq6sw40kQEJxWNgkLuudGfs9KBYesZHhV64.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/londrinasolid/v9/flUiRq6sw40kQEJxWNgkLuudGfv1CjY0n53oTrcL.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/londrinasolid/v9/flUhRq6sw40kQEJxWNgkLuudGcNZIhI8tIHh.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/londrinasolid/v9/flUiRq6sw40kQEJxWNgkLuudGfvdDzY0n53oTrcL.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/londrinasolid/v9/flUjRq6sw40kQEJxWNgkLuudGfs9KBYesZHhV64.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/londrinasolid/v9/flUiRq6sw40kQEJxWNgkLuudGfv1CjY0n53oTrcL.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/londrinasolid/v9/flUhRq6sw40kQEJxWNgkLuudGcNZIhI8tIHh.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/londrinasolid/v9/flUiRq6sw40kQEJxWNgkLuudGfvdDzY0n53oTrcL.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37477,7 +39093,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/longcang/v5/LYjAdGP8kkgoTec8zkRgrXArXN7HWQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/longcang/v5/LYjAdGP8kkgoTec8zkRgrXArXN7HWQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37546,10 +39163,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lora/v14/0QIvMX1D_JOuAw3xItNPh_A.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/lora/v14/0QIhMX1D_JOuMw_7JvFKl_C28g.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/lora/v14/0QIgMX1D_JOuO7HeBttkm_mv670.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/lora/v14/0QIiMX1D_JOuMw_Dmt5un9uq-73O-Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lora/v14/0QIvMX1D_JOuAw3xItNPh_A.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/lora/v14/0QIhMX1D_JOuMw_7JvFKl_C28g.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/lora/v14/0QIgMX1D_JOuO7HeBttkm_mv670.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/lora/v14/0QIiMX1D_JOuMw_Dmt5un9uq-73O-Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37618,7 +39239,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/loveyalikeasister/v10/R70EjzUBlOqPeouhFDfR80-0FhOqJubN-Be78nZcsGGycA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/loveyalikeasister/v10/R70EjzUBlOqPeouhFDfR80-0FhOqJubN-Be78nZcsGGycA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37687,7 +39309,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lovedbytheking/v9/Gw6gwdP76VDVJNXerebZxUMeRXUF2PiNlXFu2R64.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lovedbytheking/v9/Gw6gwdP76VDVJNXerebZxUMeRXUF2PiNlXFu2R64.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37756,7 +39379,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/loversquarrel/v7/Yq6N-LSKXTL-5bCy8ksBzpQ_-zAsY7pO6siz.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/loversquarrel/v7/Yq6N-LSKXTL-5bCy8ksBzpQ_-zAsY7pO6siz.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37825,7 +39449,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/luckiestguy/v10/_gP_1RrxsjcxVyin9l9n_j2RStR3qDpraA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/luckiestguy/v10/_gP_1RrxsjcxVyin9l9n_j2RStR3qDpraA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37894,8 +39519,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lusitana/v7/CSR84z9ShvucWzsMKxhaRuMiSct_.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/lusitana/v7/CSR74z9ShvucWzsMKyDmaccqYtd2vfwk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lusitana/v7/CSR84z9ShvucWzsMKxhaRuMiSct_.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/lusitana/v7/CSR74z9ShvucWzsMKyDmaccqYtd2vfwk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -37964,7 +39591,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/lustria/v7/9oRONYodvDEyjuhOrCg5MtPyAcg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/lustria/v7/9oRONYodvDEyjuhOrCg5MtPyAcg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38033,13 +39661,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/mplus1p/v19/e3tleuShHdiFyPFzBRrQnDQAUW3aq-5N.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/mplus1p/v19/e3tmeuShHdiFyPFzBRrQVBYge0PWovdU4w.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mplus1p/v19/e3tjeuShHdiFyPFzBRro-D4Ec2jKqw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/mplus1p/v19/e3tmeuShHdiFyPFzBRrQDBcge0PWovdU4w.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/mplus1p/v19/e3tmeuShHdiFyPFzBRrQRBEge0PWovdU4w.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/mplus1p/v19/e3tmeuShHdiFyPFzBRrQWBIge0PWovdU4w.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/mplus1p/v19/e3tmeuShHdiFyPFzBRrQfBMge0PWovdU4w.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/mplus1p/v19/e3tleuShHdiFyPFzBRrQnDQAUW3aq-5N.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/mplus1p/v19/e3tmeuShHdiFyPFzBRrQVBYge0PWovdU4w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mplus1p/v19/e3tjeuShHdiFyPFzBRro-D4Ec2jKqw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/mplus1p/v19/e3tmeuShHdiFyPFzBRrQDBcge0PWovdU4w.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/mplus1p/v19/e3tmeuShHdiFyPFzBRrQRBEge0PWovdU4w.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/mplus1p/v19/e3tmeuShHdiFyPFzBRrQWBIge0PWovdU4w.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/mplus1p/v19/e3tmeuShHdiFyPFzBRrQfBMge0PWovdU4w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38108,13 +39743,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGCAYIAV6gnpUpoWwNkYvrugw9RuM3ixLsg6-av1x0.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGBAYIAV6gnpUpoWwNkYvrugw9RuM0q5psKxeqmzgRK.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGEAYIAV6gnpUpoWwNkYvrugw9RuPWGzr8C7vav.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGBAYIAV6gnpUpoWwNkYvrugw9RuM1y55sKxeqmzgRK.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGBAYIAV6gnpUpoWwNkYvrugw9RuM064ZsKxeqmzgRK.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGBAYIAV6gnpUpoWwNkYvrugw9RuM0m4psKxeqmzgRK.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGBAYIAV6gnpUpoWwNkYvrugw9RuM0C45sKxeqmzgRK.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGCAYIAV6gnpUpoWwNkYvrugw9RuM3ixLsg6-av1x0.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGBAYIAV6gnpUpoWwNkYvrugw9RuM0q5psKxeqmzgRK.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGEAYIAV6gnpUpoWwNkYvrugw9RuPWGzr8C7vav.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGBAYIAV6gnpUpoWwNkYvrugw9RuM1y55sKxeqmzgRK.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGBAYIAV6gnpUpoWwNkYvrugw9RuM064ZsKxeqmzgRK.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGBAYIAV6gnpUpoWwNkYvrugw9RuM0m4psKxeqmzgRK.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/mplusrounded1c/v10/VdGBAYIAV6gnpUpoWwNkYvrugw9RuM0C45sKxeqmzgRK.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38183,7 +39825,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mashanzheng/v5/NaPecZTRCLxvwo41b4gvzkXaRMTsDIRSfr0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mashanzheng/v5/NaPecZTRCLxvwo41b4gvzkXaRMTsDIRSfr0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38252,7 +39895,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/macondo/v8/RrQQboN9-iB1IXmOS2XO0LBBd4Y.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/macondo/v8/RrQQboN9-iB1IXmOS2XO0LBBd4Y.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38321,7 +39965,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/macondoswashcaps/v7/6NUL8EaAJgGKZA7lpt941Z9s6ZYgDq6Oekoa_mm5bA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/macondoswashcaps/v7/6NUL8EaAJgGKZA7lpt941Z9s6ZYgDq6Oekoa_mm5bA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38390,13 +40035,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/mada/v8/7Au_p_0qnzeSdf3nCCL8zkwMIFg.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/mada/v8/7Au_p_0qnzeSdZnkCCL8zkwMIFg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mada/v8/7Auwp_0qnzeSTTXMLCrX0kU.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/mada/v8/7Au_p_0qnzeSdcHlCCL8zkwMIFg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/mada/v8/7Au_p_0qnzeSde3iCCL8zkwMIFg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/mada/v8/7Au_p_0qnzeSdYnjCCL8zkwMIFg.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/mada/v8/7Au_p_0qnzeSdbHhCCL8zkwMIFg.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/mada/v8/7Au_p_0qnzeSdf3nCCL8zkwMIFg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/mada/v8/7Au_p_0qnzeSdZnkCCL8zkwMIFg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mada/v8/7Auwp_0qnzeSTTXMLCrX0kU.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/mada/v8/7Au_p_0qnzeSdcHlCCL8zkwMIFg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/mada/v8/7Au_p_0qnzeSde3iCCL8zkwMIFg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/mada/v8/7Au_p_0qnzeSdYnjCCL8zkwMIFg.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/mada/v8/7Au_p_0qnzeSdbHhCCL8zkwMIFg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38465,8 +40117,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/magra/v8/uK_94ruaZus72k5xIDMfO-ed.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/magra/v8/uK_w4ruaZus72nbNDxcXEPuUX1ow.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/magra/v8/uK_94ruaZus72k5xIDMfO-ed.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/magra/v8/uK_w4ruaZus72nbNDxcXEPuUX1ow.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38535,7 +40189,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/maidenorange/v10/kJE1BuIX7AUmhi2V4m08kb1XjOZdCZS8FY8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/maidenorange/v10/kJE1BuIX7AUmhi2V4m08kb1XjOZdCZS8FY8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38604,12 +40259,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/maitree/v4/MjQDmil5tffhpBrklhGNWJGovLdh6OE.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/maitree/v4/MjQDmil5tffhpBrklnWOWJGovLdh6OE.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/maitree/v4/MjQGmil5tffhpBrkrtmmfJmDoL4.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/maitree/v4/MjQDmil5tffhpBrkli2PWJGovLdh6OE.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/maitree/v4/MjQDmil5tffhpBrklgGIWJGovLdh6OE.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/maitree/v4/MjQDmil5tffhpBrklmWJWJGovLdh6OE.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/maitree/v4/MjQDmil5tffhpBrklhGNWJGovLdh6OE.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/maitree/v4/MjQDmil5tffhpBrklnWOWJGovLdh6OE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/maitree/v4/MjQGmil5tffhpBrkrtmmfJmDoL4.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/maitree/v4/MjQDmil5tffhpBrkli2PWJGovLdh6OE.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/maitree/v4/MjQDmil5tffhpBrklgGIWJGovLdh6OE.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/maitree/v4/MjQDmil5tffhpBrklmWJWJGovLdh6OE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38678,7 +40339,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/majormonodisplay/v4/RWmVoLyb5fEqtsfBX9PDZIGr2tFubRhLCn2QIndPww.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/majormonodisplay/v4/RWmVoLyb5fEqtsfBX9PDZIGr2tFubRhLCn2QIndPww.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38747,7 +40409,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mako/v11/H4coBX6Mmc_Z0ST09g478Lo.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mako/v11/H4coBX6Mmc_Z0ST09g478Lo.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38816,18 +40479,30 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/mali/v3/N0bV2SRONuN4QOLlKlRaJdbWgdY.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/mali/v3/N0bX2SRONuN4SCj8wlVQIfTTkdbJYA.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/mali/v3/N0bV2SRONuN4QIbmKlRaJdbWgdY.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/mali/v3/N0bX2SRONuN4SCj8plZQIfTTkdbJYA.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mali/v3/N0ba2SRONuN4eCrODlxxOd8.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/mali/v3/N0bU2SRONuN4SCjECn50Kd_PmA.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/mali/v3/N0bV2SRONuN4QN7nKlRaJdbWgdY.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/mali/v3/N0bX2SRONuN4SCj8_ldQIfTTkdbJYA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/mali/v3/N0bV2SRONuN4QPLgKlRaJdbWgdY.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/mali/v3/N0bX2SRONuN4SCj80lBQIfTTkdbJYA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/mali/v3/N0bV2SRONuN4QJbhKlRaJdbWgdY.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/mali/v3/N0bX2SRONuN4SCj8tlFQIfTTkdbJYA.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/mali/v3/N0bV2SRONuN4QOLlKlRaJdbWgdY.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/mali/v3/N0bX2SRONuN4SCj8wlVQIfTTkdbJYA.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/mali/v3/N0bV2SRONuN4QIbmKlRaJdbWgdY.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/mali/v3/N0bX2SRONuN4SCj8plZQIfTTkdbJYA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mali/v3/N0ba2SRONuN4eCrODlxxOd8.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/mali/v3/N0bU2SRONuN4SCjECn50Kd_PmA.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/mali/v3/N0bV2SRONuN4QN7nKlRaJdbWgdY.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/mali/v3/N0bX2SRONuN4SCj8_ldQIfTTkdbJYA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/mali/v3/N0bV2SRONuN4QPLgKlRaJdbWgdY.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/mali/v3/N0bX2SRONuN4SCj80lBQIfTTkdbJYA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/mali/v3/N0bV2SRONuN4QJbhKlRaJdbWgdY.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/mali/v3/N0bX2SRONuN4SCj8tlFQIfTTkdbJYA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38896,7 +40571,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mallanna/v7/hv-Vlzx-KEQb84YaDGwzEzRwVvJ-.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mallanna/v7/hv-Vlzx-KEQb84YaDGwzEzRwVvJ-.ttf',
     };
 
     return googleFontsTextStyle(
@@ -38965,7 +40641,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mandali/v8/LhWlMVbYOfASNfNUVFk1ZPdcKtA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mandali/v8/LhWlMVbYOfASNfNUVFk1ZPdcKtA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39034,9 +40711,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/manjari/v2/k3kSo8UPMOBO2w1UdbroK2vFIaOV8A.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/manjari/v2/k3kQo8UPMOBO2w1UTd7iL0nAMaM.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/manjari/v2/k3kVo8UPMOBO2w1UdWLNC0HrLaqM6Q4.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/manjari/v2/k3kSo8UPMOBO2w1UdbroK2vFIaOV8A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/manjari/v2/k3kQo8UPMOBO2w1UTd7iL0nAMaM.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/manjari/v2/k3kVo8UPMOBO2w1UdWLNC0HrLaqM6Q4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39105,7 +40785,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mansalva/v1/aWB4m0aacbtDfvq5NJllI47vdyBg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mansalva/v1/aWB4m0aacbtDfvq5NJllI47vdyBg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39174,14 +40855,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/manuale/v5/f0Xp0eas_8Z-TFZdHv3mMxFaSqASeeHke7wD1TB_JHHY.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/manuale/v5/f0Xp0eas_8Z-TFZdHv3mMxFaSqASeeHWe7wD1TB_JHHY.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/manuale/v5/f0Xp0eas_8Z-TFZdHv3mMxFaSqASeeE6fLwD1TB_JHHY.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/manuale/v5/f0Xp0eas_8Z-TFZdHv3mMxFaSqASeeEDfLwD1TB_JHHY.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/manuale/v5/f0Xn0eas_8Z-TFZdNPTUzMkzITq8fvQsOFRA3zRdIWHYr8M.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/manuale/v5/f0Xn0eas_8Z-TFZdNPTUzMkzITq8fvQsOGZA3zRdIWHYr8M.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/manuale/v5/f0Xn0eas_8Z-TFZdNPTUzMkzITq8fvQsOIpH3zRdIWHYr8M.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/manuale/v5/f0Xn0eas_8Z-TFZdNPTUzMkzITq8fvQsOLNH3zRdIWHYr8M.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/manuale/v5/f0Xp0eas_8Z-TFZdHv3mMxFaSqASeeHke7wD1TB_JHHY.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/manuale/v5/f0Xp0eas_8Z-TFZdHv3mMxFaSqASeeHWe7wD1TB_JHHY.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/manuale/v5/f0Xp0eas_8Z-TFZdHv3mMxFaSqASeeE6fLwD1TB_JHHY.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/manuale/v5/f0Xp0eas_8Z-TFZdHv3mMxFaSqASeeEDfLwD1TB_JHHY.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/manuale/v5/f0Xn0eas_8Z-TFZdNPTUzMkzITq8fvQsOFRA3zRdIWHYr8M.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/manuale/v5/f0Xn0eas_8Z-TFZdNPTUzMkzITq8fvQsOGZA3zRdIWHYr8M.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/manuale/v5/f0Xn0eas_8Z-TFZdNPTUzMkzITq8fvQsOIpH3zRdIWHYr8M.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/manuale/v5/f0Xn0eas_8Z-TFZdNPTUzMkzITq8fvQsOLNH3zRdIWHYr8M.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39250,7 +40939,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/marcellus/v7/wEO_EBrOk8hQLDvIAF8FUfAL3EsHiA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/marcellus/v7/wEO_EBrOk8hQLDvIAF8FUfAL3EsHiA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39319,7 +41009,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/marcellussc/v7/ke8iOgUHP1dg-Rmi6RWjbLEPgdydGKikhA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/marcellussc/v7/ke8iOgUHP1dg-Rmi6RWjbLEPgdydGKikhA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39388,7 +41079,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/marckscript/v10/nwpTtK2oNgBA3Or78gapdwuCzyI-aMPF7Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/marckscript/v10/nwpTtK2oNgBA3Or78gapdwuCzyI-aMPF7Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39457,7 +41149,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/margarine/v8/qkBXXvoE6trLT9Y7YLye5JRLkAXbMQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/margarine/v8/qkBXXvoE6trLT9Y7YLye5JRLkAXbMQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39526,10 +41219,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/markazitext/v10/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtfSQT4MlBekmJLo.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/markazitext/v10/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtcaQT4MlBekmJLo.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/markazitext/v10/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtSqXT4MlBekmJLo.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/markazitext/v10/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtROXT4MlBekmJLo.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/markazitext/v10/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtfSQT4MlBekmJLo.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/markazitext/v10/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtcaQT4MlBekmJLo.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/markazitext/v10/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtSqXT4MlBekmJLo.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/markazitext/v10/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtROXT4MlBekmJLo.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39598,7 +41295,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/markoone/v9/9Btq3DFG0cnVM5lw1haaKpUfrHPzUw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/markoone/v9/9Btq3DFG0cnVM5lw1haaKpUfrHPzUw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39667,7 +41365,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/marmelad/v9/Qw3eZQdSHj_jK2e-8tFLG-YMC0R8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/marmelad/v9/Qw3eZQdSHj_jK2e-8tFLG-YMC0R8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39736,13 +41435,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/martel/v4/PN_yRfK9oXHga0XVqekahRbX9vnDzw.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/martel/v4/PN_yRfK9oXHga0XVzeoahRbX9vnDzw.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/martel/v4/PN_xRfK9oXHga0XtYcI-jT3L_w.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/martel/v4/PN_yRfK9oXHga0XVuewahRbX9vnDzw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/martel/v4/PN_yRfK9oXHga0XV3e0ahRbX9vnDzw.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/martel/v4/PN_yRfK9oXHga0XVwe4ahRbX9vnDzw.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/martel/v4/PN_yRfK9oXHga0XV5e8ahRbX9vnDzw.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/martel/v4/PN_yRfK9oXHga0XVqekahRbX9vnDzw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/martel/v4/PN_yRfK9oXHga0XVzeoahRbX9vnDzw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/martel/v4/PN_xRfK9oXHga0XtYcI-jT3L_w.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/martel/v4/PN_yRfK9oXHga0XVuewahRbX9vnDzw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/martel/v4/PN_yRfK9oXHga0XV3e0ahRbX9vnDzw.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/martel/v4/PN_yRfK9oXHga0XVwe4ahRbX9vnDzw.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/martel/v4/PN_yRfK9oXHga0XV5e8ahRbX9vnDzw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39811,13 +41517,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/martelsans/v6/h0GxssGi7VdzDgKjM-4d8hAX5suHFUknqMxQ.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/martelsans/v6/h0GxssGi7VdzDgKjM-4d8hBz5cuHFUknqMxQ.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/martelsans/v6/h0GsssGi7VdzDgKjM-4d8ijfze-PPlUu.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/martelsans/v6/h0GxssGi7VdzDgKjM-4d8hAH48uHFUknqMxQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/martelsans/v6/h0GxssGi7VdzDgKjM-4d8hBj4suHFUknqMxQ.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/martelsans/v6/h0GxssGi7VdzDgKjM-4d8hB_4cuHFUknqMxQ.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/martelsans/v6/h0GxssGi7VdzDgKjM-4d8hBb4MuHFUknqMxQ.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/martelsans/v6/h0GxssGi7VdzDgKjM-4d8hAX5suHFUknqMxQ.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/martelsans/v6/h0GxssGi7VdzDgKjM-4d8hBz5cuHFUknqMxQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/martelsans/v6/h0GsssGi7VdzDgKjM-4d8ijfze-PPlUu.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/martelsans/v6/h0GxssGi7VdzDgKjM-4d8hAH48uHFUknqMxQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/martelsans/v6/h0GxssGi7VdzDgKjM-4d8hBj4suHFUknqMxQ.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/martelsans/v6/h0GxssGi7VdzDgKjM-4d8hB_4cuHFUknqMxQ.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/martelsans/v6/h0GxssGi7VdzDgKjM-4d8hBb4MuHFUknqMxQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39886,10 +41599,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/marvel/v9/nwpVtKeoNgBV0qaIkV7ED366zg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/marvel/v9/nwpXtKeoNgBV0qa4k1TALXuqzhA7.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/marvel/v9/nwpWtKeoNgBV0qawLXHgB1WmxwkiYQ.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/marvel/v9/nwpQtKeoNgBV0qa4k2x8Al-i5QwyYdrc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/marvel/v9/nwpVtKeoNgBV0qaIkV7ED366zg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/marvel/v9/nwpXtKeoNgBV0qa4k1TALXuqzhA7.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/marvel/v9/nwpWtKeoNgBV0qawLXHgB1WmxwkiYQ.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/marvel/v9/nwpQtKeoNgBV0qa4k2x8Al-i5QwyYdrc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -39958,8 +41675,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mate/v8/m8JdjftRd7WZ2z28WoXSaLU.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/mate/v8/m8JTjftRd7WZ6z-2XqfXeLVdbw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mate/v8/m8JdjftRd7WZ2z28WoXSaLU.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/mate/v8/m8JTjftRd7WZ6z-2XqfXeLVdbw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40028,7 +41747,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/matesc/v8/-nF8OGQ1-uoVr2wKyiXZ95OkJwA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/matesc/v8/-nF8OGQ1-uoVr2wKyiXZ95OkJwA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40097,12 +41817,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mavenpro/v18/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8SX25nCpozp5GvU.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/mavenpro/v18/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8Rf25nCpozp5GvU.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/mavenpro/v18/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8fvx5nCpozp5GvU.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/mavenpro/v18/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8cLx5nCpozp5GvU.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/mavenpro/v18/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8aXx5nCpozp5GvU.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/mavenpro/v18/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8Yzx5nCpozp5GvU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mavenpro/v18/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8SX25nCpozp5GvU.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/mavenpro/v18/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8Rf25nCpozp5GvU.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/mavenpro/v18/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8fvx5nCpozp5GvU.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/mavenpro/v18/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8cLx5nCpozp5GvU.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/mavenpro/v18/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8aXx5nCpozp5GvU.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/mavenpro/v18/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8Yzx5nCpozp5GvU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40171,7 +41897,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mclaren/v7/2EbnL-ZuAXFqZFXISYYf8z2Yt_c.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mclaren/v7/2EbnL-ZuAXFqZFXISYYf8z2Yt_c.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40240,7 +41967,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/meddon/v12/kmK8ZqA2EgDNeHTZhBdB3y_Aow.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/meddon/v12/kmK8ZqA2EgDNeHTZhBdB3y_Aow.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40309,7 +42037,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/medievalsharp/v12/EvOJzAlL3oU5AQl2mP5KdgptAq96MwvXLDk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/medievalsharp/v12/EvOJzAlL3oU5AQl2mP5KdgptAq96MwvXLDk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40378,7 +42107,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/medulaone/v9/YA9Wr0qb5kjJM6l2V0yukiEqs7GtlvY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/medulaone/v9/YA9Wr0qb5kjJM6l2V0yukiEqs7GtlvY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40447,7 +42177,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/meerainimai/v4/845fNMM5EIqOW5MPuvO3ILep_2jDVevnLQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/meerainimai/v4/845fNMM5EIqOW5MPuvO3ILep_2jDVevnLQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40516,7 +42247,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/megrim/v10/46kulbz5WjvLqJZlbWXgd0RY1g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/megrim/v10/46kulbz5WjvLqJZlbWXgd0RY1g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40585,7 +42317,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/meiescript/v7/_LOImzDK7erRjhunIspaMjxn5IXg0WDz.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/meiescript/v7/_LOImzDK7erRjhunIspaMjxn5IXg0WDz.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40654,8 +42387,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/merienda/v8/gNMHW3x8Qoy5_mf8uVMCOou6_dvg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/merienda/v8/gNMAW3x8Qoy5_mf8uWu-Fa-y1sfpPES4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/merienda/v8/gNMHW3x8Qoy5_mf8uVMCOou6_dvg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/merienda/v8/gNMAW3x8Qoy5_mf8uWu-Fa-y1sfpPES4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40724,7 +42459,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/meriendaone/v10/H4cgBXaMndbflEq6kyZ1ht6YgoyyYzFzFw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/meriendaone/v10/H4cgBXaMndbflEq6kyZ1ht6YgoyyYzFzFw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40793,14 +42529,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/merriweather/v21/u-4n0qyriQwlOrhSvowK_l521wRpX837pvjxPA.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/merriweather/v21/u-4l0qyriQwlOrhSvowK_l5-eR7lXcf_hP3hPGWH.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/merriweather/v21/u-440qyriQwlOrhSvowK_l5OeyxNV-bnrw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/merriweather/v21/u-4m0qyriQwlOrhSvowK_l5-eSZJdeP3r-Ho.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/merriweather/v21/u-4n0qyriQwlOrhSvowK_l52xwNpX837pvjxPA.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/merriweather/v21/u-4l0qyriQwlOrhSvowK_l5-eR71Wsf_hP3hPGWH.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/merriweather/v21/u-4n0qyriQwlOrhSvowK_l52_wFpX837pvjxPA.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/merriweather/v21/u-4l0qyriQwlOrhSvowK_l5-eR7NWMf_hP3hPGWH.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/merriweather/v21/u-4n0qyriQwlOrhSvowK_l521wRpX837pvjxPA.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/merriweather/v21/u-4l0qyriQwlOrhSvowK_l5-eR7lXcf_hP3hPGWH.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/merriweather/v21/u-440qyriQwlOrhSvowK_l5OeyxNV-bnrw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/merriweather/v21/u-4m0qyriQwlOrhSvowK_l5-eSZJdeP3r-Ho.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/merriweather/v21/u-4n0qyriQwlOrhSvowK_l52xwNpX837pvjxPA.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/merriweather/v21/u-4l0qyriQwlOrhSvowK_l5-eR71Wsf_hP3hPGWH.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/merriweather/v21/u-4n0qyriQwlOrhSvowK_l52_wFpX837pvjxPA.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/merriweather/v21/u-4l0qyriQwlOrhSvowK_l5-eR7NWMf_hP3hPGWH.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40869,14 +42613,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/merriweathersans/v11/2-c49IRs1JiJN1FRAMjTN5zd9vgsFH1eYBDD2BdWzIqY.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/merriweathersans/v11/2-c29IRs1JiJN1FRAMjTN5zd9vgsFHXwepzB0hN0yZqYcqw.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/merriweathersans/v11/2-c99IRs1JiJN1FRAMjTN5zd9vgsFEXySDTL8wtf.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/merriweathersans/v11/2-c79IRs1JiJN1FRAMjTN5zd9vgsFHXwQjDp9htf1ZM.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/merriweathersans/v11/2-c49IRs1JiJN1FRAMjTN5zd9vgsFH1OZxDD2BdWzIqY.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/merriweathersans/v11/2-c29IRs1JiJN1FRAMjTN5zd9vgsFHXweozG0hN0yZqYcqw.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/merriweathersans/v11/2-c49IRs1JiJN1FRAMjTN5zd9vgsFH1SZBDD2BdWzIqY.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/merriweathersans/v11/2-c29IRs1JiJN1FRAMjTN5zd9vgsFHXwepDF0hN0yZqYcqw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/merriweathersans/v11/2-c49IRs1JiJN1FRAMjTN5zd9vgsFH1eYBDD2BdWzIqY.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/merriweathersans/v11/2-c29IRs1JiJN1FRAMjTN5zd9vgsFHXwepzB0hN0yZqYcqw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/merriweathersans/v11/2-c99IRs1JiJN1FRAMjTN5zd9vgsFEXySDTL8wtf.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/merriweathersans/v11/2-c79IRs1JiJN1FRAMjTN5zd9vgsFHXwQjDp9htf1ZM.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/merriweathersans/v11/2-c49IRs1JiJN1FRAMjTN5zd9vgsFH1OZxDD2BdWzIqY.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/merriweathersans/v11/2-c29IRs1JiJN1FRAMjTN5zd9vgsFHXweozG0hN0yZqYcqw.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/merriweathersans/v11/2-c49IRs1JiJN1FRAMjTN5zd9vgsFH1SZBDD2BdWzIqY.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/merriweathersans/v11/2-c29IRs1JiJN1FRAMjTN5zd9vgsFHXwepDF0hN0yZqYcqw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -40945,7 +42697,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/metal/v12/lW-wwjUJIXTo7i3nnoQAUdN2.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/metal/v12/lW-wwjUJIXTo7i3nnoQAUdN2.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41014,7 +42767,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/metalmania/v9/RWmMoKWb4e8kqMfBUdPFJeXCg6UKDXlq.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/metalmania/v9/RWmMoKWb4e8kqMfBUdPFJeXCg6UKDXlq.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41083,7 +42837,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/metamorphous/v10/Wnz8HA03aAXcC39ZEX5y1330PCCthTsmaQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/metamorphous/v10/Wnz8HA03aAXcC39ZEX5y1330PCCthTsmaQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41152,7 +42907,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/metrophobic/v13/sJoA3LZUhMSAPV_u0qwiAT-J737FPEEL.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/metrophobic/v13/sJoA3LZUhMSAPV_u0qwiAT-J737FPEEL.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41221,7 +42977,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/michroma/v10/PN_zRfy9qWD8fEagAMg6rzjb_-Da.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/michroma/v10/PN_zRfy9qWD8fEagAMg6rzjb_-Da.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41290,7 +43047,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/milonga/v7/SZc53FHnIaK9W5kffz3GkUrS8DI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/milonga/v7/SZc53FHnIaK9W5kffz3GkUrS8DI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41359,7 +43117,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/miltonian/v13/zOL-4pbPn6Ne9JqTg9mr6e5As-FeiQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/miltonian/v13/zOL-4pbPn6Ne9JqTg9mr6e5As-FeiQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41428,7 +43187,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/miltoniantattoo/v15/EvOUzBRL0o0kCxF-lcMCQxlpVsA_FwP8MDBku-s.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/miltoniantattoo/v15/EvOUzBRL0o0kCxF-lcMCQxlpVsA_FwP8MDBku-s.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41497,8 +43257,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mina/v3/-nFzOGc18vARrz9j7i3y65o.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/mina/v3/-nF8OGc18vARl4NMyiXZ95OkJwA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mina/v3/-nFzOGc18vARrz9j7i3y65o.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/mina/v3/-nF8OGc18vARl4NMyiXZ95OkJwA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41567,7 +43329,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/miniver/v8/eLGcP-PxIg-5H0vC770Cy8r8fWA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/miniver/v8/eLGcP-PxIg-5H0vC770Cy8r8fWA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41636,8 +43399,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/miriamlibre/v6/DdTh798HsHwubBAqfkcBTL_vYJn_Teun9g.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/miriamlibre/v6/DdT-798HsHwubBAqfkcBTL_X3LbbRcC7_-Z7Hg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/miriamlibre/v6/DdTh798HsHwubBAqfkcBTL_vYJn_Teun9g.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/miriamlibre/v6/DdT-798HsHwubBAqfkcBTL_X3LbbRcC7_-Z7Hg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41706,10 +43471,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mirza/v7/co3ImWlikiN5EurdKMewsrvI.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/mirza/v7/co3FmWlikiN5EtIpAeO4mafBomDi.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/mirza/v7/co3FmWlikiN5EtIFBuO4mafBomDi.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/mirza/v7/co3FmWlikiN5EtJhB-O4mafBomDi.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mirza/v7/co3ImWlikiN5EurdKMewsrvI.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/mirza/v7/co3FmWlikiN5EtIpAeO4mafBomDi.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/mirza/v7/co3FmWlikiN5EtIFBuO4mafBomDi.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/mirza/v7/co3FmWlikiN5EtJhB-O4mafBomDi.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41778,7 +43547,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/missfajardose/v9/E21-_dn5gvrawDdPFVl-N0Ajb8qvWPaJq4no.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/missfajardose/v9/E21-_dn5gvrawDdPFVl-N0Ajb8qvWPaJq4no.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41847,12 +43617,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/mitr/v5/pxiEypw5ucZF8fMZFJDUc1NECPY.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/mitr/v5/pxiEypw5ucZF8ZcaFJDUc1NECPY.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mitr/v5/pxiLypw5ucZFyTsyMJj_b1o.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/mitr/v5/pxiEypw5ucZF8c8bFJDUc1NECPY.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/mitr/v5/pxiEypw5ucZF8eMcFJDUc1NECPY.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/mitr/v5/pxiEypw5ucZF8YcdFJDUc1NECPY.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/mitr/v5/pxiEypw5ucZF8fMZFJDUc1NECPY.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/mitr/v5/pxiEypw5ucZF8ZcaFJDUc1NECPY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mitr/v5/pxiLypw5ucZFyTsyMJj_b1o.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/mitr/v5/pxiEypw5ucZF8c8bFJDUc1NECPY.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/mitr/v5/pxiEypw5ucZF8eMcFJDUc1NECPY.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/mitr/v5/pxiEypw5ucZF8YcdFJDUc1NECPY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41921,7 +43697,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/modak/v5/EJRYQgs1XtIEsnMH8BVZ76KU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/modak/v5/EJRYQgs1XtIEsnMH8BVZ76KU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -41990,7 +43767,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/modernantiqua/v9/NGStv5TIAUg6Iq_RLNo_2dp1sI1Ea2u0c3Gi.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/modernantiqua/v9/NGStv5TIAUg6Iq_RLNo_2dp1sI1Ea2u0c3Gi.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42059,7 +43837,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mogra/v6/f0X40eSs8c95TBo4DvLmxtnG.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mogra/v6/f0X40eSs8c95TBo4DvLmxtnG.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42128,7 +43907,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/molengo/v10/I_uuMpWeuBzZNBtQbbRQkiCvs5Y.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/molengo/v10/I_uuMpWeuBzZNBtQbbRQkiCvs5Y.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42197,7 +43977,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/molle/v8/E21n_dL5hOXFhWEsXzgmVydREus.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/molle/v8/E21n_dL5hOXFhWEsXzgmVydREus.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42266,8 +44047,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/monda/v9/TK3tWkYFABsmjvpmNBsLvPdG.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/monda/v9/TK3gWkYFABsmjsLaGz8Dl-tPKo2t.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/monda/v9/TK3tWkYFABsmjvpmNBsLvPdG.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/monda/v9/TK3gWkYFABsmjsLaGz8Dl-tPKo2t.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42336,7 +44119,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/monofett/v9/mFTyWbofw6zc9NtnW43SuRwr0VJ7.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/monofett/v9/mFTyWbofw6zc9NtnW43SuRwr0VJ7.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42405,7 +44189,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/monoton/v9/5h1aiZUrOngCibe4fkbBQ2S7FU8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/monoton/v9/5h1aiZUrOngCibe4fkbBQ2S7FU8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42474,7 +44259,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/monsieurladoulaise/v8/_Xmz-GY4rjmCbQfc-aPRaa4pqV340p7EZl5ewkEU4HTy.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/monsieurladoulaise/v8/_Xmz-GY4rjmCbQfc-aPRaa4pqV340p7EZl5ewkEU4HTy.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42543,7 +44329,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/montaga/v7/H4cnBX2Ml8rCkEO_0gYQ7LO5mqc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/montaga/v7/H4cnBX2Ml8rCkEO_0gYQ7LO5mqc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42612,7 +44399,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/montez/v10/845ZNMk5GoGIX8lm1LDeSd-R_g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/montez/v10/845ZNMk5GoGIX8lm1LDeSd-R_g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42681,24 +44469,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/montserrat/v14/JTUQjIg1_i6t8kCHKm45_QphziTn89dtpQ.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/montserrat/v14/JTUOjIg1_i6t8kCHKm459WxZqi7j0dJ9pTOi.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_aZA7g7J_950vCo.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZBg_D-_xxrCq7qg.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_cJD7g7J_950vCo.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZYgzD-_xxrCq7qg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/montserrat/v14/JTUSjIg1_i6t8kCHKm45xW5rygbi49c.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/montserrat/v14/JTUQjIg1_i6t8kCHKm459WxhziTn89dtpQ.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_ZpC7g7J_950vCo.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZOg3D-_xxrCq7qg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_bZF7g7J_950vCo.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZFgrD-_xxrCq7qg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_dJE7g7J_950vCo.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZcgvD-_xxrCq7qg.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_c5H7g7J_950vCo.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZbgjD-_xxrCq7qg.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_epG7g7J_950vCo.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZSgnD-_xxrCq7qg.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTUQjIg1_i6t8kCHKm45_QphziTn89dtpQ.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTUOjIg1_i6t8kCHKm459WxZqi7j0dJ9pTOi.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_aZA7g7J_950vCo.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZBg_D-_xxrCq7qg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_cJD7g7J_950vCo.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZYgzD-_xxrCq7qg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTUSjIg1_i6t8kCHKm45xW5rygbi49c.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTUQjIg1_i6t8kCHKm459WxhziTn89dtpQ.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_ZpC7g7J_950vCo.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZOg3D-_xxrCq7qg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_bZF7g7J_950vCo.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZFgrD-_xxrCq7qg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_dJE7g7J_950vCo.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZcgvD-_xxrCq7qg.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_c5H7g7J_950vCo.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZbgjD-_xxrCq7qg.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTURjIg1_i6t8kCHKm45_epG7g7J_950vCo.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/montserrat/v14/JTUPjIg1_i6t8kCHKm459WxZSgnD-_xxrCq7qg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42767,24 +44573,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFThWacfw6zH4dthXcyms1lPpC8I_b0juU0xiKfVKphL03l4.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTjWacfw6zH4dthXcyms1lPpC8I_b0juU057p-xIJxp1ml4imo.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xJIb1ALZH2mBhkw.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p8dAbxD-GVxk3Nd.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xQIX1ALZH2mBhkw.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p95ArxD-GVxk3Nd.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTvWacfw6zH4dthXcyms1lPpC8I_b0juU0J7K3RCJ1b0w.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFThWacfw6zH4dthXcyms1lPpC8I_b0juU057qfVKphL03l4.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xGIT1ALZH2mBhkw.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p8hA7xD-GVxk3Nd.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xNIP1ALZH2mBhkw.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p8NBLxD-GVxk3Nd.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xUIL1ALZH2mBhkw.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p9pBbxD-GVxk3Nd.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xTIH1ALZH2mBhkw.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p91BrxD-GVxk3Nd.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xaID1ALZH2mBhkw.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p9RB7xD-GVxk3Nd.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFThWacfw6zH4dthXcyms1lPpC8I_b0juU0xiKfVKphL03l4.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTjWacfw6zH4dthXcyms1lPpC8I_b0juU057p-xIJxp1ml4imo.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xJIb1ALZH2mBhkw.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p8dAbxD-GVxk3Nd.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xQIX1ALZH2mBhkw.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p95ArxD-GVxk3Nd.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTvWacfw6zH4dthXcyms1lPpC8I_b0juU0J7K3RCJ1b0w.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFThWacfw6zH4dthXcyms1lPpC8I_b0juU057qfVKphL03l4.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xGIT1ALZH2mBhkw.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p8hA7xD-GVxk3Nd.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xNIP1ALZH2mBhkw.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p8NBLxD-GVxk3Nd.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xUIL1ALZH2mBhkw.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p9pBbxD-GVxk3Nd.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xTIH1ALZH2mBhkw.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p91BrxD-GVxk3Nd.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTiWacfw6zH4dthXcyms1lPpC8I_b0juU0xaID1ALZH2mBhkw.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/montserratalternates/v11/mFTkWacfw6zH4dthXcyms1lPpC8I_b0juU057p9RB7xD-GVxk3Nd.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42815,19 +44639,26 @@ class GoogleFonts {
   static TextTheme montserratAlternatesTextTheme([TextTheme textTheme]) {
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(
-      display4: GoogleFonts.montserratAlternates(textStyle: textTheme?.display4),
-      display3: GoogleFonts.montserratAlternates(textStyle: textTheme?.display3),
-      display2: GoogleFonts.montserratAlternates(textStyle: textTheme?.display2),
-      display1: GoogleFonts.montserratAlternates(textStyle: textTheme?.display1),
-      headline: GoogleFonts.montserratAlternates(textStyle: textTheme?.headline),
+      display4:
+          GoogleFonts.montserratAlternates(textStyle: textTheme?.display4),
+      display3:
+          GoogleFonts.montserratAlternates(textStyle: textTheme?.display3),
+      display2:
+          GoogleFonts.montserratAlternates(textStyle: textTheme?.display2),
+      display1:
+          GoogleFonts.montserratAlternates(textStyle: textTheme?.display1),
+      headline:
+          GoogleFonts.montserratAlternates(textStyle: textTheme?.headline),
       title: GoogleFonts.montserratAlternates(textStyle: textTheme?.title),
       subhead: GoogleFonts.montserratAlternates(textStyle: textTheme?.subhead),
       body2: GoogleFonts.montserratAlternates(textStyle: textTheme?.body2),
       body1: GoogleFonts.montserratAlternates(textStyle: textTheme?.body1),
       caption: GoogleFonts.montserratAlternates(textStyle: textTheme?.caption),
       button: GoogleFonts.montserratAlternates(textStyle: textTheme?.button),
-      subtitle: GoogleFonts.montserratAlternates(textStyle: textTheme?.subtitle),
-      overline: GoogleFonts.montserratAlternates(textStyle: textTheme?.overline),
+      subtitle:
+          GoogleFonts.montserratAlternates(textStyle: textTheme?.subtitle),
+      overline:
+          GoogleFonts.montserratAlternates(textStyle: textTheme?.overline),
     );
   }
 
@@ -42853,8 +44684,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/montserratsubrayada/v9/U9MD6c-o9H7PgjlTHThBnNHGVUORwteQQE8LYuceqGT-.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/montserratsubrayada/v9/U9MM6c-o9H7PgjlTHThBnNHGVUORwteQQHe3TcMWg3j36Ebz.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/montserratsubrayada/v9/U9MD6c-o9H7PgjlTHThBnNHGVUORwteQQE8LYuceqGT-.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/montserratsubrayada/v9/U9MM6c-o9H7PgjlTHThBnNHGVUORwteQQHe3TcMWg3j36Ebz.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42923,7 +44756,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/moul/v11/nuF2D__FSo_3E-RYiJCy-00.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/moul/v11/nuF2D__FSo_3E-RYiJCy-00.ttf',
     };
 
     return googleFontsTextStyle(
@@ -42992,7 +44826,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/moulpali/v12/H4ckBXKMl9HagUWymyY6wr-wg763.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/moulpali/v12/H4ckBXKMl9HagUWymyY6wr-wg763.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43061,8 +44896,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mountainsofchristmas/v12/3y9w6a4zcCnn5X0FDyrKi2ZRUBIy8uxoUo7ePNamMPNpJpc.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/mountainsofchristmas/v12/3y9z6a4zcCnn5X0FDyrKi2ZRUBIy8uxoUo7eBGqJFPtCOp6IaEA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mountainsofchristmas/v12/3y9w6a4zcCnn5X0FDyrKi2ZRUBIy8uxoUo7ePNamMPNpJpc.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/mountainsofchristmas/v12/3y9z6a4zcCnn5X0FDyrKi2ZRUBIy8uxoUo7eBGqJFPtCOp6IaEA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43093,19 +44930,26 @@ class GoogleFonts {
   static TextTheme mountainsofChristmasTextTheme([TextTheme textTheme]) {
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(
-      display4: GoogleFonts.mountainsofChristmas(textStyle: textTheme?.display4),
-      display3: GoogleFonts.mountainsofChristmas(textStyle: textTheme?.display3),
-      display2: GoogleFonts.mountainsofChristmas(textStyle: textTheme?.display2),
-      display1: GoogleFonts.mountainsofChristmas(textStyle: textTheme?.display1),
-      headline: GoogleFonts.mountainsofChristmas(textStyle: textTheme?.headline),
+      display4:
+          GoogleFonts.mountainsofChristmas(textStyle: textTheme?.display4),
+      display3:
+          GoogleFonts.mountainsofChristmas(textStyle: textTheme?.display3),
+      display2:
+          GoogleFonts.mountainsofChristmas(textStyle: textTheme?.display2),
+      display1:
+          GoogleFonts.mountainsofChristmas(textStyle: textTheme?.display1),
+      headline:
+          GoogleFonts.mountainsofChristmas(textStyle: textTheme?.headline),
       title: GoogleFonts.mountainsofChristmas(textStyle: textTheme?.title),
       subhead: GoogleFonts.mountainsofChristmas(textStyle: textTheme?.subhead),
       body2: GoogleFonts.mountainsofChristmas(textStyle: textTheme?.body2),
       body1: GoogleFonts.mountainsofChristmas(textStyle: textTheme?.body1),
       caption: GoogleFonts.mountainsofChristmas(textStyle: textTheme?.caption),
       button: GoogleFonts.mountainsofChristmas(textStyle: textTheme?.button),
-      subtitle: GoogleFonts.mountainsofChristmas(textStyle: textTheme?.subtitle),
-      overline: GoogleFonts.mountainsofChristmas(textStyle: textTheme?.overline),
+      subtitle:
+          GoogleFonts.mountainsofChristmas(textStyle: textTheme?.subtitle),
+      overline:
+          GoogleFonts.mountainsofChristmas(textStyle: textTheme?.overline),
     );
   }
 
@@ -43131,7 +44975,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mousememoirs/v7/t5tmIRoSNJ-PH0WNNgDYxdSb7TnFrpOHYh4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mousememoirs/v7/t5tmIRoSNJ-PH0WNNgDYxdSb7TnFrpOHYh4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43200,7 +45045,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mrbedfort/v8/MQpR-WCtNZSWAdTMwBicliq0XZe_Iy8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mrbedfort/v8/MQpR-WCtNZSWAdTMwBicliq0XZe_Iy8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43269,7 +45115,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mrdafoe/v8/lJwE-pIzkS5NXuMMrGiqg7MCxz_C.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mrdafoe/v8/lJwE-pIzkS5NXuMMrGiqg7MCxz_C.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43338,7 +45185,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mrdehaviland/v8/OpNVnooIhJj96FdB73296ksbOj3C4ULVNTlB.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mrdehaviland/v8/OpNVnooIhJj96FdB73296ksbOj3C4ULVNTlB.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43407,7 +45255,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mrssaintdelafield/v7/v6-IGZDIOVXH9xtmTZfRagunqBw5WC62cK4tLsubB2w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mrssaintdelafield/v7/v6-IGZDIOVXH9xtmTZfRagunqBw5WC62cK4tLsubB2w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43476,7 +45325,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mrssheppards/v8/PN_2Rfm9snC0XUGoEZhb91ig3vjxynMix4Y.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mrssheppards/v8/PN_2Rfm9snC0XUGoEZhb91ig3vjxynMix4Y.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43545,13 +45395,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/mukta/v7/iJWHBXyXfDDVXbEOjFma-2HW7ZB_.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/mukta/v7/iJWHBXyXfDDVXbFqj1ma-2HW7ZB_.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mukta/v7/iJWKBXyXfDDVXYnGp32S0H3f.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/mukta/v7/iJWHBXyXfDDVXbEyjlma-2HW7ZB_.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/mukta/v7/iJWHBXyXfDDVXbEeiVma-2HW7ZB_.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/mukta/v7/iJWHBXyXfDDVXbF6iFma-2HW7ZB_.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/mukta/v7/iJWHBXyXfDDVXbFmi1ma-2HW7ZB_.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/mukta/v7/iJWHBXyXfDDVXbEOjFma-2HW7ZB_.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/mukta/v7/iJWHBXyXfDDVXbFqj1ma-2HW7ZB_.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mukta/v7/iJWKBXyXfDDVXYnGp32S0H3f.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/mukta/v7/iJWHBXyXfDDVXbEyjlma-2HW7ZB_.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/mukta/v7/iJWHBXyXfDDVXbEeiVma-2HW7ZB_.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/mukta/v7/iJWHBXyXfDDVXbF6iFma-2HW7ZB_.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/mukta/v7/iJWHBXyXfDDVXbFmi1ma-2HW7ZB_.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43620,13 +45477,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/muktamahee/v5/XRXN3IOIi0hcP8iVU67hA9MFcBoHJndqZCsW.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/muktamahee/v5/XRXN3IOIi0hcP8iVU67hA9NhcxoHJndqZCsW.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/muktamahee/v5/XRXQ3IOIi0hcP8iVU67hA-vNWz4PDWtj.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/muktamahee/v5/XRXN3IOIi0hcP8iVU67hA9M5choHJndqZCsW.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/muktamahee/v5/XRXN3IOIi0hcP8iVU67hA9MVdRoHJndqZCsW.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/muktamahee/v5/XRXN3IOIi0hcP8iVU67hA9NxdBoHJndqZCsW.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/muktamahee/v5/XRXN3IOIi0hcP8iVU67hA9NtdxoHJndqZCsW.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/muktamahee/v5/XRXN3IOIi0hcP8iVU67hA9MFcBoHJndqZCsW.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/muktamahee/v5/XRXN3IOIi0hcP8iVU67hA9NhcxoHJndqZCsW.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/muktamahee/v5/XRXQ3IOIi0hcP8iVU67hA-vNWz4PDWtj.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/muktamahee/v5/XRXN3IOIi0hcP8iVU67hA9M5choHJndqZCsW.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/muktamahee/v5/XRXN3IOIi0hcP8iVU67hA9MVdRoHJndqZCsW.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/muktamahee/v5/XRXN3IOIi0hcP8iVU67hA9NxdBoHJndqZCsW.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/muktamahee/v5/XRXN3IOIi0hcP8iVU67hA9NtdxoHJndqZCsW.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43695,13 +45559,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/muktamalar/v6/MCoKzAXyz8LOE2FpJMxZqIMwBtAB62ruoAZW.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/muktamalar/v6/MCoKzAXyz8LOE2FpJMxZqINUBdAB62ruoAZW.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/muktamalar/v6/MCoXzAXyz8LOE2FpJMxZqLv4LfQJwHbn.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/muktamalar/v6/MCoKzAXyz8LOE2FpJMxZqIMMBNAB62ruoAZW.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/muktamalar/v6/MCoKzAXyz8LOE2FpJMxZqIMgA9AB62ruoAZW.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/muktamalar/v6/MCoKzAXyz8LOE2FpJMxZqINEAtAB62ruoAZW.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/muktamalar/v6/MCoKzAXyz8LOE2FpJMxZqINYAdAB62ruoAZW.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/muktamalar/v6/MCoKzAXyz8LOE2FpJMxZqIMwBtAB62ruoAZW.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/muktamalar/v6/MCoKzAXyz8LOE2FpJMxZqINUBdAB62ruoAZW.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/muktamalar/v6/MCoXzAXyz8LOE2FpJMxZqLv4LfQJwHbn.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/muktamalar/v6/MCoKzAXyz8LOE2FpJMxZqIMMBNAB62ruoAZW.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/muktamalar/v6/MCoKzAXyz8LOE2FpJMxZqIMgA9AB62ruoAZW.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/muktamalar/v6/MCoKzAXyz8LOE2FpJMxZqINEAtAB62ruoAZW.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/muktamalar/v6/MCoKzAXyz8LOE2FpJMxZqINYAdAB62ruoAZW.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43770,13 +45641,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/muktavaani/v7/3JnkSD_-ynaxmxnEfVHPIGXNV8BD-u97MW1a.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/muktavaani/v7/3JnkSD_-ynaxmxnEfVHPIGWpVMBD-u97MW1a.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/muktavaani/v7/3Jn5SD_-ynaxmxnEfVHPIF0FfORL0fNy.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/muktavaani/v7/3JnkSD_-ynaxmxnEfVHPIGXxVcBD-u97MW1a.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/muktavaani/v7/3JnkSD_-ynaxmxnEfVHPIGXdUsBD-u97MW1a.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/muktavaani/v7/3JnkSD_-ynaxmxnEfVHPIGW5U8BD-u97MW1a.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/muktavaani/v7/3JnkSD_-ynaxmxnEfVHPIGWlUMBD-u97MW1a.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/muktavaani/v7/3JnkSD_-ynaxmxnEfVHPIGXNV8BD-u97MW1a.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/muktavaani/v7/3JnkSD_-ynaxmxnEfVHPIGWpVMBD-u97MW1a.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/muktavaani/v7/3Jn5SD_-ynaxmxnEfVHPIF0FfORL0fNy.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/muktavaani/v7/3JnkSD_-ynaxmxnEfVHPIGXxVcBD-u97MW1a.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/muktavaani/v7/3JnkSD_-ynaxmxnEfVHPIGXdUsBD-u97MW1a.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/muktavaani/v7/3JnkSD_-ynaxmxnEfVHPIGW5U8BD-u97MW1a.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/muktavaani/v7/3JnkSD_-ynaxmxnEfVHPIGWlUMBD-u97MW1a.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43845,22 +45723,38 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFlOkHkw2-m9x2iC.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFmQkHkw2-m9x2iC.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFnOkHkw2-m9x2iC.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFn8kHkw2-m9x2iC.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFkQl3kw2-m9x2iC.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFkpl3kw2-m9x2iC.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFlOl3kw2-m9x2iC.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFlnl3kw2-m9x2iC.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG0xFz0e2fwniCvzM.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG089z0e2fwniCvzM.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG05Fz0e2fwniCvzM.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG06Nz0e2fwniCvzM.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG00900e2fwniCvzM.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG03Z00e2fwniCvzM.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG0xF00e2fwniCvzM.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG0zh00e2fwniCvzM.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFlOkHkw2-m9x2iC.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFmQkHkw2-m9x2iC.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFnOkHkw2-m9x2iC.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFn8kHkw2-m9x2iC.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFkQl3kw2-m9x2iC.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFkpl3kw2-m9x2iC.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFlOl3kw2-m9x2iC.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aulp_0qiz-aVz7u3PJLcUMYOFlnl3kw2-m9x2iC.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG0xFz0e2fwniCvzM.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG089z0e2fwniCvzM.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG05Fz0e2fwniCvzM.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG06Nz0e2fwniCvzM.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG00900e2fwniCvzM.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG03Z00e2fwniCvzM.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG0xF00e2fwniCvzM.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/muli/v19/7Aujp_0qiz-afTfcIyoiGtm2P0wG0zh00e2fwniCvzM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43929,7 +45823,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/mysteryquest/v7/-nF6OG414u0E6k0wynSGlujRHwElD_9Qz9E.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/mysteryquest/v7/-nF6OG414u0E6k0wynSGlujRHwElD_9Qz9E.ttf',
     };
 
     return googleFontsTextStyle(
@@ -43998,7 +45893,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ntr/v7/RLpzK5Xy0ZjiGGhs5TA4bg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ntr/v7/RLpzK5Xy0ZjiGGhs5TA4bg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44067,7 +45963,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/nanumbrushscript/v17/wXK2E2wfpokopxzthSqPbcR5_gVaxazyjqBr1lO97Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/nanumbrushscript/v17/wXK2E2wfpokopxzthSqPbcR5_gVaxazyjqBr1lO97Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44136,9 +46033,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/nanumgothic/v17/PN_3Rfi-oW3hYwmKDpxS7F_z_tLfxno73g.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/nanumgothic/v17/PN_oRfi-oW3hYwmKDpxS7F_LQv37zlEn14YEUQ.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/nanumgothic/v17/PN_oRfi-oW3hYwmKDpxS7F_LXv77zlEn14YEUQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/nanumgothic/v17/PN_3Rfi-oW3hYwmKDpxS7F_z_tLfxno73g.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/nanumgothic/v17/PN_oRfi-oW3hYwmKDpxS7F_LQv37zlEn14YEUQ.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/nanumgothic/v17/PN_oRfi-oW3hYwmKDpxS7F_LXv77zlEn14YEUQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44207,8 +46107,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/nanumgothiccoding/v14/8QIVdjzHisX_8vv59_xMxtPFW4IXROwsy6QxVs1X7tc.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/nanumgothiccoding/v14/8QIYdjzHisX_8vv59_xMxtPFW4IXROws8xgecsV88t5V9r4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/nanumgothiccoding/v14/8QIVdjzHisX_8vv59_xMxtPFW4IXROwsy6QxVs1X7tc.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/nanumgothiccoding/v14/8QIYdjzHisX_8vv59_xMxtPFW4IXROws8xgecsV88t5V9r4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44277,9 +46179,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/nanummyeongjo/v15/9Btx3DZF0dXLMZlywRbVRNhxy1LreHQ8juyl.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/nanummyeongjo/v15/9Bty3DZF0dXLMZlywRbVRNhxy2pXV1A0pfCs5Kos.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/nanummyeongjo/v15/9Bty3DZF0dXLMZlywRbVRNhxy2pLVFA0pfCs5Kos.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/nanummyeongjo/v15/9Btx3DZF0dXLMZlywRbVRNhxy1LreHQ8juyl.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/nanummyeongjo/v15/9Bty3DZF0dXLMZlywRbVRNhxy2pXV1A0pfCs5Kos.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/nanummyeongjo/v15/9Bty3DZF0dXLMZlywRbVRNhxy2pLVFA0pfCs5Kos.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44348,7 +46253,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/nanumpenscript/v15/daaDSSYiLGqEal3MvdA_FOL_3FkN2z7-aMFCcTU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/nanumpenscript/v15/daaDSSYiLGqEal3MvdA_FOL_3FkN2z7-aMFCcTU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44417,7 +46323,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/neucha/v11/q5uGsou0JOdh94bvugNsCxVEgA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/neucha/v11/q5uGsou0JOdh94bvugNsCxVEgA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44486,12 +46393,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/neuton/v12/UMBQrPtMoH62xUZKAKkfegD5Drog6Q.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/neuton/v12/UMBQrPtMoH62xUZKZKofegD5Drog6Q.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/neuton/v12/UMBTrPtMoH62xUZyyII7civlBw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/neuton/v12/UMBRrPtMoH62xUZCyog_UC71B6M5.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/neuton/v12/UMBQrPtMoH62xUZKdK0fegD5Drog6Q.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/neuton/v12/UMBQrPtMoH62xUZKaK4fegD5Drog6Q.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/neuton/v12/UMBQrPtMoH62xUZKAKkfegD5Drog6Q.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/neuton/v12/UMBQrPtMoH62xUZKZKofegD5Drog6Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/neuton/v12/UMBTrPtMoH62xUZyyII7civlBw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/neuton/v12/UMBRrPtMoH62xUZCyog_UC71B6M5.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/neuton/v12/UMBQrPtMoH62xUZKdK0fegD5Drog6Q.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/neuton/v12/UMBQrPtMoH62xUZKaK4fegD5Drog6Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44560,7 +46473,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/newrocker/v8/MwQzbhjp3-HImzcCU_cJkGMViblPtXs.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/newrocker/v8/MwQzbhjp3-HImzcCU_cJkGMViblPtXs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44629,8 +46543,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/newscycle/v16/CSR64z1Qlv-GDxkbKVQ_TOcATNt_pOU.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/newscycle/v16/CSR54z1Qlv-GDxkbKVQ_dFsvaNNUuOwkC2s.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/newscycle/v16/CSR64z1Qlv-GDxkbKVQ_TOcATNt_pOU.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/newscycle/v16/CSR54z1Qlv-GDxkbKVQ_dFsvaNNUuOwkC2s.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44699,7 +46615,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/niconne/v9/w8gaH2QvRug1_rTfrQut2F4OuOo.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/niconne/v9/w8gaH2QvRug1_rTfrQut2F4OuOo.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44768,18 +46685,30 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/niramit/v4/I_urMpWdvgLdNxVLVXx7tiiEr5_BdZ8.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/niramit/v4/I_upMpWdvgLdNxVLXbZiXimOq73EZZ_f6w.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/niramit/v4/I_urMpWdvgLdNxVLVRh4tiiEr5_BdZ8.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/niramit/v4/I_upMpWdvgLdNxVLXbZiOiqOq73EZZ_f6w.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/niramit/v4/I_uuMpWdvgLdNxVLbbRQkiCvs5Y.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/niramit/v4/I_usMpWdvgLdNxVLXbZalgKqo5bYbA.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/niramit/v4/I_urMpWdvgLdNxVLVUB5tiiEr5_BdZ8.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/niramit/v4/I_upMpWdvgLdNxVLXbZiYiuOq73EZZ_f6w.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/niramit/v4/I_urMpWdvgLdNxVLVWx-tiiEr5_BdZ8.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/niramit/v4/I_upMpWdvgLdNxVLXbZiTiyOq73EZZ_f6w.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/niramit/v4/I_urMpWdvgLdNxVLVQh_tiiEr5_BdZ8.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/niramit/v4/I_upMpWdvgLdNxVLXbZiKi2Oq73EZZ_f6w.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/niramit/v4/I_urMpWdvgLdNxVLVXx7tiiEr5_BdZ8.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/niramit/v4/I_upMpWdvgLdNxVLXbZiXimOq73EZZ_f6w.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/niramit/v4/I_urMpWdvgLdNxVLVRh4tiiEr5_BdZ8.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/niramit/v4/I_upMpWdvgLdNxVLXbZiOiqOq73EZZ_f6w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/niramit/v4/I_uuMpWdvgLdNxVLbbRQkiCvs5Y.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/niramit/v4/I_usMpWdvgLdNxVLXbZalgKqo5bYbA.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/niramit/v4/I_urMpWdvgLdNxVLVUB5tiiEr5_BdZ8.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/niramit/v4/I_upMpWdvgLdNxVLXbZiYiuOq73EZZ_f6w.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/niramit/v4/I_urMpWdvgLdNxVLVWx-tiiEr5_BdZ8.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/niramit/v4/I_upMpWdvgLdNxVLXbZiTiyOq73EZZ_f6w.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/niramit/v4/I_urMpWdvgLdNxVLVQh_tiiEr5_BdZ8.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/niramit/v4/I_upMpWdvgLdNxVLXbZiKi2Oq73EZZ_f6w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44848,7 +46777,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/nixieone/v10/lW-8wjkKLXjg5y2o2uUoUOFzpS-yLw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/nixieone/v10/lW-8wjkKLXjg5y2o2uUoUOFzpS-yLw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44917,12 +46847,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/nobile/v11/m8JTjflSeaOVl1i2XqfXeLVdbw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/nobile/v11/m8JRjflSeaOVl1iGXK3TWrBNb3OD.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/nobile/v11/m8JQjflSeaOVl1iOqo7zcJ5BZmqa3A.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/nobile/v11/m8JWjflSeaOVl1iGXJUnc5RFRG-K3Mud.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/nobile/v11/m8JQjflSeaOVl1iO4ojzcJ5BZmqa3A.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/nobile/v11/m8JWjflSeaOVl1iGXJVvdZRFRG-K3Mud.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/nobile/v11/m8JTjflSeaOVl1i2XqfXeLVdbw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/nobile/v11/m8JRjflSeaOVl1iGXK3TWrBNb3OD.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/nobile/v11/m8JQjflSeaOVl1iOqo7zcJ5BZmqa3A.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/nobile/v11/m8JWjflSeaOVl1iGXJUnc5RFRG-K3Mud.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/nobile/v11/m8JQjflSeaOVl1iO4ojzcJ5BZmqa3A.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/nobile/v11/m8JWjflSeaOVl1iGXJVvdZRFRG-K3Mud.ttf',
     };
 
     return googleFontsTextStyle(
@@ -44991,8 +46927,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/nokora/v13/hYkIPuwgTubzaWxQOzoPovZg8Q.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/nokora/v13/hYkLPuwgTubzaWxohxUrqt18-B9Uuw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/nokora/v13/hYkIPuwgTubzaWxQOzoPovZg8Q.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/nokora/v13/hYkLPuwgTubzaWxohxUrqt18-B9Uuw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -45061,7 +46999,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/norican/v8/MwQ2bhXp1eSBqjkPGJJRtGs-lbA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/norican/v8/MwQ2bhXp1eSBqjkPGJJRtGs-lbA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -45130,7 +47069,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/nosifer/v8/ZGjXol5JTp0g5bxZaC1RVDNdGDs.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/nosifer/v8/ZGjXol5JTp0g5bxZaC1RVDNdGDs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -45199,7 +47139,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/notable/v4/gNMEW3N_SIqx-WX9-HMoFIez5MI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/notable/v4/gNMEW3N_SIqx-WX9-HMoFIez5MI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -45268,7 +47209,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/nothingyoucoulddo/v9/oY1B8fbBpaP5OX3DtrRYf_Q2BPB1SnfZb0OJl1ol2Ymo.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/nothingyoucoulddo/v9/oY1B8fbBpaP5OX3DtrRYf_Q2BPB1SnfZb0OJl1ol2Ymo.ttf',
     };
 
     return googleFontsTextStyle(
@@ -45337,10 +47279,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/noticiatext/v9/VuJ2dNDF2Yv9qppOePKYRP1GYTFZt0rNpQ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/noticiatext/v9/VuJodNDF2Yv9qppOePKYRP12YztdlU_dpSjt.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/noticiatext/v9/VuJpdNDF2Yv9qppOePKYRP1-3R59v2HRrDH0eA.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/noticiatext/v9/VuJrdNDF2Yv9qppOePKYRP12YwPhumvVjjTkeMnz.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/noticiatext/v9/VuJ2dNDF2Yv9qppOePKYRP1GYTFZt0rNpQ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/noticiatext/v9/VuJodNDF2Yv9qppOePKYRP12YztdlU_dpSjt.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/noticiatext/v9/VuJpdNDF2Yv9qppOePKYRP1-3R59v2HRrDH0eA.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/noticiatext/v9/VuJrdNDF2Yv9qppOePKYRP12YwPhumvVjjTkeMnz.ttf',
     };
 
     return googleFontsTextStyle(
@@ -45409,10 +47355,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/notosans/v9/o-0IIpQlx3QUlC5A4PNb4j5Ba_2c7A.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/notosans/v9/o-0OIpQlx3QUlC5A4PNr4DRFSfiM7HBj.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/notosans/v9/o-0NIpQlx3QUlC5A4PNjXhFlY9aA5Wl6PQ.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/notosans/v9/o-0TIpQlx3QUlC5A4PNr4Az5ZtyEx2xqPaif.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/notosans/v9/o-0IIpQlx3QUlC5A4PNb4j5Ba_2c7A.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/notosans/v9/o-0OIpQlx3QUlC5A4PNr4DRFSfiM7HBj.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/notosans/v9/o-0NIpQlx3QUlC5A4PNjXhFlY9aA5Wl6PQ.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/notosans/v9/o-0TIpQlx3QUlC5A4PNr4Az5ZtyEx2xqPaif.ttf',
     };
 
     return googleFontsTextStyle(
@@ -45481,12 +47431,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/notosanshk/v5/nKKO-GM_FYFRJvXzVXaAPe9ZUHp1MOv2ObB7.otf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/notosanshk/v5/nKKP-GM_FYFRJvXzVXaAPe9ZmFhTHMX6MKliqQ.otf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/notosanshk/v5/nKKQ-GM_FYFRJvXzVXaAPe9hMnB3Eu7mOQ.otf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/notosanshk/v5/nKKP-GM_FYFRJvXzVXaAPe9ZwFlTHMX6MKliqQ.otf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/notosanshk/v5/nKKP-GM_FYFRJvXzVXaAPe9ZiF9THMX6MKliqQ.otf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/notosanshk/v5/nKKP-GM_FYFRJvXzVXaAPe9ZsF1THMX6MKliqQ.otf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/notosanshk/v5/nKKO-GM_FYFRJvXzVXaAPe9ZUHp1MOv2ObB7.otf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/notosanshk/v5/nKKP-GM_FYFRJvXzVXaAPe9ZmFhTHMX6MKliqQ.otf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/notosanshk/v5/nKKQ-GM_FYFRJvXzVXaAPe9hMnB3Eu7mOQ.otf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/notosanshk/v5/nKKP-GM_FYFRJvXzVXaAPe9ZwFlTHMX6MKliqQ.otf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/notosanshk/v5/nKKP-GM_FYFRJvXzVXaAPe9ZiF9THMX6MKliqQ.otf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/notosanshk/v5/nKKP-GM_FYFRJvXzVXaAPe9ZsF1THMX6MKliqQ.otf',
     };
 
     return googleFontsTextStyle(
@@ -45555,12 +47511,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/notosansjp/v24/-F6ofjtqLzI2JPCgQBnw7HFQoggM-FNthvIU.otf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/notosansjp/v24/-F6pfjtqLzI2JPCgQBnw7HFQaioq1H1hj-sNFQ.otf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/notosansjp/v24/-F62fjtqLzI2JPCgQBnw7HFowAIO2lZ9hg.otf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/notosansjp/v24/-F6pfjtqLzI2JPCgQBnw7HFQMisq1H1hj-sNFQ.otf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/notosansjp/v24/-F6pfjtqLzI2JPCgQBnw7HFQei0q1H1hj-sNFQ.otf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/notosansjp/v24/-F6pfjtqLzI2JPCgQBnw7HFQQi8q1H1hj-sNFQ.otf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/notosansjp/v24/-F6ofjtqLzI2JPCgQBnw7HFQoggM-FNthvIU.otf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/notosansjp/v24/-F6pfjtqLzI2JPCgQBnw7HFQaioq1H1hj-sNFQ.otf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/notosansjp/v24/-F62fjtqLzI2JPCgQBnw7HFowAIO2lZ9hg.otf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/notosansjp/v24/-F6pfjtqLzI2JPCgQBnw7HFQMisq1H1hj-sNFQ.otf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/notosansjp/v24/-F6pfjtqLzI2JPCgQBnw7HFQei0q1H1hj-sNFQ.otf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/notosansjp/v24/-F6pfjtqLzI2JPCgQBnw7HFQQi8q1H1hj-sNFQ.otf',
     };
 
     return googleFontsTextStyle(
@@ -45629,12 +47591,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/notosanskr/v12/Pby6FmXiEBPT4ITbgNA5CgmOsn7uwpYcuH8y.otf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/notosanskr/v12/Pby7FmXiEBPT4ITbgNA5CgmOelzI7rgQsWYrzw.otf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/notosanskr/v12/PbykFmXiEBPT4ITbgNA5Cgm20HTs4JMMuA.otf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/notosanskr/v12/Pby7FmXiEBPT4ITbgNA5CgmOIl3I7rgQsWYrzw.otf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/notosanskr/v12/Pby7FmXiEBPT4ITbgNA5CgmOalvI7rgQsWYrzw.otf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/notosanskr/v12/Pby7FmXiEBPT4ITbgNA5CgmOUlnI7rgQsWYrzw.otf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/notosanskr/v12/Pby6FmXiEBPT4ITbgNA5CgmOsn7uwpYcuH8y.otf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/notosanskr/v12/Pby7FmXiEBPT4ITbgNA5CgmOelzI7rgQsWYrzw.otf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/notosanskr/v12/PbykFmXiEBPT4ITbgNA5Cgm20HTs4JMMuA.otf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/notosanskr/v12/Pby7FmXiEBPT4ITbgNA5CgmOIl3I7rgQsWYrzw.otf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/notosanskr/v12/Pby7FmXiEBPT4ITbgNA5CgmOalvI7rgQsWYrzw.otf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/notosanskr/v12/Pby7FmXiEBPT4ITbgNA5CgmOUlnI7rgQsWYrzw.otf',
     };
 
     return googleFontsTextStyle(
@@ -45703,12 +47671,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/notosanssc/v9/k3kJo84MPvpLmixcA63oeALZTYKL2wv287Sb.otf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/notosanssc/v9/k3kIo84MPvpLmixcA63oeALZhaCt9yX6-q2CGg.otf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/notosanssc/v9/k3kXo84MPvpLmixcA63oeALhL4iJ-Q7m8w.otf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/notosanssc/v9/k3kIo84MPvpLmixcA63oeALZ3aGt9yX6-q2CGg.otf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/notosanssc/v9/k3kIo84MPvpLmixcA63oeALZlaet9yX6-q2CGg.otf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/notosanssc/v9/k3kIo84MPvpLmixcA63oeALZraWt9yX6-q2CGg.otf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/notosanssc/v9/k3kJo84MPvpLmixcA63oeALZTYKL2wv287Sb.otf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/notosanssc/v9/k3kIo84MPvpLmixcA63oeALZhaCt9yX6-q2CGg.otf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/notosanssc/v9/k3kXo84MPvpLmixcA63oeALhL4iJ-Q7m8w.otf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/notosanssc/v9/k3kIo84MPvpLmixcA63oeALZ3aGt9yX6-q2CGg.otf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/notosanssc/v9/k3kIo84MPvpLmixcA63oeALZlaet9yX6-q2CGg.otf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/notosanssc/v9/k3kIo84MPvpLmixcA63oeALZraWt9yX6-q2CGg.otf',
     };
 
     return googleFontsTextStyle(
@@ -45777,12 +47751,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/notosanstc/v9/-nFlOG829Oofr2wohFbTp9i9WyEJIfNZ1sjy.otf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/notosanstc/v9/-nFkOG829Oofr2wohFbTp9i9kwMvDd1V39Hr7g.otf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/notosanstc/v9/-nF7OG829Oofr2wohFbTp9iFOSsLA_ZJ1g.otf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/notosanstc/v9/-nFkOG829Oofr2wohFbTp9i9ywIvDd1V39Hr7g.otf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/notosanstc/v9/-nFkOG829Oofr2wohFbTp9i9gwQvDd1V39Hr7g.otf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/notosanstc/v9/-nFkOG829Oofr2wohFbTp9i9uwYvDd1V39Hr7g.otf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/notosanstc/v9/-nFlOG829Oofr2wohFbTp9i9WyEJIfNZ1sjy.otf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/notosanstc/v9/-nFkOG829Oofr2wohFbTp9i9kwMvDd1V39Hr7g.otf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/notosanstc/v9/-nF7OG829Oofr2wohFbTp9iFOSsLA_ZJ1g.otf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/notosanstc/v9/-nFkOG829Oofr2wohFbTp9i9ywIvDd1V39Hr7g.otf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/notosanstc/v9/-nFkOG829Oofr2wohFbTp9i9gwQvDd1V39Hr7g.otf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/notosanstc/v9/-nFkOG829Oofr2wohFbTp9i9uwYvDd1V39Hr7g.otf',
     };
 
     return googleFontsTextStyle(
@@ -45851,10 +47831,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/notoserif/v8/ga6Iaw1J5X9T9RW6j9bNTFAcaRi_bMQ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/notoserif/v8/ga6Kaw1J5X9T9RW6j9bNfFIWbTq6fMRRMw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/notoserif/v8/ga6Law1J5X9T9RW6j9bNdOwzTRCUcM1IKoY.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/notoserif/v8/ga6Vaw1J5X9T9RW6j9bNfFIu0RWedO9NOoYIDg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/notoserif/v8/ga6Iaw1J5X9T9RW6j9bNTFAcaRi_bMQ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/notoserif/v8/ga6Kaw1J5X9T9RW6j9bNfFIWbTq6fMRRMw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/notoserif/v8/ga6Law1J5X9T9RW6j9bNdOwzTRCUcM1IKoY.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/notoserif/v8/ga6Vaw1J5X9T9RW6j9bNfFIu0RWedO9NOoYIDg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -45923,13 +47907,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZBaPRkgfU8fEwb0.otf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZHKMRkgfU8fEwb0.otf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/notoserifjp/v7/xn7mYHs72GKoTvER4Gn3b5eMXNikYkY0T84.otf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZCqNRkgfU8fEwb0.otf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZAaKRkgfU8fEwb0.otf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZGKLRkgfU8fEwb0.otf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZFqJRkgfU8fEwb0.otf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZBaPRkgfU8fEwb0.otf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZHKMRkgfU8fEwb0.otf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/notoserifjp/v7/xn7mYHs72GKoTvER4Gn3b5eMXNikYkY0T84.otf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZCqNRkgfU8fEwb0.otf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZAaKRkgfU8fEwb0.otf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZGKLRkgfU8fEwb0.otf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/notoserifjp/v7/xn77YHs72GKoTvER4Gn3b5eMZFqJRkgfU8fEwb0.otf',
     };
 
     return googleFontsTextStyle(
@@ -45998,13 +47989,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/notoserifkr/v6/3JnmSDn90Gmq2mr3blnHaTZXTihC8O1ZNH1ahck.otf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/notoserifkr/v6/3JnmSDn90Gmq2mr3blnHaTZXTkxB8O1ZNH1ahck.otf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/notoserifkr/v6/3Jn7SDn90Gmq2mr3blnHaTZXduZp1ONyKHQ.otf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/notoserifkr/v6/3JnmSDn90Gmq2mr3blnHaTZXThRA8O1ZNH1ahck.otf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/notoserifkr/v6/3JnmSDn90Gmq2mr3blnHaTZXTjhH8O1ZNH1ahck.otf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/notoserifkr/v6/3JnmSDn90Gmq2mr3blnHaTZXTlxG8O1ZNH1ahck.otf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/notoserifkr/v6/3JnmSDn90Gmq2mr3blnHaTZXTmRE8O1ZNH1ahck.otf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/notoserifkr/v6/3JnmSDn90Gmq2mr3blnHaTZXTihC8O1ZNH1ahck.otf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/notoserifkr/v6/3JnmSDn90Gmq2mr3blnHaTZXTkxB8O1ZNH1ahck.otf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/notoserifkr/v6/3Jn7SDn90Gmq2mr3blnHaTZXduZp1ONyKHQ.otf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/notoserifkr/v6/3JnmSDn90Gmq2mr3blnHaTZXThRA8O1ZNH1ahck.otf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/notoserifkr/v6/3JnmSDn90Gmq2mr3blnHaTZXTjhH8O1ZNH1ahck.otf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/notoserifkr/v6/3JnmSDn90Gmq2mr3blnHaTZXTlxG8O1ZNH1ahck.otf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/notoserifkr/v6/3JnmSDn90Gmq2mr3blnHaTZXTmRE8O1ZNH1ahck.otf',
     };
 
     return googleFontsTextStyle(
@@ -46073,13 +48071,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/notoserifsc/v6/H4c8BXePl9DZ0Xe7gG9cyOj7mm63SzZBEtERe7U.otf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/notoserifsc/v6/H4c8BXePl9DZ0Xe7gG9cyOj7mgq0SzZBEtERe7U.otf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/notoserifsc/v6/H4chBXePl9DZ0Xe7gG9cyOj7oqCcbzhqDtg.otf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/notoserifsc/v6/H4c8BXePl9DZ0Xe7gG9cyOj7mlK1SzZBEtERe7U.otf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/notoserifsc/v6/H4c8BXePl9DZ0Xe7gG9cyOj7mn6ySzZBEtERe7U.otf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/notoserifsc/v6/H4c8BXePl9DZ0Xe7gG9cyOj7mhqzSzZBEtERe7U.otf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/notoserifsc/v6/H4c8BXePl9DZ0Xe7gG9cyOj7miKxSzZBEtERe7U.otf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/notoserifsc/v6/H4c8BXePl9DZ0Xe7gG9cyOj7mm63SzZBEtERe7U.otf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/notoserifsc/v6/H4c8BXePl9DZ0Xe7gG9cyOj7mgq0SzZBEtERe7U.otf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/notoserifsc/v6/H4chBXePl9DZ0Xe7gG9cyOj7oqCcbzhqDtg.otf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/notoserifsc/v6/H4c8BXePl9DZ0Xe7gG9cyOj7mlK1SzZBEtERe7U.otf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/notoserifsc/v6/H4c8BXePl9DZ0Xe7gG9cyOj7mn6ySzZBEtERe7U.otf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/notoserifsc/v6/H4c8BXePl9DZ0Xe7gG9cyOj7mhqzSzZBEtERe7U.otf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/notoserifsc/v6/H4c8BXePl9DZ0Xe7gG9cyOj7miKxSzZBEtERe7U.otf',
     };
 
     return googleFontsTextStyle(
@@ -46148,13 +48153,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/notoseriftc/v6/XLY9IZb5bJNDGYxLBibeHZ0Bvr8vbX9GTsoOAX4.otf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/notoseriftc/v6/XLY9IZb5bJNDGYxLBibeHZ0BvtssbX9GTsoOAX4.otf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/notoseriftc/v6/XLYgIZb5bJNDGYxLBibeHZ0BhnEESXFtUsM.otf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/notoseriftc/v6/XLY9IZb5bJNDGYxLBibeHZ0BvoMtbX9GTsoOAX4.otf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/notoseriftc/v6/XLY9IZb5bJNDGYxLBibeHZ0Bvq8qbX9GTsoOAX4.otf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/notoseriftc/v6/XLY9IZb5bJNDGYxLBibeHZ0BvssrbX9GTsoOAX4.otf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/notoseriftc/v6/XLY9IZb5bJNDGYxLBibeHZ0BvvMpbX9GTsoOAX4.otf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/notoseriftc/v6/XLY9IZb5bJNDGYxLBibeHZ0Bvr8vbX9GTsoOAX4.otf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/notoseriftc/v6/XLY9IZb5bJNDGYxLBibeHZ0BvtssbX9GTsoOAX4.otf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/notoseriftc/v6/XLYgIZb5bJNDGYxLBibeHZ0BhnEESXFtUsM.otf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/notoseriftc/v6/XLY9IZb5bJNDGYxLBibeHZ0BvoMtbX9GTsoOAX4.otf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/notoseriftc/v6/XLY9IZb5bJNDGYxLBibeHZ0Bvq8qbX9GTsoOAX4.otf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/notoseriftc/v6/XLY9IZb5bJNDGYxLBibeHZ0BvssrbX9GTsoOAX4.otf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/notoseriftc/v6/XLY9IZb5bJNDGYxLBibeHZ0BvvMpbX9GTsoOAX4.otf',
     };
 
     return googleFontsTextStyle(
@@ -46223,7 +48235,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/novacut/v11/KFOkCnSYu8mL-39LkWxPKTM1K9nz.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/novacut/v11/KFOkCnSYu8mL-39LkWxPKTM1K9nz.ttf',
     };
 
     return googleFontsTextStyle(
@@ -46292,7 +48305,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/novaflat/v11/QdVUSTc-JgqpytEbVebEuStkm20oJA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/novaflat/v11/QdVUSTc-JgqpytEbVebEuStkm20oJA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -46361,7 +48375,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/novamono/v10/Cn-0JtiGWQ5Ajb--MRKfYGxYrdM9Sg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/novamono/v10/Cn-0JtiGWQ5Ajb--MRKfYGxYrdM9Sg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -46430,7 +48445,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/novaoval/v11/jAnEgHdmANHvPenMaswCMY-h3cWkWg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/novaoval/v11/jAnEgHdmANHvPenMaswCMY-h3cWkWg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -46499,7 +48515,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/novaround/v11/flU9Rqquw5UhEnlwTJYTYYfeeetYEBc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/novaround/v11/flU9Rqquw5UhEnlwTJYTYYfeeetYEBc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -46568,7 +48585,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/novascript/v12/7Au7p_IpkSWSTWaFWkumvmQNEl0O0kEx.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/novascript/v12/7Au7p_IpkSWSTWaFWkumvmQNEl0O0kEx.ttf',
     };
 
     return googleFontsTextStyle(
@@ -46637,7 +48655,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/novaslim/v11/Z9XUDmZNQAuem8jyZcn-yMOInrib9Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/novaslim/v11/Z9XUDmZNQAuem8jyZcn-yMOInrib9Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -46706,7 +48725,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/novasquare/v12/RrQUbo9-9DV7b06QHgSWsZhARYMgGtWA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/novasquare/v12/RrQUbo9-9DV7b06QHgSWsZhARYMgGtWA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -46775,7 +48795,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/numans/v9/SlGRmQmGupYAfH8IYRggiHVqaQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/numans/v9/SlGRmQmGupYAfH8IYRggiHVqaQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -46844,20 +48865,34 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/nunito/v12/XRXW3I6Li01BKofA-sekZuHJeTsfDQ.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/nunito/v12/XRXQ3I6Li01BKofIMN5MZ-vNWz4PDWtj.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/nunito/v12/XRXW3I6Li01BKofAnsSkZuHJeTsfDQ.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/nunito/v12/XRXQ3I6Li01BKofIMN4oZOvNWz4PDWtj.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/nunito/v12/XRXV3I6Li01BKof4MuyAbsrVcA.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/nunito/v12/XRXX3I6Li01BKofIMOaETM_FcCIG.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/nunito/v12/XRXW3I6Li01BKofA6sKkZuHJeTsfDQ.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/nunito/v12/XRXQ3I6Li01BKofIMN5cYuvNWz4PDWtj.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/nunito/v12/XRXW3I6Li01BKofAjsOkZuHJeTsfDQ.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/nunito/v12/XRXQ3I6Li01BKofIMN44Y-vNWz4PDWtj.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/nunito/v12/XRXW3I6Li01BKofAksCkZuHJeTsfDQ.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/nunito/v12/XRXQ3I6Li01BKofIMN4kYOvNWz4PDWtj.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/nunito/v12/XRXW3I6Li01BKofAtsGkZuHJeTsfDQ.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/nunito/v12/XRXQ3I6Li01BKofIMN4AYevNWz4PDWtj.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXW3I6Li01BKofA-sekZuHJeTsfDQ.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXQ3I6Li01BKofIMN5MZ-vNWz4PDWtj.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXW3I6Li01BKofAnsSkZuHJeTsfDQ.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXQ3I6Li01BKofIMN4oZOvNWz4PDWtj.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXV3I6Li01BKof4MuyAbsrVcA.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXX3I6Li01BKofIMOaETM_FcCIG.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXW3I6Li01BKofA6sKkZuHJeTsfDQ.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXQ3I6Li01BKofIMN5cYuvNWz4PDWtj.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXW3I6Li01BKofAjsOkZuHJeTsfDQ.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXQ3I6Li01BKofIMN44Y-vNWz4PDWtj.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXW3I6Li01BKofAksCkZuHJeTsfDQ.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXQ3I6Li01BKofIMN4kYOvNWz4PDWtj.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXW3I6Li01BKofAtsGkZuHJeTsfDQ.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/nunito/v12/XRXQ3I6Li01BKofIMN4AYevNWz4PDWtj.ttf',
     };
 
     return googleFontsTextStyle(
@@ -46926,20 +48961,34 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc9yAv5qWVAgVol-.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe01MImSLYBIv1o4X1M8cce4GxZrU1QCU5l-06Y.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8WAf5qWVAgVol-.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe01MImSLYBIv1o4X1M8cce4G3JoU1QCU5l-06Y.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe0qMImSLYBIv1o4X1M8cfe6Kdpickwp.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe0oMImSLYBIv1o4X1M8cce4I95Ad1wpT5A.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc9iB_5qWVAgVol-.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe01MImSLYBIv1o4X1M8cce4GwZuU1QCU5l-06Y.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8GBv5qWVAgVol-.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe01MImSLYBIv1o4X1M8cce4G2JvU1QCU5l-06Y.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8aBf5qWVAgVol-.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe01MImSLYBIv1o4X1M8cce4G35sU1QCU5l-06Y.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8-BP5qWVAgVol-.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/nunitosans/v5/pe01MImSLYBIv1o4X1M8cce4G1ptU1QCU5l-06Y.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc9yAv5qWVAgVol-.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe01MImSLYBIv1o4X1M8cce4GxZrU1QCU5l-06Y.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8WAf5qWVAgVol-.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe01MImSLYBIv1o4X1M8cce4G3JoU1QCU5l-06Y.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe0qMImSLYBIv1o4X1M8cfe6Kdpickwp.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe0oMImSLYBIv1o4X1M8cce4I95Ad1wpT5A.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc9iB_5qWVAgVol-.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe01MImSLYBIv1o4X1M8cce4GwZuU1QCU5l-06Y.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8GBv5qWVAgVol-.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe01MImSLYBIv1o4X1M8cce4G2JvU1QCU5l-06Y.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8aBf5qWVAgVol-.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe01MImSLYBIv1o4X1M8cce4G35sU1QCU5l-06Y.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8-BP5qWVAgVol-.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/nunitosans/v5/pe01MImSLYBIv1o4X1M8cce4G1ptU1QCU5l-06Y.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47008,7 +49057,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/odibeesans/v1/neIPzCSooYAho6WvjeToRYkyepH9qGsf.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/odibeesans/v1/neIPzCSooYAho6WvjeToRYkyepH9qGsf.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47077,7 +49127,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/odormeanchey/v11/raxkHiKDttkTe1aOGcJMR1A_4mrY2zqUKafv.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/odormeanchey/v11/raxkHiKDttkTe1aOGcJMR1A_4mrY2zqUKafv.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47146,7 +49197,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/offside/v7/HI_KiYMWKa9QrAykQ5HiRp-dhpQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/offside/v7/HI_KiYMWKa9QrAykQ5HiRp-dhpQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47215,9 +49267,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/oldstandardtt/v12/MwQubh3o1vLImiwAVvYawgcf2eVurVC5RHdCZg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/oldstandardtt/v12/MwQsbh3o1vLImiwAVvYawgcf2eVer1q9ZnJSZtQG.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/oldstandardtt/v12/MwQrbh3o1vLImiwAVvYawgcf2eVWEX-dTFxeb80flQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/oldstandardtt/v12/MwQubh3o1vLImiwAVvYawgcf2eVurVC5RHdCZg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/oldstandardtt/v12/MwQsbh3o1vLImiwAVvYawgcf2eVer1q9ZnJSZtQG.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/oldstandardtt/v12/MwQrbh3o1vLImiwAVvYawgcf2eVWEX-dTFxeb80flQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47286,7 +49341,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/oldenburg/v7/fC1jPY5JYWzbywv7c4V6UU6oXyndrw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/oldenburg/v7/fC1jPY5JYWzbywv7c4V6UU6oXyndrw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47355,8 +49411,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/oleoscript/v8/rax5HieDvtMOe0iICsUccBhasU7Q8Cad.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/oleoscript/v8/raxkHieDvtMOe0iICsUccCDmnmrY2zqUKafv.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/oleoscript/v8/rax5HieDvtMOe0iICsUccBhasU7Q8Cad.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/oleoscript/v8/raxkHieDvtMOe0iICsUccCDmnmrY2zqUKafv.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47425,8 +49483,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/oleoscriptswashcaps/v7/Noaj6Vb-w5SFbTTAsZP_7JkCS08K-jCzDn_HMXquSY0Hg90.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/oleoscriptswashcaps/v7/Noag6Vb-w5SFbTTAsZP_7JkCS08K-jCzDn_HCcaBbYUsn9T5dt0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/oleoscriptswashcaps/v7/Noaj6Vb-w5SFbTTAsZP_7JkCS08K-jCzDn_HMXquSY0Hg90.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/oleoscriptswashcaps/v7/Noag6Vb-w5SFbTTAsZP_7JkCS08K-jCzDn_HCcaBbYUsn9T5dt0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47495,16 +49555,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN_r8-VeJoCqeDjg.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/opensans/v17/memnYaGs126MiZpBA-UFUKWyV-hsKKKTjrPW.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-U1UpcaXcl0Aw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/opensans/v17/mem6YaGs126MiZpBA-UFUJ0ef8xkA76a.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UNirk-VeJoCqeDjg.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/opensans/v17/memnYaGs126MiZpBA-UFUKXGUehsKKKTjrPW.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rg-VeJoCqeDjg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/opensans/v17/memnYaGs126MiZpBA-UFUKWiUOhsKKKTjrPW.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN8rs-VeJoCqeDjg.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/opensans/v17/memnYaGs126MiZpBA-UFUKW-U-hsKKKTjrPW.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN_r8-VeJoCqeDjg.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/opensans/v17/memnYaGs126MiZpBA-UFUKWyV-hsKKKTjrPW.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-U1UpcaXcl0Aw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/opensans/v17/mem6YaGs126MiZpBA-UFUJ0ef8xkA76a.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UNirk-VeJoCqeDjg.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/opensans/v17/memnYaGs126MiZpBA-UFUKXGUehsKKKTjrPW.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rg-VeJoCqeDjg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/opensans/v17/memnYaGs126MiZpBA-UFUKWiUOhsKKKTjrPW.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN8rs-VeJoCqeDjg.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/opensans/v17/memnYaGs126MiZpBA-UFUKW-U-hsKKKTjrPW.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47573,9 +49643,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/opensanscondensed/v14/z7NFdQDnbTkabZAIOl9il_O6KJj73e7Ff1GhPuLGRpWRyAs.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/opensanscondensed/v14/z7NHdQDnbTkabZAIOl9il_O6KJj73e7Fd_-7suDMQreU2AsJSg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/opensanscondensed/v14/z7NFdQDnbTkabZAIOl9il_O6KJj73e7Ff0GmPuLGRpWRyAs.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/opensanscondensed/v14/z7NFdQDnbTkabZAIOl9il_O6KJj73e7Ff1GhPuLGRpWRyAs.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/opensanscondensed/v14/z7NHdQDnbTkabZAIOl9il_O6KJj73e7Fd_-7suDMQreU2AsJSg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/opensanscondensed/v14/z7NFdQDnbTkabZAIOl9il_O6KJj73e7Ff0GmPuLGRpWRyAs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47644,7 +49717,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/oranienbaum/v8/OZpHg_txtzZKMuXLIVrx-3zn7kz3dpHc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/oranienbaum/v8/OZpHg_txtzZKMuXLIVrx-3zn7kz3dpHc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47713,12 +49787,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/orbitron/v14/yMJMMIlzdpvBhQQL_SC3X9yhF25-T1nyGy6xpmIyXjU1pg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/orbitron/v14/yMJMMIlzdpvBhQQL_SC3X9yhF25-T1nyKS6xpmIyXjU1pg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/orbitron/v14/yMJMMIlzdpvBhQQL_SC3X9yhF25-T1nyxSmxpmIyXjU1pg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/orbitron/v14/yMJMMIlzdpvBhQQL_SC3X9yhF25-T1ny_CmxpmIyXjU1pg.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/orbitron/v14/yMJMMIlzdpvBhQQL_SC3X9yhF25-T1nymymxpmIyXjU1pg.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/orbitron/v14/yMJMMIlzdpvBhQQL_SC3X9yhF25-T1nysimxpmIyXjU1pg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/orbitron/v14/yMJMMIlzdpvBhQQL_SC3X9yhF25-T1nyGy6xpmIyXjU1pg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/orbitron/v14/yMJMMIlzdpvBhQQL_SC3X9yhF25-T1nyKS6xpmIyXjU1pg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/orbitron/v14/yMJMMIlzdpvBhQQL_SC3X9yhF25-T1nyxSmxpmIyXjU1pg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/orbitron/v14/yMJMMIlzdpvBhQQL_SC3X9yhF25-T1ny_CmxpmIyXjU1pg.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/orbitron/v14/yMJMMIlzdpvBhQQL_SC3X9yhF25-T1nymymxpmIyXjU1pg.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/orbitron/v14/yMJMMIlzdpvBhQQL_SC3X9yhF25-T1nysimxpmIyXjU1pg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47787,8 +49867,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/oregano/v7/If2IXTPxciS3H4S2kZffPznO3yM.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/oregano/v7/If2KXTPxciS3H4S2oZXVOxvLzyP_qw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/oregano/v7/If2IXTPxciS3H4S2kZffPznO3yM.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/oregano/v7/If2KXTPxciS3H4S2oZXVOxvLzyP_qw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47857,7 +49939,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/orienta/v7/PlI9FlK4Jrl5Y9zNeyeo9HRFhcU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/orienta/v7/PlI9FlK4Jrl5Y9zNeyeo9HRFhcU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47926,7 +50009,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/originalsurfer/v8/RWmQoKGZ9vIirYntXJ3_MbekzNMiDEtvAlaMKw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/originalsurfer/v8/RWmQoKGZ9vIirYntXJ3_MbekzNMiDEtvAlaMKw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -47995,12 +50079,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/oswald/v29/TK3_WkUHHAIjg75cFRf3bXL8LICs13FvgUFoZAaRliE.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/oswald/v29/TK3_WkUHHAIjg75cFRf3bXL8LICs169vgUFoZAaRliE.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/oswald/v29/TK3_WkUHHAIjg75cFRf3bXL8LICs1_FvgUFoZAaRliE.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/oswald/v29/TK3_WkUHHAIjg75cFRf3bXL8LICs18NvgUFoZAaRliE.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/oswald/v29/TK3_WkUHHAIjg75cFRf3bXL8LICs1y9ogUFoZAaRliE.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/oswald/v29/TK3_WkUHHAIjg75cFRf3bXL8LICs1xZogUFoZAaRliE.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/oswald/v29/TK3_WkUHHAIjg75cFRf3bXL8LICs13FvgUFoZAaRliE.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/oswald/v29/TK3_WkUHHAIjg75cFRf3bXL8LICs169vgUFoZAaRliE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/oswald/v29/TK3_WkUHHAIjg75cFRf3bXL8LICs1_FvgUFoZAaRliE.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/oswald/v29/TK3_WkUHHAIjg75cFRf3bXL8LICs18NvgUFoZAaRliE.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/oswald/v29/TK3_WkUHHAIjg75cFRf3bXL8LICs1y9ogUFoZAaRliE.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/oswald/v29/TK3_WkUHHAIjg75cFRf3bXL8LICs1xZogUFoZAaRliE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48069,7 +50159,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/overtherainbow/v10/11haGoXG1k_HKhMLUWz7Mc7vvW5upvOm9NA2XG0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/overtherainbow/v10/11haGoXG1k_HKhMLUWz7Mc7vvW5upvOm9NA2XG0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48138,12 +50229,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/overlock/v9/Z9XVDmdMWRiN1_T9Z4Te4u2El6GC.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/overlock/v9/Z9XTDmdMWRiN1_T9Z7Tc6OmmkrGC7Cs.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/overlock/v9/Z9XSDmdMWRiN1_T9Z7xizcmMvL2L9TLT.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/overlock/v9/Z9XQDmdMWRiN1_T9Z7Tc0FWJtrmp8CLTlNs.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/overlock/v9/Z9XSDmdMWRiN1_T9Z7xaz8mMvL2L9TLT.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/overlock/v9/Z9XQDmdMWRiN1_T9Z7Tc0G2Ltrmp8CLTlNs.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/overlock/v9/Z9XVDmdMWRiN1_T9Z4Te4u2El6GC.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/overlock/v9/Z9XTDmdMWRiN1_T9Z7Tc6OmmkrGC7Cs.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/overlock/v9/Z9XSDmdMWRiN1_T9Z7xizcmMvL2L9TLT.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/overlock/v9/Z9XQDmdMWRiN1_T9Z7Tc0FWJtrmp8CLTlNs.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/overlock/v9/Z9XSDmdMWRiN1_T9Z7xaz8mMvL2L9TLT.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/overlock/v9/Z9XQDmdMWRiN1_T9Z7Tc0G2Ltrmp8CLTlNs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48212,7 +50309,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/overlocksc/v8/1cX3aUHKGZrstGAY8nwVzHGAq8Sk1PoH.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/overlocksc/v8/1cX3aUHKGZrstGAY8nwVzHGAq8Sk1PoH.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48281,22 +50379,38 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/overpass/v4/qFdB35WCmI96Ajtm81nGU97gxhcJk1s.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/overpass/v4/qFdD35WCmI96Ajtm81Gga7rqwjUMg1siNQ.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/overpass/v4/qFdA35WCmI96Ajtm81lqcv7K6BsAikI7.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/overpass/v4/qFdC35WCmI96Ajtm81GgaxbL4h8ij1I7LLE.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/overpass/v4/qFdA35WCmI96Ajtm81kOcf7K6BsAikI7.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/overpass/v4/qFdC35WCmI96Ajtm81Gga3LI4h8ij1I7LLE.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/overpass/v4/qFdH35WCmI96Ajtm82GiWdrCwwcJ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/overpass/v4/qFdB35WCmI96Ajtm81GgU97gxhcJk1s.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/overpass/v4/qFdA35WCmI96Ajtm81l6d_7K6BsAikI7.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/overpass/v4/qFdC35WCmI96Ajtm81GgawbO4h8ij1I7LLE.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/overpass/v4/qFdA35WCmI96Ajtm81kedv7K6BsAikI7.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/overpass/v4/qFdC35WCmI96Ajtm81Gga2LP4h8ij1I7LLE.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/overpass/v4/qFdA35WCmI96Ajtm81kCdf7K6BsAikI7.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/overpass/v4/qFdC35WCmI96Ajtm81Gga37M4h8ij1I7LLE.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/overpass/v4/qFdA35WCmI96Ajtm81kmdP7K6BsAikI7.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/overpass/v4/qFdC35WCmI96Ajtm81Gga1rN4h8ij1I7LLE.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdB35WCmI96Ajtm81nGU97gxhcJk1s.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdD35WCmI96Ajtm81Gga7rqwjUMg1siNQ.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdA35WCmI96Ajtm81lqcv7K6BsAikI7.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdC35WCmI96Ajtm81GgaxbL4h8ij1I7LLE.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdA35WCmI96Ajtm81kOcf7K6BsAikI7.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdC35WCmI96Ajtm81Gga3LI4h8ij1I7LLE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdH35WCmI96Ajtm82GiWdrCwwcJ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdB35WCmI96Ajtm81GgU97gxhcJk1s.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdA35WCmI96Ajtm81l6d_7K6BsAikI7.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdC35WCmI96Ajtm81GgawbO4h8ij1I7LLE.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdA35WCmI96Ajtm81kedv7K6BsAikI7.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdC35WCmI96Ajtm81Gga2LP4h8ij1I7LLE.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdA35WCmI96Ajtm81kCdf7K6BsAikI7.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdC35WCmI96Ajtm81Gga37M4h8ij1I7LLE.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdA35WCmI96Ajtm81kmdP7K6BsAikI7.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/overpass/v4/qFdC35WCmI96Ajtm81Gga1rN4h8ij1I7LLE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48365,10 +50479,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/overpassmono/v5/_Xm3-H86tzKDdAPa-KPQZ-AC3oSWk_edB3Zf8EQ.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/overpassmono/v5/_Xmq-H86tzKDdAPa-KPQZ-AC5ii-t_-2G38.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/overpassmono/v5/_Xm3-H86tzKDdAPa-KPQZ-AC3vCQk_edB3Zf8EQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/overpassmono/v5/_Xm3-H86tzKDdAPa-KPQZ-AC3pSRk_edB3Zf8EQ.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/overpassmono/v5/_Xm3-H86tzKDdAPa-KPQZ-AC3oSWk_edB3Zf8EQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/overpassmono/v5/_Xmq-H86tzKDdAPa-KPQZ-AC5ii-t_-2G38.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/overpassmono/v5/_Xm3-H86tzKDdAPa-KPQZ-AC3vCQk_edB3Zf8EQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/overpassmono/v5/_Xm3-H86tzKDdAPa-KPQZ-AC3pSRk_edB3Zf8EQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48437,7 +50555,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ovo/v11/yYLl0h7Wyfzjy4Q5_3WVxA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ovo/v11/yYLl0h7Wyfzjy4Q5_3WVxA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48506,9 +50625,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/oxygen/v9/2sDcZG1Wl4LcnbuCJW8Db2-4C7wFZQ.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/oxygen/v9/2sDfZG1Wl4Lcnbu6iUcnZ0SkAg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/oxygen/v9/2sDcZG1Wl4LcnbuCNWgDb2-4C7wFZQ.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/oxygen/v9/2sDcZG1Wl4LcnbuCJW8Db2-4C7wFZQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/oxygen/v9/2sDfZG1Wl4Lcnbu6iUcnZ0SkAg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/oxygen/v9/2sDcZG1Wl4LcnbuCNWgDb2-4C7wFZQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48577,7 +50699,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/oxygenmono/v7/h0GsssGg9FxgDgCjLeAd7ijfze-PPlUu.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/oxygenmono/v7/h0GsssGg9FxgDgCjLeAd7ijfze-PPlUu.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48646,7 +50769,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ptmono/v7/9oRONYoBnWILk-9ArCg5MtPyAcg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ptmono/v7/9oRONYoBnWILk-9ArCg5MtPyAcg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48715,10 +50839,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ptsans/v11/jizaRExUiTo99u79P0WOxOGMMDQ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/ptsans/v11/jizYRExUiTo99u79D0eEwMOJIDQA-g.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ptsans/v11/jizfRExUiTo99u79B_mh4OmnLD0Z4zM.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/ptsans/v11/jizdRExUiTo99u79D0e8fOytKB8c8zMrig.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ptsans/v11/jizaRExUiTo99u79P0WOxOGMMDQ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/ptsans/v11/jizYRExUiTo99u79D0eEwMOJIDQA-g.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ptsans/v11/jizfRExUiTo99u79B_mh4OmnLD0Z4zM.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/ptsans/v11/jizdRExUiTo99u79D0e8fOytKB8c8zMrig.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48787,8 +50915,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ptsanscaption/v12/0FlMVP6Hrxmt7-fsUFhlFXNIlpcqfQXwQy6yxg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ptsanscaption/v12/0FlJVP6Hrxmt7-fsUFhlFXNIlpcSwSrUSwWuz38Tgg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ptsanscaption/v12/0FlMVP6Hrxmt7-fsUFhlFXNIlpcqfQXwQy6yxg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ptsanscaption/v12/0FlJVP6Hrxmt7-fsUFhlFXNIlpcSwSrUSwWuz38Tgg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48857,8 +50987,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ptsansnarrow/v11/BngRUXNadjH0qYEzV7ab-oWlsYCByxyKeuDp.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ptsansnarrow/v11/BngSUXNadjH0qYEzV7ab-oWlsbg95DiCUfzgRd-3.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ptsansnarrow/v11/BngRUXNadjH0qYEzV7ab-oWlsYCByxyKeuDp.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ptsansnarrow/v11/BngSUXNadjH0qYEzV7ab-oWlsbg95DiCUfzgRd-3.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48927,10 +51059,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ptserif/v11/EJRVQgYoZZY2vCFuvDFRxL6ddjb-.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/ptserif/v11/EJRTQgYoZZY2vCFuvAFTzrq_cyb-vco.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ptserif/v11/EJRSQgYoZZY2vCFuvAnt65qVXSr3pNNB.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/ptserif/v11/EJRQQgYoZZY2vCFuvAFT9gaQVy7VocNB6Iw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ptserif/v11/EJRVQgYoZZY2vCFuvDFRxL6ddjb-.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/ptserif/v11/EJRTQgYoZZY2vCFuvAFTzrq_cyb-vco.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ptserif/v11/EJRSQgYoZZY2vCFuvAnt65qVXSr3pNNB.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/ptserif/v11/EJRQQgYoZZY2vCFuvAFT9gaQVy7VocNB6Iw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -48999,8 +51135,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ptserifcaption/v11/ieVl2ZhbGCW-JoW6S34pSDpqYKU059WxDCs5cvI.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/ptserifcaption/v11/ieVj2ZhbGCW-JoW6S34pSDpqYKU019e7CAk8YvJEeg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ptserifcaption/v11/ieVl2ZhbGCW-JoW6S34pSDpqYKU059WxDCs5cvI.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/ptserifcaption/v11/ieVj2ZhbGCW-JoW6S34pSDpqYKU019e7CAk8YvJEeg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49069,7 +51207,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/pacifico/v16/FwZY7-Qmy14u9lezJ96A4sijpFu_.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/pacifico/v16/FwZY7-Qmy14u9lezJ96A4sijpFu_.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49138,8 +51277,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/padauk/v6/RrQRboJg-id7OnbBa0_g3LlYbg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/padauk/v6/RrQSboJg-id7Onb512DE1JJEZ4YwGg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/padauk/v6/RrQRboJg-id7OnbBa0_g3LlYbg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/padauk/v6/RrQSboJg-id7Onb512DE1JJEZ4YwGg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49208,13 +51349,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/palanquin/v5/9XUhlJ90n1fBFg7ceXwUEltI7rWmZzTH.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/palanquin/v5/9XUilJ90n1fBFg7ceXwUvnpoxJuqbi3ezg.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/palanquin/v5/9XUilJ90n1fBFg7ceXwU2nloxJuqbi3ezg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/palanquin/v5/9XUnlJ90n1fBFg7ceXwsdlFMzLC2Zw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/palanquin/v5/9XUilJ90n1fBFg7ceXwUgnhoxJuqbi3ezg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/palanquin/v5/9XUilJ90n1fBFg7ceXwUrn9oxJuqbi3ezg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/palanquin/v5/9XUilJ90n1fBFg7ceXwUyn5oxJuqbi3ezg.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/palanquin/v5/9XUhlJ90n1fBFg7ceXwUEltI7rWmZzTH.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/palanquin/v5/9XUilJ90n1fBFg7ceXwUvnpoxJuqbi3ezg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/palanquin/v5/9XUilJ90n1fBFg7ceXwU2nloxJuqbi3ezg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/palanquin/v5/9XUnlJ90n1fBFg7ceXwsdlFMzLC2Zw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/palanquin/v5/9XUilJ90n1fBFg7ceXwUgnhoxJuqbi3ezg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/palanquin/v5/9XUilJ90n1fBFg7ceXwUrn9oxJuqbi3ezg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/palanquin/v5/9XUilJ90n1fBFg7ceXwUyn5oxJuqbi3ezg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49283,10 +51431,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/palanquindark/v6/xn75YHgl1nqmANMB-26xC7yuF_6OTEo9VtfE.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/palanquindark/v6/xn76YHgl1nqmANMB-26xC7yuF8Z6ZW41fcvN2KT4.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/palanquindark/v6/xn76YHgl1nqmANMB-26xC7yuF8ZWYm41fcvN2KT4.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/palanquindark/v6/xn76YHgl1nqmANMB-26xC7yuF8YyY241fcvN2KT4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/palanquindark/v6/xn75YHgl1nqmANMB-26xC7yuF_6OTEo9VtfE.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/palanquindark/v6/xn76YHgl1nqmANMB-26xC7yuF8Z6ZW41fcvN2KT4.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/palanquindark/v6/xn76YHgl1nqmANMB-26xC7yuF8ZWYm41fcvN2KT4.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/palanquindark/v6/xn76YHgl1nqmANMB-26xC7yuF8YyY241fcvN2KT4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49355,7 +51507,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/pangolin/v5/cY9GfjGcW0FPpi-tWPfK5d3aiLBG.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/pangolin/v5/cY9GfjGcW0FPpi-tWPfK5d3aiLBG.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49424,7 +51577,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/paprika/v7/8QIJdijZitv49rDfuIgOq7jkAOw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/paprika/v7/8QIJdijZitv49rDfuIgOq7jkAOw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49493,7 +51647,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/parisienne/v7/E21i_d3kivvAkxhLEVZpcy96DuKuavM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/parisienne/v7/E21i_d3kivvAkxhLEVZpcy96DuKuavM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49562,7 +51717,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/passeroone/v11/JTUTjIko8DOq5FeaeEAjgE5B5Arr-s50.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/passeroone/v11/JTUTjIko8DOq5FeaeEAjgE5B5Arr-s50.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49631,9 +51787,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/passionone/v10/PbynFmL8HhTPqbjUzux3JHuW_Frg6YoV.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/passionone/v10/Pby6FmL8HhTPqbjUzux3JEMq037owpYcuH8y.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/passionone/v10/Pby6FmL8HhTPqbjUzux3JEMS0X7owpYcuH8y.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/passionone/v10/PbynFmL8HhTPqbjUzux3JHuW_Frg6YoV.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/passionone/v10/Pby6FmL8HhTPqbjUzux3JEMq037owpYcuH8y.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/passionone/v10/Pby6FmL8HhTPqbjUzux3JEMS0X7owpYcuH8y.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49702,7 +51861,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/pathwaygothicone/v8/MwQrbgD32-KAvjkYGNUUxAtW7pEBwx-dTFxeb80flQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/pathwaygothicone/v8/MwQrbgD32-KAvjkYGNUUxAtW7pEBwx-dTFxeb80flQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49771,7 +51931,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/patrickhand/v13/LDI1apSQOAYtSuYWp8ZhfYeMWcjKm7sp8g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/patrickhand/v13/LDI1apSQOAYtSuYWp8ZhfYeMWcjKm7sp8g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49840,7 +52001,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/patrickhandsc/v7/0nkwC9f7MfsBiWcLtY65AWDK873ViSi6JQc7Vg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/patrickhandsc/v7/0nkwC9f7MfsBiWcLtY65AWDK873ViSi6JQc7Vg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49909,7 +52071,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/pattaya/v5/ea8ZadcqV_zkHY-XNdCn92ZEmVs.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/pattaya/v5/ea8ZadcqV_zkHY-XNdCn92ZEmVs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -49978,7 +52141,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/patuaone/v10/ZXuke1cDvLCKLDcimxBI5PNvNA9LuA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/patuaone/v10/ZXuke1cDvLCKLDcimxBI5PNvNA9LuA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50047,7 +52211,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/pavanam/v4/BXRrvF_aiezLh0xPDOtQ9Wf0QcE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/pavanam/v4/BXRrvF_aiezLh0xPDOtQ9Wf0QcE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50116,7 +52281,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/paytoneone/v12/0nksC9P7MfYHj2oFtYm2CiTqivr9iBq_.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/paytoneone/v12/0nksC9P7MfYHj2oFtYm2CiTqivr9iBq_.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50185,7 +52351,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/peddana/v7/aFTU7PBhaX89UcKWhh2aBYyMcKw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/peddana/v7/aFTU7PBhaX89UcKWhh2aBYyMcKw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50254,7 +52421,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/peralta/v7/hYkJPu0-RP_9d3kRGxAhrv956B8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/peralta/v7/hYkJPu0-RP_9d3kRGxAhrv956B8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50323,7 +52491,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/permanentmarker/v9/Fh4uPib9Iyv2ucM6pGQMWimMp004HaqIfrT5nlk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/permanentmarker/v9/Fh4uPib9Iyv2ucM6pGQMWimMp004HaqIfrT5nlk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50392,7 +52561,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/petitformalscript/v7/B50TF6xQr2TXJBnGOFME6u5OR83oRP5qoHnqP4gZSiE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/petitformalscript/v7/B50TF6xQr2TXJBnGOFME6u5OR83oRP5qoHnqP4gZSiE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50461,7 +52631,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/petrona/v8/mtG64_NXL7bZo9XXsXVStGsRwCU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/petrona/v8/mtG64_NXL7bZo9XXsXVStGsRwCU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50530,10 +52701,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/philosopher/v11/vEFV2_5QCwIS4_Dhez5jcVBpRUwU08qe.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/philosopher/v11/vEFX2_5QCwIS4_Dhez5jcWBrT0g21tqeR7c.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/philosopher/v11/vEFI2_5QCwIS4_Dhez5jcWjVamgc-NaXXq7H.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/philosopher/v11/vEFK2_5QCwIS4_Dhez5jcWBrd_QZ8tK1W77HtMo.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/philosopher/v11/vEFV2_5QCwIS4_Dhez5jcVBpRUwU08qe.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/philosopher/v11/vEFX2_5QCwIS4_Dhez5jcWBrT0g21tqeR7c.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/philosopher/v11/vEFI2_5QCwIS4_Dhez5jcWjVamgc-NaXXq7H.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/philosopher/v11/vEFK2_5QCwIS4_Dhez5jcWBrd_QZ8tK1W77HtMo.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50602,7 +52777,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/piedra/v8/ke8kOg8aN0Bn7hTunEyHN_M3gA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/piedra/v8/ke8kOg8aN0Bn7hTunEyHN_M3gA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50671,7 +52847,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/pinyonscript/v9/6xKpdSJbL9-e9LuoeQiDRQR8aOLQO4bhiDY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/pinyonscript/v9/6xKpdSJbL9-e9LuoeQiDRQR8aOLQO4bhiDY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50740,7 +52917,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/pirataone/v8/I_urMpiDvgLdLh0fAtoftiiEr5_BdZ8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/pirataone/v8/I_urMpiDvgLdLh0fAtoftiiEr5_BdZ8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50809,7 +52987,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/plaster/v11/DdTm79QatW80eRh4Ei5JOtLOeLI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/plaster/v11/DdTm79QatW80eRh4Ei5JOtLOeLI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50878,8 +53057,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/play/v11/6aez4K2oVqwIjtI8Hp8Tx3A.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/play/v11/6ae84K2oVqwItm4TOpc423nTJTM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/play/v11/6aez4K2oVqwIjtI8Hp8Tx3A.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/play/v11/6ae84K2oVqwItm4TOpc423nTJTM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -50948,7 +53129,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/playball/v9/TK3gWksYAxQ7jbsKcj8Dl-tPKo2t.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/playball/v9/TK3gWksYAxQ7jbsKcj8Dl-tPKo2t.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51017,12 +53199,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/playfairdisplay/v18/nuFiD-vYSZviVYUb_rj3ij__anPXPTvSgWE_-xU.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/playfairdisplay/v18/nuFkD-vYSZviVYUb_rj3ij__anPXDTnYhUM66xV7PQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/playfairdisplay/v18/nuFlD-vYSZviVYUb_rj3ij__anPXBYf9pWkU5xxiJKY.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/playfairdisplay/v18/nuFnD-vYSZviVYUb_rj3ij__anPXDTngOWwe4z5nNKaV_w.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/playfairdisplay/v18/nuFlD-vYSZviVYUb_rj3ij__anPXBb__pWkU5xxiJKY.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/playfairdisplay/v18/nuFnD-vYSZviVYUb_rj3ij__anPXDTngAW4e4z5nNKaV_w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/playfairdisplay/v18/nuFiD-vYSZviVYUb_rj3ij__anPXPTvSgWE_-xU.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/playfairdisplay/v18/nuFkD-vYSZviVYUb_rj3ij__anPXDTnYhUM66xV7PQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/playfairdisplay/v18/nuFlD-vYSZviVYUb_rj3ij__anPXBYf9pWkU5xxiJKY.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/playfairdisplay/v18/nuFnD-vYSZviVYUb_rj3ij__anPXDTngOWwe4z5nNKaV_w.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/playfairdisplay/v18/nuFlD-vYSZviVYUb_rj3ij__anPXBb__pWkU5xxiJKY.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/playfairdisplay/v18/nuFnD-vYSZviVYUb_rj3ij__anPXDTngAW4e4z5nNKaV_w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51091,12 +53279,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/playfairdisplaysc/v9/ke85OhoaMkR6-hSn7kbHVoFf7ZfgMPr_pb4GEcM2M4s.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/playfairdisplaysc/v9/ke87OhoaMkR6-hSn7kbHVoFf7ZfgMPr_lbwMFeEzI4sNKg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/playfairdisplaysc/v9/ke80OhoaMkR6-hSn7kbHVoFf7ZfgMPr_nQIpNcsdL4IUMyE.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/playfairdisplaysc/v9/ke82OhoaMkR6-hSn7kbHVoFf7ZfgMPr_lbw0qc4XK6ARIyH5IA.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/playfairdisplaysc/v9/ke80OhoaMkR6-hSn7kbHVoFf7ZfgMPr_nTorNcsdL4IUMyE.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/playfairdisplaysc/v9/ke82OhoaMkR6-hSn7kbHVoFf7ZfgMPr_lbw0kcwXK6ARIyH5IA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/playfairdisplaysc/v9/ke85OhoaMkR6-hSn7kbHVoFf7ZfgMPr_pb4GEcM2M4s.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/playfairdisplaysc/v9/ke87OhoaMkR6-hSn7kbHVoFf7ZfgMPr_lbwMFeEzI4sNKg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/playfairdisplaysc/v9/ke80OhoaMkR6-hSn7kbHVoFf7ZfgMPr_nQIpNcsdL4IUMyE.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/playfairdisplaysc/v9/ke82OhoaMkR6-hSn7kbHVoFf7ZfgMPr_lbw0qc4XK6ARIyH5IA.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/playfairdisplaysc/v9/ke80OhoaMkR6-hSn7kbHVoFf7ZfgMPr_nTorNcsdL4IUMyE.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/playfairdisplaysc/v9/ke82OhoaMkR6-hSn7kbHVoFf7ZfgMPr_lbw0kcwXK6ARIyH5IA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51165,11 +53359,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/podkova/v15/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWtFzcU4EoporSHH.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/podkova/v15/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWt3zcU4EoporSHH.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/podkova/v15/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWubysU4EoporSHH.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/podkova/v15/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWuiysU4EoporSHH.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/podkova/v15/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWvFysU4EoporSHH.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/podkova/v15/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWtFzcU4EoporSHH.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/podkova/v15/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWt3zcU4EoporSHH.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/podkova/v15/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWubysU4EoporSHH.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/podkova/v15/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWuiysU4EoporSHH.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/podkova/v15/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWvFysU4EoporSHH.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51238,7 +53437,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/poiretone/v8/UqyVK80NJXN4zfRgbdfbk5lWVscxdKE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/poiretone/v8/UqyVK80NJXN4zfRgbdfbk5lWVscxdKE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51307,7 +53507,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/pollerone/v9/ahccv82n0TN3gia5E4Bud-lbgUS5u0s.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/pollerone/v9/ahccv82n0TN3gia5E4Bud-lbgUS5u0s.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51376,8 +53577,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/poly/v10/MQpb-W6wKNitRLCAq2Lpris.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/poly/v10/MQpV-W6wKNitdLKKr0DsviuGWA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/poly/v10/MQpb-W6wKNitRLCAq2Lpris.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/poly/v10/MQpV-W6wKNitdLKKr0DsviuGWA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51446,7 +53649,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/pompiere/v9/VEMyRoxis5Dwuyeov6Wt5jDtreOL.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/pompiere/v9/VEMyRoxis5Dwuyeov6Wt5jDtreOL.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51515,7 +53719,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/pontanosans/v7/qFdD35GdgYR8EzR6oBLDHa3qwjUMg1siNQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/pontanosans/v7/qFdD35GdgYR8EzR6oBLDHa3qwjUMg1siNQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51584,7 +53789,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/poorstory/v8/jizfREFUsnUct9P6cDfd4OmnLD0Z4zM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/poorstory/v8/jizfREFUsnUct9P6cDfd4OmnLD0Z4zM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51653,24 +53859,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/poppins/v9/pxiGyp8kv8JHgFVrLPTed3FBGPaTSQ.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/poppins/v9/pxiAyp8kv8JHgFVrJJLmE3tFOvODSVFF.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLFj_V1tvFP-KUEg.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLmv1plEN2PQEhcqw.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLDz8V1tvFP-KUEg.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLm21llEN2PQEhcqw.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/poppins/v9/pxiEyp8kv8JHgFVrFJDUc1NECPY.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/poppins/v9/pxiGyp8kv8JHgFVrJJLed3FBGPaTSQ.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLGT9V1tvFP-KUEg.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLmg1hlEN2PQEhcqw.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLEj6V1tvFP-KUEg.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLmr19lEN2PQEhcqw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLCz7V1tvFP-KUEg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLmy15lEN2PQEhcqw.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLDD4V1tvFP-KUEg.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLm111lEN2PQEhcqw.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLBT5V1tvFP-KUEg.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLm81xlEN2PQEhcqw.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiGyp8kv8JHgFVrLPTed3FBGPaTSQ.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiAyp8kv8JHgFVrJJLmE3tFOvODSVFF.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLFj_V1tvFP-KUEg.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLmv1plEN2PQEhcqw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLDz8V1tvFP-KUEg.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLm21llEN2PQEhcqw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiEyp8kv8JHgFVrFJDUc1NECPY.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiGyp8kv8JHgFVrJJLed3FBGPaTSQ.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLGT9V1tvFP-KUEg.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLmg1hlEN2PQEhcqw.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLEj6V1tvFP-KUEg.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLmr19lEN2PQEhcqw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLCz7V1tvFP-KUEg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLmy15lEN2PQEhcqw.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLDD4V1tvFP-KUEg.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLm111lEN2PQEhcqw.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiByp8kv8JHgFVrLBT5V1tvFP-KUEg.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/poppins/v9/pxiDyp8kv8JHgFVrJJLm81xlEN2PQEhcqw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51739,7 +53963,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/portlligatsans/v8/kmKmZrYrGBbdN1aV7Vokow6Lw4s4l7N0Tx4xEcQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/portlligatsans/v8/kmKmZrYrGBbdN1aV7Vokow6Lw4s4l7N0Tx4xEcQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51808,7 +54033,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/portlligatslab/v8/LDIpaoiQNgArA8kR7ulhZ8P_NYOss7ob9yGLmfI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/portlligatslab/v8/LDIpaoiQNgArA8kR7ulhZ8P_NYOss7ob9yGLmfI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51877,8 +54103,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/pragatinarrow/v5/vm8vdRf0T0bS1ffgsPB7WZ-mD17_ytN3M48a.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/pragatinarrow/v5/vm8sdRf0T0bS1ffgsPB7WZ-mD2ZD5fd_GJMTlo_4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/pragatinarrow/v5/vm8vdRf0T0bS1ffgsPB7WZ-mD17_ytN3M48a.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/pragatinarrow/v5/vm8sdRf0T0bS1ffgsPB7WZ-mD2ZD5fd_GJMTlo_4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -51947,7 +54175,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/prata/v10/6xKhdSpbNNCT-vWIAG_5LWwJ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/prata/v10/6xKhdSpbNNCT-vWIAG_5LWwJ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52016,7 +54245,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/preahvihear/v11/6NUS8F-dNQeEYhzj7uluxswE49FJf8Wv.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/preahvihear/v11/6NUS8F-dNQeEYhzj7uluxswE49FJf8Wv.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52085,7 +54315,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/pressstart2p/v8/e3t4euO8T-267oIAQAu6jDQyK0nSgPJE4580.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/pressstart2p/v8/e3t4euO8T-267oIAQAu6jDQyK0nSgPJE4580.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52154,12 +54385,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/pridi/v5/2sDdZG5JnZLfkc1SiE0jRUG0AqUc.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/pridi/v5/2sDdZG5JnZLfkc02i00jRUG0AqUc.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/pridi/v5/2sDQZG5JnZLfkfWao2krbl29.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/pridi/v5/2sDdZG5JnZLfkc1uik0jRUG0AqUc.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/pridi/v5/2sDdZG5JnZLfkc1CjU0jRUG0AqUc.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/pridi/v5/2sDdZG5JnZLfkc0mjE0jRUG0AqUc.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/pridi/v5/2sDdZG5JnZLfkc1SiE0jRUG0AqUc.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/pridi/v5/2sDdZG5JnZLfkc02i00jRUG0AqUc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/pridi/v5/2sDQZG5JnZLfkfWao2krbl29.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/pridi/v5/2sDdZG5JnZLfkc1uik0jRUG0AqUc.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/pridi/v5/2sDdZG5JnZLfkc1CjU0jRUG0AqUc.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/pridi/v5/2sDdZG5JnZLfkc0mjE0jRUG0AqUc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52228,7 +54465,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/princesssofia/v8/qWczB6yguIb8DZ_GXZst16n7GRz7mDUoupoI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/princesssofia/v8/qWczB6yguIb8DZ_GXZst16n7GRz7mDUoupoI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52297,7 +54535,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/prociono/v9/r05YGLlR-KxAf9GGO8upyDYtStiJ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/prociono/v9/r05YGLlR-KxAf9GGO8upyDYtStiJ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52366,24 +54605,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/prompt/v4/-W_9XJnvUD7dzB2CA9oYREcjeo0k.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/prompt/v4/-W_7XJnvUD7dzB2KZeJ8TkMBf50kbiM.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2Cr_s4bmkvc5Q9dw.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeLQb2MrUZEtdzow.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2Cy_g4bmkvc5Q9dw.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeK0bGMrUZEtdzow.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/prompt/v4/-W__XJnvUD7dzB26Z9AcZkIzeg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/prompt/v4/-W_9XJnvUD7dzB2KZdoYREcjeo0k.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2Ck_k4bmkvc5Q9dw.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeLsbWMrUZEtdzow.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2Cv_44bmkvc5Q9dw.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeLAamMrUZEtdzow.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2C2_84bmkvc5Q9dw.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeKka2MrUZEtdzow.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2Cx_w4bmkvc5Q9dw.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeK4aGMrUZEtdzow.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2C4_04bmkvc5Q9dw.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeKcaWMrUZEtdzow.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_9XJnvUD7dzB2CA9oYREcjeo0k.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_7XJnvUD7dzB2KZeJ8TkMBf50kbiM.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2Cr_s4bmkvc5Q9dw.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeLQb2MrUZEtdzow.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2Cy_g4bmkvc5Q9dw.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeK0bGMrUZEtdzow.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W__XJnvUD7dzB26Z9AcZkIzeg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_9XJnvUD7dzB2KZdoYREcjeo0k.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2Ck_k4bmkvc5Q9dw.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeLsbWMrUZEtdzow.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2Cv_44bmkvc5Q9dw.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeLAamMrUZEtdzow.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2C2_84bmkvc5Q9dw.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeKka2MrUZEtdzow.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2Cx_w4bmkvc5Q9dw.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeK4aGMrUZEtdzow.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_8XJnvUD7dzB2C4_04bmkvc5Q9dw.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/prompt/v4/-W_6XJnvUD7dzB2KZeKcaWMrUZEtdzow.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52452,7 +54709,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/prostoone/v8/OpNJno4VhNfK-RgpwWWxpipfWhXD00c.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/prostoone/v8/OpNJno4VhNfK-RgpwWWxpipfWhXD00c.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52521,16 +54779,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/prozalibre/v4/LYjGdGHgj0k1DIQRyUEyyHovftvXWYyz.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/prozalibre/v4/LYjEdGHgj0k1DIQRyUEyyEotdN_1XJyz7zc.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/prozalibre/v4/LYjbdGHgj0k1DIQRyUEyyELbV__fcpC69i6N.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/prozalibre/v4/LYjZdGHgj0k1DIQRyUEyyEotTCvceJSY8z6Np1k.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/prozalibre/v4/LYjbdGHgj0k1DIQRyUEyyEL3UP_fcpC69i6N.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/prozalibre/v4/LYjZdGHgj0k1DIQRyUEyyEotTAfbeJSY8z6Np1k.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/prozalibre/v4/LYjbdGHgj0k1DIQRyUEyyEKTUf_fcpC69i6N.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/prozalibre/v4/LYjZdGHgj0k1DIQRyUEyyEotTGPaeJSY8z6Np1k.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/prozalibre/v4/LYjbdGHgj0k1DIQRyUEyyEKPUv_fcpC69i6N.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/prozalibre/v4/LYjZdGHgj0k1DIQRyUEyyEotTH_ZeJSY8z6Np1k.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/prozalibre/v4/LYjGdGHgj0k1DIQRyUEyyHovftvXWYyz.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/prozalibre/v4/LYjEdGHgj0k1DIQRyUEyyEotdN_1XJyz7zc.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/prozalibre/v4/LYjbdGHgj0k1DIQRyUEyyELbV__fcpC69i6N.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/prozalibre/v4/LYjZdGHgj0k1DIQRyUEyyEotTCvceJSY8z6Np1k.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/prozalibre/v4/LYjbdGHgj0k1DIQRyUEyyEL3UP_fcpC69i6N.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/prozalibre/v4/LYjZdGHgj0k1DIQRyUEyyEotTAfbeJSY8z6Np1k.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/prozalibre/v4/LYjbdGHgj0k1DIQRyUEyyEKTUf_fcpC69i6N.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/prozalibre/v4/LYjZdGHgj0k1DIQRyUEyyEotTGPaeJSY8z6Np1k.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/prozalibre/v4/LYjbdGHgj0k1DIQRyUEyyEKPUv_fcpC69i6N.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/prozalibre/v4/LYjZdGHgj0k1DIQRyUEyyEotTH_ZeJSY8z6Np1k.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52599,24 +54867,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuFpi5ww0pX189fg.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymulpm5ww0pX189fg.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuSJm5ww0pX189fg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuFpm5ww0pX189fg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuJJm5ww0pX189fg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuyJ65ww0pX189fg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymu8Z65ww0pX189fg.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymulp65ww0pX189fg.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuv565ww0pX189fg.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tpRgQctfVotfj7j.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673trRgActfVotfj7j.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673toPgActfVotfj7j.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tpRgActfVotfj7j.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tpjgActfVotfj7j.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tqPhwctfVotfj7j.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tq2hwctfVotfj7j.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673trRhwctfVotfj7j.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tr4hwctfVotfj7j.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuFpi5ww0pX189fg.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymulpm5ww0pX189fg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuSJm5ww0pX189fg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuFpm5ww0pX189fg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuJJm5ww0pX189fg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuyJ65ww0pX189fg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymu8Z65ww0pX189fg.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymulp65ww0pX189fg.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuv565ww0pX189fg.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tpRgQctfVotfj7j.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673trRgActfVotfj7j.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673toPgActfVotfj7j.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tpRgActfVotfj7j.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tpjgActfVotfj7j.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tqPhwctfVotfj7j.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tq2hwctfVotfj7j.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673trRhwctfVotfj7j.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/publicsans/v2/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tr4hwctfVotfj7j.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52685,10 +54971,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/puritan/v11/845YNMgkAJ2VTtIo9JrwRdaI50M.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/puritan/v11/845aNMgkAJ2VTtIoxJj6QfSN90PfXA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/puritan/v11/845dNMgkAJ2VTtIozCbfYd6j-0rGRes.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/puritan/v11/845fNMgkAJ2VTtIoxJjC_dup_2jDVevnLQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/puritan/v11/845YNMgkAJ2VTtIo9JrwRdaI50M.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/puritan/v11/845aNMgkAJ2VTtIoxJj6QfSN90PfXA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/puritan/v11/845dNMgkAJ2VTtIozCbfYd6j-0rGRes.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/puritan/v11/845fNMgkAJ2VTtIoxJjC_dup_2jDVevnLQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52757,7 +55047,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/purplepurse/v8/qWctB66gv53iAp-Vfs4My6qyeBb_ujA4ug.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/purplepurse/v8/qWctB66gv53iAp-Vfs4My6qyeBb_ujA4ug.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52826,7 +55117,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/quando/v8/xMQVuFNaVa6YuW0pC6WzKX_QmA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/quando/v8/xMQVuFNaVa6YuW0pC6WzKX_QmA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52895,10 +55187,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/quantico/v9/rax-HiSdp9cPL3KIF4xsLjxSmlLZ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/quantico/v9/rax4HiSdp9cPL3KIF7xuJDhwn0LZ6T8.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/quantico/v9/rax5HiSdp9cPL3KIF7TQARhasU7Q8Cad.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/quantico/v9/rax7HiSdp9cPL3KIF7xuHIRfu0ry9TadML4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/quantico/v9/rax-HiSdp9cPL3KIF4xsLjxSmlLZ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/quantico/v9/rax4HiSdp9cPL3KIF7xuJDhwn0LZ6T8.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/quantico/v9/rax5HiSdp9cPL3KIF7TQARhasU7Q8Cad.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/quantico/v9/rax7HiSdp9cPL3KIF7xuHIRfu0ry9TadML4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -52967,8 +55263,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/quattrocento/v11/OZpEg_xvsDZQL_LKIF7q4jPHxGL7f4jFuA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/quattrocento/v11/OZpbg_xvsDZQL_LKIF7q4jP_eE3fd6PZsXcM9w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/quattrocento/v11/OZpEg_xvsDZQL_LKIF7q4jPHxGL7f4jFuA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/quattrocento/v11/OZpbg_xvsDZQL_LKIF7q4jP_eE3fd6PZsXcM9w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53037,10 +55335,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/quattrocentosans/v12/va9c4lja2NVIDdIAAoMR5MfuElaRB3zOvU7eHGHJ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/quattrocentosans/v12/va9a4lja2NVIDdIAAoMR5MfuElaRB0zMt0r8GXHJkLI.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/quattrocentosans/v12/va9Z4lja2NVIDdIAAoMR5MfuElaRB0RykmrWN33AiasJ.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/quattrocentosans/v12/va9X4lja2NVIDdIAAoMR5MfuElaRB0zMj_bTPXnijLsJV7E.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/quattrocentosans/v12/va9c4lja2NVIDdIAAoMR5MfuElaRB3zOvU7eHGHJ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/quattrocentosans/v12/va9a4lja2NVIDdIAAoMR5MfuElaRB0zMt0r8GXHJkLI.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/quattrocentosans/v12/va9Z4lja2NVIDdIAAoMR5MfuElaRB0RykmrWN33AiasJ.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/quattrocentosans/v12/va9X4lja2NVIDdIAAoMR5MfuElaRB0zMj_bTPXnijLsJV7E.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53109,7 +55411,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/questrial/v9/QdVUSTchPBm7nuUeVf7EuStkm20oJA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/questrial/v9/QdVUSTchPBm7nuUeVf7EuStkm20oJA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53178,11 +55481,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/quicksand/v19/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkKEo18G0wx40QDw.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/quicksand/v19/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkP8o18G0wx40QDw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/quicksand/v19/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkM0o18G0wx40QDw.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/quicksand/v19/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkCEv18G0wx40QDw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/quicksand/v19/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkBgv18G0wx40QDw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/quicksand/v19/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkKEo18G0wx40QDw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/quicksand/v19/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkP8o18G0wx40QDw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/quicksand/v19/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkM0o18G0wx40QDw.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/quicksand/v19/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkCEv18G0wx40QDw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/quicksand/v19/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkBgv18G0wx40QDw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53251,7 +55559,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/quintessential/v7/fdNn9sOGq31Yjnh3qWU14DdtjY5wS7kmAyxM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/quintessential/v7/fdNn9sOGq31Yjnh3qWU14DdtjY5wS7kmAyxM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53320,7 +55629,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/qwigley/v9/1cXzaU3UGJb5tGoCuVxsi1mBmcE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/qwigley/v9/1cXzaU3UGJb5tGoCuVxsi1mBmcE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53389,7 +55699,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/racingsansone/v7/sykr-yRtm7EvTrXNxkv5jfKKyDCwL3rmWpIBtA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/racingsansone/v7/sykr-yRtm7EvTrXNxkv5jfKKyDCwL3rmWpIBtA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53458,8 +55769,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/radley/v14/LYjDdGzinEIjCN19oAlEpVs3VQ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/radley/v14/LYjBdGzinEIjCN1NogNAh14nVcfe.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/radley/v14/LYjDdGzinEIjCN19oAlEpVs3VQ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/radley/v14/LYjBdGzinEIjCN1NogNAh14nVcfe.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53528,11 +55841,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/rajdhani/v9/LDI2apCSOBg7S-QT7pasEcOsc-bGkqIw.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rajdhani/v9/LDIxapCSOBg7S-QT7q4AOeekWPrP.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/rajdhani/v9/LDI2apCSOBg7S-QT7pb0EMOsc-bGkqIw.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/rajdhani/v9/LDI2apCSOBg7S-QT7pbYF8Osc-bGkqIw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/rajdhani/v9/LDI2apCSOBg7S-QT7pa8FsOsc-bGkqIw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/rajdhani/v9/LDI2apCSOBg7S-QT7pasEcOsc-bGkqIw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rajdhani/v9/LDIxapCSOBg7S-QT7q4AOeekWPrP.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/rajdhani/v9/LDI2apCSOBg7S-QT7pb0EMOsc-bGkqIw.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/rajdhani/v9/LDI2apCSOBg7S-QT7pbYF8Osc-bGkqIw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/rajdhani/v9/LDI2apCSOBg7S-QT7pa8FsOsc-bGkqIw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53601,7 +55919,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rakkas/v7/Qw3cZQlNHiblL3j_lttPOeMcCw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rakkas/v7/Qw3cZQlNHiblL3j_lttPOeMcCw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53670,24 +55989,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptsg8zYS_SKggPNwE4ISotrDfGGxA.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptqg8zYS_SKggPNyCgwLoFvL_SWxEMT.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwOIpaqFFAfif3Vo.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgwgqBPBdqazVoK4A.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwIYqaqFFAfif3Vo.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgw5qNPBdqazVoK4A.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptug8zYS_SKggPN-CoCTqluHfE.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptsg8zYS_SKggPNyCgISotrDfGGxA.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwN4raqFFAfif3Vo.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgwvqJPBdqazVoK4A.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwPIsaqFFAfif3Vo.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgwkqVPBdqazVoK4A.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwJYtaqFFAfif3Vo.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgw9qRPBdqazVoK4A.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwIouaqFFAfif3Vo.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgw6qdPBdqazVoK4A.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqFFAfif3Vo.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgwzqZPBdqazVoK4A.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptsg8zYS_SKggPNwE4ISotrDfGGxA.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptqg8zYS_SKggPNyCgwLoFvL_SWxEMT.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwOIpaqFFAfif3Vo.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgwgqBPBdqazVoK4A.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwIYqaqFFAfif3Vo.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgw5qNPBdqazVoK4A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptug8zYS_SKggPN-CoCTqluHfE.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptsg8zYS_SKggPNyCgISotrDfGGxA.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwN4raqFFAfif3Vo.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgwvqJPBdqazVoK4A.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwPIsaqFFAfif3Vo.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgwkqVPBdqazVoK4A.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwJYtaqFFAfif3Vo.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgw9qRPBdqazVoK4A.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwIouaqFFAfif3Vo.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgw6qdPBdqazVoK4A.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqFFAfif3Vo.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/raleway/v14/1Ptpg8zYS_SKggPNyCgwzqZPBdqazVoK4A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53756,7 +56093,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ralewaydots/v7/6NUR8FifJg6AfQvzpshgwJ8kyf9Fdty2ew.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ralewaydots/v7/6NUR8FifJg6AfQvzpshgwJ8kyf9Fdty2ew.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53825,7 +56163,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ramabhadra/v9/EYq2maBOwqRW9P1SQ83LehNGX5uWw3o.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ramabhadra/v9/EYq2maBOwqRW9P1SQ83LehNGX5uWw3o.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53894,7 +56233,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ramaraja/v4/SlGTmQearpYAYG1CABIkqnB6aSQU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ramaraja/v4/SlGTmQearpYAYG1CABIkqnB6aSQU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -53963,10 +56303,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rambla/v7/snfrs0ip98hx6mr0I7IONthkwQ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/rambla/v7/snfps0ip98hx6mrEIbgKFN10wYKa.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/rambla/v7/snfos0ip98hx6mrMn50qPvN4yJuDYQ.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/rambla/v7/snfus0ip98hx6mrEIYC2O_l86p6TYS-Y.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rambla/v7/snfrs0ip98hx6mr0I7IONthkwQ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/rambla/v7/snfps0ip98hx6mrEIbgKFN10wYKa.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/rambla/v7/snfos0ip98hx6mrMn50qPvN4yJuDYQ.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/rambla/v7/snfus0ip98hx6mrEIYC2O_l86p6TYS-Y.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54035,7 +56379,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rammettoone/v8/LhWiMV3HOfMbMetJG3lQDpp9Mvuciu-_SQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rammettoone/v8/LhWiMV3HOfMbMetJG3lQDpp9Mvuciu-_SQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54104,7 +56449,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ranchers/v7/zrfm0H3Lx-P2Xvs2AoDYDC79XTHv.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ranchers/v7/zrfm0H3Lx-P2Xvs2AoDYDC79XTHv.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54173,7 +56519,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rancho/v10/46kulbzmXjLaqZRlbWXgd0RY1g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rancho/v10/46kulbzmXjLaqZRlbWXgd0RY1g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54242,8 +56589,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ranga/v5/C8ct4cYisGb28p6CLDwZwmGE.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ranga/v5/C8cg4cYisGb28qY-AxgR6X2NZAn2.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ranga/v5/C8ct4cYisGb28p6CLDwZwmGE.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ranga/v5/C8cg4cYisGb28qY-AxgR6X2NZAn2.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54312,11 +56661,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/rasa/v5/xn7gYHIn1mWmdg52sgC7S9XdZN8.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rasa/v5/xn7vYHIn1mWmTqJelgiQV9w.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/rasa/v5/xn7gYHIn1mWmdlZ3sgC7S9XdZN8.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/rasa/v5/xn7gYHIn1mWmdnpwsgC7S9XdZN8.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/rasa/v5/xn7gYHIn1mWmdh5xsgC7S9XdZN8.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/rasa/v5/xn7gYHIn1mWmdg52sgC7S9XdZN8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rasa/v5/xn7vYHIn1mWmTqJelgiQV9w.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/rasa/v5/xn7gYHIn1mWmdlZ3sgC7S9XdZN8.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/rasa/v5/xn7gYHIn1mWmdnpwsgC7S9XdZN8.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/rasa/v5/xn7gYHIn1mWmdh5xsgC7S9XdZN8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54385,7 +56739,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rationale/v11/9XUnlJ92n0_JFxHIfHcsdlFMzLC2Zw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rationale/v11/9XUnlJ92n0_JFxHIfHcsdlFMzLC2Zw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54454,7 +56809,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/raviprakash/v6/gokpH6fsDkVrF9Bv9X8SOAKHmNZEq6TTFw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/raviprakash/v6/gokpH6fsDkVrF9Bv9X8SOAKHmNZEq6TTFw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54523,14 +56879,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIQ7wUr0m80wwYf0QCXZzYzUoTQ-jSgZYvdCQ.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIS7wUr0m80wwYf0QCXZzYzUoTg-D6kR47NCV5Z.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIV7wUr0m80wwYf0QCXZzYzUoToDh2EbaDBAEdAbw.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIX7wUr0m80wwYf0QCXZzYzUoTg-AZQbqrFIkJQb7zU.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIV7wUr0m80wwYf0QCXZzYzUoToRhuEbaDBAEdAbw.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIX7wUr0m80wwYf0QCXZzYzUoTg-AYYaKrFIkJQb7zU.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIV7wUr0m80wwYf0QCXZzYzUoTofhmEbaDBAEdAbw.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIX7wUr0m80wwYf0QCXZzYzUoTg-AYgaqrFIkJQb7zU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIQ7wUr0m80wwYf0QCXZzYzUoTQ-jSgZYvdCQ.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIS7wUr0m80wwYf0QCXZzYzUoTg-D6kR47NCV5Z.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIV7wUr0m80wwYf0QCXZzYzUoToDh2EbaDBAEdAbw.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIX7wUr0m80wwYf0QCXZzYzUoTg-AZQbqrFIkJQb7zU.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIV7wUr0m80wwYf0QCXZzYzUoToRhuEbaDBAEdAbw.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIX7wUr0m80wwYf0QCXZzYzUoTg-AYYaKrFIkJQb7zU.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIV7wUr0m80wwYf0QCXZzYzUoTofhmEbaDBAEdAbw.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/redhatdisplay/v3/8vIX7wUr0m80wwYf0QCXZzYzUoTg-AYgaqrFIkJQb7zU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54599,12 +56963,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/redhattext/v2/RrQXbohi_ic6B3yVSzGBrMxgb60sE8yZPA.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/redhattext/v2/RrQJbohi_ic6B3yVSzGBrMxQbacoMcmJPECN.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/redhattext/v2/RrQIbohi_ic6B3yVSzGBrMxYm4QIG-eFNVmULg.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/redhattext/v2/RrQKbohi_ic6B3yVSzGBrMxQbZ_cGO2BF1yELmgy.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/redhattext/v2/RrQIbohi_ic6B3yVSzGBrMxY04IIG-eFNVmULg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/redhattext/v2/RrQKbohi_ic6B3yVSzGBrMxQbZ-UHu2BF1yELmgy.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/redhattext/v2/RrQXbohi_ic6B3yVSzGBrMxgb60sE8yZPA.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/redhattext/v2/RrQJbohi_ic6B3yVSzGBrMxQbacoMcmJPECN.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/redhattext/v2/RrQIbohi_ic6B3yVSzGBrMxYm4QIG-eFNVmULg.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/redhattext/v2/RrQKbohi_ic6B3yVSzGBrMxQbZ_cGO2BF1yELmgy.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/redhattext/v2/RrQIbohi_ic6B3yVSzGBrMxY04IIG-eFNVmULg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/redhattext/v2/RrQKbohi_ic6B3yVSzGBrMxQbZ-UHu2BF1yELmgy.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54673,7 +57043,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/redressed/v10/x3dickHUbrmJ7wMy9MsBfPACvy_1BA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/redressed/v10/x3dickHUbrmJ7wMy9MsBfPACvy_1BA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54742,7 +57113,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/reemkufi/v7/2sDcZGJLip7W2J7v7wQDb2-4C7wFZQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/reemkufi/v7/2sDcZGJLip7W2J7v7wQDb2-4C7wFZQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54811,7 +57183,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/reeniebeanie/v10/z7NSdR76eDkaJKZJFkkjuvWxbP2_qoOgf_w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/reeniebeanie/v10/z7NSdR76eDkaJKZJFkkjuvWxbP2_qoOgf_w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54880,7 +57253,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/revalia/v7/WwkexPimBE2-4ZPEeVruNIgJSNM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/revalia/v7/WwkexPimBE2-4ZPEeVruNIgJSNM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -54949,7 +57323,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rhodiumlibre/v4/1q2AY5adA0tn_ukeHcQHqpx6pETLeo2gm2U.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rhodiumlibre/v4/1q2AY5adA0tn_ukeHcQHqpx6pETLeo2gm2U.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55018,7 +57393,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ribeye/v8/L0x8DFMxk1MP9R3RvPCmRSlUig.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ribeye/v8/L0x8DFMxk1MP9R3RvPCmRSlUig.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55087,7 +57463,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ribeyemarrow/v9/GFDsWApshnqMRO2JdtRZ2d0vEAwTVWgKdtw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ribeyemarrow/v9/GFDsWApshnqMRO2JdtRZ2d0vEAwTVWgKdtw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55156,7 +57533,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/righteous/v8/1cXxaUPXBpj2rGoU7C9mj3uEicG01A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/righteous/v8/1cXxaUPXBpj2rGoU7C9mj3uEicG01A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55225,7 +57603,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/risque/v7/VdGfAZUfHosahXxoCUYVBJ-T5g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/risque/v7/VdGfAZUfHosahXxoCUYVBJ-T5g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55294,18 +57673,30 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/roboto/v20/KFOkCnqEu92Fr1MmgWxPKTM1K9nz.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/roboto/v20/KFOiCnqEu92Fr1Mu51QrIzcXLsnzjYk.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/roboto/v20/KFOlCnqEu92Fr1MmSU5vAx05IsDqlA.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/roboto/v20/KFOjCnqEu92Fr1Mu51TjARc9AMX6lJBP.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/roboto/v20/KFOkCnqEu92Fr1Mu52xPKTM1K9nz.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/roboto/v20/KFOlCnqEu92Fr1MmEU9vAx05IsDqlA.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/roboto/v20/KFOjCnqEu92Fr1Mu51S7ABc9AMX6lJBP.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/roboto/v20/KFOlCnqEu92Fr1MmWUlvAx05IsDqlA.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/roboto/v20/KFOjCnqEu92Fr1Mu51TzBhc9AMX6lJBP.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/roboto/v20/KFOlCnqEu92Fr1MmYUtvAx05IsDqlA.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/roboto/v20/KFOjCnqEu92Fr1Mu51TLBBc9AMX6lJBP.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/roboto/v20/KFOkCnqEu92Fr1MmgWxPKTM1K9nz.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/roboto/v20/KFOiCnqEu92Fr1Mu51QrIzcXLsnzjYk.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/roboto/v20/KFOlCnqEu92Fr1MmSU5vAx05IsDqlA.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/roboto/v20/KFOjCnqEu92Fr1Mu51TjARc9AMX6lJBP.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/roboto/v20/KFOkCnqEu92Fr1Mu52xPKTM1K9nz.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/roboto/v20/KFOlCnqEu92Fr1MmEU9vAx05IsDqlA.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/roboto/v20/KFOjCnqEu92Fr1Mu51S7ABc9AMX6lJBP.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/roboto/v20/KFOlCnqEu92Fr1MmWUlvAx05IsDqlA.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/roboto/v20/KFOjCnqEu92Fr1Mu51TzBhc9AMX6lJBP.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/roboto/v20/KFOlCnqEu92Fr1MmYUtvAx05IsDqlA.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/roboto/v20/KFOjCnqEu92Fr1Mu51TLBBc9AMX6lJBP.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55374,12 +57765,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/robotocondensed/v18/ieVi2ZhZI2eCN5jzbjEETS9weq8-33mZKCMSbvtdYyQ.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/robotocondensed/v18/ieVg2ZhZI2eCN5jzbjEETS9weq8-19eDpCEYatlYcyRi4A.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/robotocondensed/v18/ieVl2ZhZI2eCN5jzbjEETS9weq8-59WxDCs5cvI.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/robotocondensed/v18/ieVj2ZhZI2eCN5jzbjEETS9weq8-19e7CAk8YvJEeg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/robotocondensed/v18/ieVi2ZhZI2eCN5jzbjEETS9weq8-32meKCMSbvtdYyQ.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/robotocondensed/v18/ieVg2ZhZI2eCN5jzbjEETS9weq8-19eDtCYYatlYcyRi4A.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/robotocondensed/v18/ieVi2ZhZI2eCN5jzbjEETS9weq8-33mZKCMSbvtdYyQ.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/robotocondensed/v18/ieVg2ZhZI2eCN5jzbjEETS9weq8-19eDpCEYatlYcyRi4A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/robotocondensed/v18/ieVl2ZhZI2eCN5jzbjEETS9weq8-59WxDCs5cvI.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/robotocondensed/v18/ieVj2ZhZI2eCN5jzbjEETS9weq8-19e7CAk8YvJEeg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/robotocondensed/v18/ieVi2ZhZI2eCN5jzbjEETS9weq8-32meKCMSbvtdYyQ.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/robotocondensed/v18/ieVg2ZhZI2eCN5jzbjEETS9weq8-19eDtCYYatlYcyRi4A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55448,16 +57845,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/robotomono/v7/L0x7DF4xlVMF-BfR8bXMIjAoq3qcW7KCG1w.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/robotomono/v7/L0xlDF4xlVMF-BfR8bXMIjhOkx6WX5CHC1wnFw.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/robotomono/v7/L0xkDF4xlVMF-BfR8bXMIjDgiVq2db6LAkU-.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/robotomono/v7/L0xmDF4xlVMF-BfR8bXMIjhOk9a0f7qpB1U-Drg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/robotomono/v7/L0x5DF4xlVMF-BfR8bXMIghMoX6-XqKC.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/robotomono/v7/L0x7DF4xlVMF-BfR8bXMIjhOq3qcW7KCG1w.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/robotomono/v7/L0xkDF4xlVMF-BfR8bXMIjC4iFq2db6LAkU-.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/robotomono/v7/L0xmDF4xlVMF-BfR8bXMIjhOk461f7qpB1U-Drg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/robotomono/v7/L0xkDF4xlVMF-BfR8bXMIjDwjlq2db6LAkU-.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/robotomono/v7/L0xmDF4xlVMF-BfR8bXMIjhOk8azf7qpB1U-Drg.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/robotomono/v7/L0x7DF4xlVMF-BfR8bXMIjAoq3qcW7KCG1w.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/robotomono/v7/L0xlDF4xlVMF-BfR8bXMIjhOkx6WX5CHC1wnFw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/robotomono/v7/L0xkDF4xlVMF-BfR8bXMIjDgiVq2db6LAkU-.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/robotomono/v7/L0xmDF4xlVMF-BfR8bXMIjhOk9a0f7qpB1U-Drg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/robotomono/v7/L0x5DF4xlVMF-BfR8bXMIghMoX6-XqKC.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/robotomono/v7/L0x7DF4xlVMF-BfR8bXMIjhOq3qcW7KCG1w.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/robotomono/v7/L0xkDF4xlVMF-BfR8bXMIjC4iFq2db6LAkU-.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/robotomono/v7/L0xmDF4xlVMF-BfR8bXMIjhOk461f7qpB1U-Drg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/robotomono/v7/L0xkDF4xlVMF-BfR8bXMIjDwjlq2db6LAkU-.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/robotomono/v7/L0xmDF4xlVMF-BfR8bXMIjhOk8azf7qpB1U-Drg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55526,15 +57933,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjojIWWaG5iddG-1A.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjoDISWaG5iddG-1A.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjo0oSWaG5iddG-1A.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjojISWaG5iddG-1A.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjovoSWaG5iddG-1A.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjoUoOWaG5iddG-1A.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjoa4OWaG5iddG-1A.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjoDIOWaG5iddG-1A.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjoJYOWaG5iddG-1A.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjojIWWaG5iddG-1A.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjoDISWaG5iddG-1A.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjo0oSWaG5iddG-1A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjojISWaG5iddG-1A.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjovoSWaG5iddG-1A.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjoUoOWaG5iddG-1A.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjoa4OWaG5iddG-1A.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjoDIOWaG5iddG-1A.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/robotoslab/v10/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjoJYOWaG5iddG-1A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55603,7 +58019,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rochester/v10/6ae-4KCqVa4Zy6Fif-Uy31vWNTMwoQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rochester/v10/6ae-4KCqVa4Zy6Fif-Uy31vWNTMwoQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55672,7 +58089,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rocksalt/v10/MwQ0bhv11fWD6QsAVOZbsEk7hbBWrA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rocksalt/v10/MwQ0bhv11fWD6QsAVOZbsEk7hbBWrA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55741,15 +58159,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1rydpDLE76HvN6n.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1pyd5DLE76HvN6n.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1qsd5DLE76HvN6n.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1ryd5DLE76HvN6n.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1rAd5DLE76HvN6n.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1oscJDLE76HvN6n.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1oVcJDLE76HvN6n.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1pycJDLE76HvN6n.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1pbcJDLE76HvN6n.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1rydpDLE76HvN6n.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1pyd5DLE76HvN6n.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1qsd5DLE76HvN6n.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1ryd5DLE76HvN6n.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1rAd5DLE76HvN6n.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1oscJDLE76HvN6n.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1oVcJDLE76HvN6n.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1pycJDLE76HvN6n.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/rokkitt/v17/qFdb35qfgYFjGy5hukqqhw5XeRgdi1pbcJDLE76HvN6n.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55818,7 +58245,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/romanesco/v8/w8gYH2ozQOY7_r_J7mSn3HwLqOqSBg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/romanesco/v8/w8gYH2ozQOY7_r_J7mSn3HwLqOqSBg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55887,8 +58315,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ropasans/v9/EYqxmaNOzLlWtsZSScyKWjloU5KP2g.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/ropasans/v9/EYq3maNOzLlWtsZSScy6WDNscZef2mNE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ropasans/v9/EYqxmaNOzLlWtsZSScyKWjloU5KP2g.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/ropasans/v9/EYq3maNOzLlWtsZSScy6WDNscZef2mNE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -55957,16 +58387,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/rosario/v16/xfuu0WDhWW_fOEoY8l_VPNZfB7jPM69GCWczd-YnOzUD.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rosario/v16/xfuu0WDhWW_fOEoY8l_VPNZfB7jPM68YCWczd-YnOzUD.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/rosario/v16/xfuu0WDhWW_fOEoY8l_VPNZfB7jPM68qCWczd-YnOzUD.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/rosario/v16/xfuu0WDhWW_fOEoY8l_VPNZfB7jPM6_GDmczd-YnOzUD.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/rosario/v16/xfuu0WDhWW_fOEoY8l_VPNZfB7jPM6__Dmczd-YnOzUD.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/rosario/v16/xfug0WDhWW_fOEoY2Fbnww42bCJhNLrQStFwfeIFPiUDn08.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/rosario/v16/xfug0WDhWW_fOEoY2Fbnww42bCJhNLrQSo9wfeIFPiUDn08.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/rosario/v16/xfug0WDhWW_fOEoY2Fbnww42bCJhNLrQSr1wfeIFPiUDn08.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/rosario/v16/xfug0WDhWW_fOEoY2Fbnww42bCJhNLrQSlF3feIFPiUDn08.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/rosario/v16/xfug0WDhWW_fOEoY2Fbnww42bCJhNLrQSmh3feIFPiUDn08.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/rosario/v16/xfuu0WDhWW_fOEoY8l_VPNZfB7jPM69GCWczd-YnOzUD.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rosario/v16/xfuu0WDhWW_fOEoY8l_VPNZfB7jPM68YCWczd-YnOzUD.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/rosario/v16/xfuu0WDhWW_fOEoY8l_VPNZfB7jPM68qCWczd-YnOzUD.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/rosario/v16/xfuu0WDhWW_fOEoY8l_VPNZfB7jPM6_GDmczd-YnOzUD.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/rosario/v16/xfuu0WDhWW_fOEoY8l_VPNZfB7jPM6__Dmczd-YnOzUD.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/rosario/v16/xfug0WDhWW_fOEoY2Fbnww42bCJhNLrQStFwfeIFPiUDn08.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/rosario/v16/xfug0WDhWW_fOEoY2Fbnww42bCJhNLrQSo9wfeIFPiUDn08.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/rosario/v16/xfug0WDhWW_fOEoY2Fbnww42bCJhNLrQSr1wfeIFPiUDn08.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/rosario/v16/xfug0WDhWW_fOEoY2Fbnww42bCJhNLrQSlF3feIFPiUDn08.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/rosario/v16/xfug0WDhWW_fOEoY2Fbnww42bCJhNLrQSmh3feIFPiUDn08.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56035,8 +58475,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rosarivo/v7/PlI-Fl2lO6N9f8HaNAeC2nhMnNy5.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/rosarivo/v7/PlI4Fl2lO6N9f8HaNDeA0Hxumcy5ZX8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rosarivo/v7/PlI-Fl2lO6N9f8HaNAeC2nhMnNy5.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/rosarivo/v7/PlI4Fl2lO6N9f8HaNDeA0Hxumcy5ZX8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56105,7 +58547,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rougescript/v8/LYjFdGbiklMoCIQOw1Ep3S4PVPXbUJWq9g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rougescript/v8/LYjFdGbiklMoCIQOw1Ep3S4PVPXbUJWq9g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56174,7 +58617,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rozhaone/v7/AlZy_zVFtYP12Zncg2khdXf4XB0Tow.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rozhaone/v7/AlZy_zVFtYP12Zncg2khdXf4XB0Tow.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56243,16 +58687,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/rubik/v9/iJWHBXyIfDnIV7Fqj1ma-2HW7ZB_.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/rubik/v9/iJWBBXyIfDnIV7nEldWY8WX06IB_18o.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rubik/v9/iJWKBXyIfDnIV4nGp32S0H3f.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/rubik/v9/iJWEBXyIfDnIV7nErXmw1W3f9Ik.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/rubik/v9/iJWHBXyIfDnIV7Eyjlma-2HW7ZB_.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/rubik/v9/iJWBBXyIfDnIV7nElY2Z8WX06IB_18o.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/rubik/v9/iJWHBXyIfDnIV7F6iFma-2HW7ZB_.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/rubik/v9/iJWBBXyIfDnIV7nElcWf8WX06IB_18o.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/rubik/v9/iJWHBXyIfDnIV7FCilma-2HW7ZB_.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/rubik/v9/iJWBBXyIfDnIV7nElf2d8WX06IB_18o.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/rubik/v9/iJWHBXyIfDnIV7Fqj1ma-2HW7ZB_.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/rubik/v9/iJWBBXyIfDnIV7nEldWY8WX06IB_18o.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rubik/v9/iJWKBXyIfDnIV4nGp32S0H3f.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/rubik/v9/iJWEBXyIfDnIV7nErXmw1W3f9Ik.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/rubik/v9/iJWHBXyIfDnIV7Eyjlma-2HW7ZB_.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/rubik/v9/iJWBBXyIfDnIV7nElY2Z8WX06IB_18o.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/rubik/v9/iJWHBXyIfDnIV7F6iFma-2HW7ZB_.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/rubik/v9/iJWBBXyIfDnIV7nElcWf8WX06IB_18o.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/rubik/v9/iJWHBXyIfDnIV7FCilma-2HW7ZB_.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/rubik/v9/iJWBBXyIfDnIV7nElf2d8WX06IB_18o.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56321,7 +58775,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rubikmonoone/v8/UqyJK8kPP3hjw6ANTdfRk9YSN-8wRqQrc_j9.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rubikmonoone/v8/UqyJK8kPP3hjw6ANTdfRk9YSN-8wRqQrc_j9.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56390,9 +58845,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ruda/v11/k3kfo8YQJOpFmn8XadbJM0A.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ruda/v11/k3kQo8YQJOpFosM4Td7iL0nAMaM.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/ruda/v11/k3kQo8YQJOpFovs6Td7iL0nAMaM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ruda/v11/k3kfo8YQJOpFmn8XadbJM0A.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ruda/v11/k3kQo8YQJOpFosM4Td7iL0nAMaM.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/ruda/v11/k3kQo8YQJOpFovs6Td7iL0nAMaM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56461,8 +58919,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rufina/v7/Yq6V-LyURyLy-aKyoxRktOdClg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/rufina/v7/Yq6W-LyURyLy-aKKHztAvMxenxE0SA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rufina/v7/Yq6V-LyURyLy-aKyoxRktOdClg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/rufina/v7/Yq6W-LyURyLy-aKKHztAvMxenxE0SA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56531,7 +58991,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rugeboogie/v10/JIA3UVFwbHRF_GIWSMhKNROiPzUveSxy.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rugeboogie/v10/JIA3UVFwbHRF_GIWSMhKNROiPzUveSxy.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56600,7 +59061,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ruluko/v7/xMQVuFNZVaODtm0pC6WzKX_QmA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ruluko/v7/xMQVuFNZVaODtm0pC6WzKX_QmA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56669,7 +59131,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rumraisin/v7/nwpRtKu3Ih8D5avB4h2uJ3-IywA7eMM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rumraisin/v7/nwpRtKu3Ih8D5avB4h2uJ3-IywA7eMM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56738,7 +59201,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ruslandisplay/v10/Gw6jwczl81XcIZuckK_e3UpfdzxrldyFvm1n.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ruslandisplay/v10/Gw6jwczl81XcIZuckK_e3UpfdzxrldyFvm1n.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56807,7 +59271,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/russoone/v8/Z9XUDmZRWg6M1LvRYsH-yMOInrib9Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/russoone/v8/Z9XUDmZRWg6M1LvRYsH-yMOInrib9Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56876,7 +59341,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ruthie/v10/gokvH63sGkdqXuU9lD53Q2u_mQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ruthie/v10/gokvH63sGkdqXuU9lD53Q2u_mQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -56945,7 +59411,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/rye/v7/r05XGLJT86YDFpTsXOqx4w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/rye/v7/r05XGLJT86YDFpTsXOqx4w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57014,7 +59481,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sacramento/v7/buEzpo6gcdjy0EiZMBUG0CoV_NxLeiw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sacramento/v7/buEzpo6gcdjy0EiZMBUG0CoV_NxLeiw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57083,8 +59551,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sahitya/v4/6qLAKZkOuhnuqlJAaScFPywEDnI.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sahitya/v4/6qLFKZkOuhnuqlJAUZsqGyQvEnvSexI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sahitya/v4/6qLAKZkOuhnuqlJAaScFPywEDnI.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sahitya/v4/6qLFKZkOuhnuqlJAUZsqGyQvEnvSexI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57153,7 +59623,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sail/v10/DPEjYwiBxwYJFBTDADYAbvw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sail/v10/DPEjYwiBxwYJFBTDADYAbvw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57222,15 +59693,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/saira/v4/mem-Ya2wxmKQyNFETZY_VrUfTck.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNHobLYVeLkWVNBt.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNGMb7YVeLkWVNBt.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/saira/v4/memwYa2wxmKQyOkgR5IdU6Uf.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNHUbrYVeLkWVNBt.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNH4abYVeLkWVNBt.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNGcaLYVeLkWVNBt.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNGAa7YVeLkWVNBt.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNGkarYVeLkWVNBt.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/saira/v4/mem-Ya2wxmKQyNFETZY_VrUfTck.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNHobLYVeLkWVNBt.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNGMb7YVeLkWVNBt.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/saira/v4/memwYa2wxmKQyOkgR5IdU6Uf.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNHUbrYVeLkWVNBt.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNH4abYVeLkWVNBt.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNGcaLYVeLkWVNBt.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNGAa7YVeLkWVNBt.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/saira/v4/mem9Ya2wxmKQyNGkarYVeLkWVNBt.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57299,15 +59779,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/sairacondensed/v5/EJRMQgErUN8XuHNEtX81i9TmEkrnwetA2omSrzS8.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnbcpg8Keepi2lHw.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnCclg8Keepi2lHw.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sairacondensed/v5/EJROQgErUN8XuHNEtX81i9TmEkrfpeFE-IyCrw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnUchg8Keepi2lHw.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnfc9g8Keepi2lHw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnGc5g8Keepi2lHw.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnBc1g8Keepi2lHw.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnIcxg8Keepi2lHw.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/sairacondensed/v5/EJRMQgErUN8XuHNEtX81i9TmEkrnwetA2omSrzS8.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnbcpg8Keepi2lHw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnCclg8Keepi2lHw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sairacondensed/v5/EJROQgErUN8XuHNEtX81i9TmEkrfpeFE-IyCrw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnUchg8Keepi2lHw.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnfc9g8Keepi2lHw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnGc5g8Keepi2lHw.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnBc1g8Keepi2lHw.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/sairacondensed/v5/EJRLQgErUN8XuHNEtX81i9TmEkrnIcxg8Keepi2lHw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57376,15 +59865,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFsOHYr-vcC7h8MklGBkrvmUG9rbpkisrTri0jx9i5ss3a3.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTrJ2nR3ABgum-uoQ.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTrQ2rR3ABgum-uoQ.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFiOHYr-vcC7h8MklGBkrvmUG9rbpkisrTT70L11Ct8sw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTrG2vR3ABgum-uoQ.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTrN2zR3ABgum-uoQ.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTrU23R3ABgum-uoQ.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTrT27R3ABgum-uoQ.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTra2_R3ABgum-uoQ.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFsOHYr-vcC7h8MklGBkrvmUG9rbpkisrTri0jx9i5ss3a3.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTrJ2nR3ABgum-uoQ.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTrQ2rR3ABgum-uoQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFiOHYr-vcC7h8MklGBkrvmUG9rbpkisrTT70L11Ct8sw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTrG2vR3ABgum-uoQ.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTrN2zR3ABgum-uoQ.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTrU23R3ABgum-uoQ.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTrT27R3ABgum-uoQ.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/sairaextracondensed/v5/-nFvOHYr-vcC7h8MklGBkrvmUG9rbpkisrTra2_R3ABgum-uoQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57453,15 +59951,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MN6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXdvaOM8rXT-8V8.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXfDScMWg3j36Ebz.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXenSsMWg3j36Ebz.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MD6c-2-nnJkHxyCjRcnMHcWVWV1cWRRU8LYuceqGT-.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXf_S8MWg3j36Ebz.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXfTTMMWg3j36Ebz.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXe3TcMWg3j36Ebz.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXerTsMWg3j36Ebz.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXePT8MWg3j36Ebz.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MN6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXdvaOM8rXT-8V8.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXfDScMWg3j36Ebz.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXenSsMWg3j36Ebz.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MD6c-2-nnJkHxyCjRcnMHcWVWV1cWRRU8LYuceqGT-.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXf_S8MWg3j36Ebz.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXfTTMMWg3j36Ebz.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXe3TcMWg3j36Ebz.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXerTsMWg3j36Ebz.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/sairasemicondensed/v5/U9MM6c-2-nnJkHxyCjRcnMHcWVWV1cWRRXePT8MWg3j36Ebz.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57530,7 +60037,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sairastencilone/v1/SLXSc03I6HkvZGJ1GvvipLoYSTEL9AsMawif2YQ2.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sairastencilone/v1/SLXSc03I6HkvZGJ1GvvipLoYSTEL9AsMawif2YQ2.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57599,7 +60107,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/salsa/v9/gNMKW3FiRpKj-imY8ncKEZez.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/salsa/v9/gNMKW3FiRpKj-imY8ncKEZez.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57668,8 +60177,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sanchez/v7/Ycm2sZJORluHnXbITm5b_BwE1l0.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/sanchez/v7/Ycm0sZJORluHnXbIfmxR-D4Bxl3gkw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sanchez/v7/Ycm2sZJORluHnXbITm5b_BwE1l0.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/sanchez/v7/Ycm0sZJORluHnXbIfmxR-D4Bxl3gkw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57738,7 +60249,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sancreek/v10/pxiHypAnsdxUm159X7D-XV9NEe-K.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sancreek/v10/pxiHypAnsdxUm159X7D-XV9NEe-K.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57807,14 +60319,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sansita/v4/QldONTRRphEb_-V7HBm7TXFf3qw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/sansita/v4/QldMNTRRphEb_-V7LBuxSVNazqx2xg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sansita/v4/QldLNTRRphEb_-V7JKWUaXl0wqVv3_g.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/sansita/v4/QldJNTRRphEb_-V7LBuJ9Xx-xodqz_joDQ.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/sansita/v4/QldLNTRRphEb_-V7JLmXaXl0wqVv3_g.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/sansita/v4/QldJNTRRphEb_-V7LBuJ6X9-xodqz_joDQ.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/sansita/v4/QldLNTRRphEb_-V7JJ2WaXl0wqVv3_g.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/sansita/v4/QldJNTRRphEb_-V7LBuJzX5-xodqz_joDQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sansita/v4/QldONTRRphEb_-V7HBm7TXFf3qw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/sansita/v4/QldMNTRRphEb_-V7LBuxSVNazqx2xg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sansita/v4/QldLNTRRphEb_-V7JKWUaXl0wqVv3_g.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/sansita/v4/QldJNTRRphEb_-V7LBuJ9Xx-xodqz_joDQ.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/sansita/v4/QldLNTRRphEb_-V7JLmXaXl0wqVv3_g.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/sansita/v4/QldJNTRRphEb_-V7LBuJ6X9-xodqz_joDQ.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/sansita/v4/QldLNTRRphEb_-V7JJ2WaXl0wqVv3_g.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/sansita/v4/QldJNTRRphEb_-V7LBuJzX5-xodqz_joDQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57883,22 +60403,38 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVhJx26TKEr37c9YHZJmnYI5gnOpg.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVnJx26TKEr37c9aBBx_nwMxAzephhN.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVmJx26TKEr37c9YNpoulwm6gDXvwE.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVkJx26TKEr37c9aBBxUl0s7iLSrwFUlw.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVmJx26TKEr37c9YL5rulwm6gDXvwE.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVkJx26TKEr37c9aBBxNl4s7iLSrwFUlw.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVjJx26TKEr37c9WBJDnlQN9gk.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVhJx26TKEr37c9aBBJmnYI5gnOpg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVmJx26TKEr37c9YOZqulwm6gDXvwE.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVkJx26TKEr37c9aBBxbl8s7iLSrwFUlw.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVmJx26TKEr37c9YMptulwm6gDXvwE.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVkJx26TKEr37c9aBBxQlgs7iLSrwFUlw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVmJx26TKEr37c9YK5sulwm6gDXvwE.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVkJx26TKEr37c9aBBxJlks7iLSrwFUlw.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVmJx26TKEr37c9YLJvulwm6gDXvwE.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/sarabun/v7/DtVkJx26TKEr37c9aBBxOlos7iLSrwFUlw.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVhJx26TKEr37c9YHZJmnYI5gnOpg.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVnJx26TKEr37c9aBBx_nwMxAzephhN.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVmJx26TKEr37c9YNpoulwm6gDXvwE.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVkJx26TKEr37c9aBBxUl0s7iLSrwFUlw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVmJx26TKEr37c9YL5rulwm6gDXvwE.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVkJx26TKEr37c9aBBxNl4s7iLSrwFUlw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVjJx26TKEr37c9WBJDnlQN9gk.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVhJx26TKEr37c9aBBJmnYI5gnOpg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVmJx26TKEr37c9YOZqulwm6gDXvwE.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVkJx26TKEr37c9aBBxbl8s7iLSrwFUlw.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVmJx26TKEr37c9YMptulwm6gDXvwE.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVkJx26TKEr37c9aBBxQlgs7iLSrwFUlw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVmJx26TKEr37c9YK5sulwm6gDXvwE.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVkJx26TKEr37c9aBBxJlks7iLSrwFUlw.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVmJx26TKEr37c9YLJvulwm6gDXvwE.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/sarabun/v7/DtVkJx26TKEr37c9aBBxOlos7iLSrwFUlw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -57967,8 +60503,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sarala/v4/uK_y4riEZv4o1w9RCh0TMv6EXw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sarala/v4/uK_x4riEZv4o1w9ptjI3OtWYVkMpXA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sarala/v4/uK_y4riEZv4o1w9RCh0TMv6EXw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sarala/v4/uK_x4riEZv4o1w9ptjI3OtWYVkMpXA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58037,7 +60575,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sarina/v8/-F6wfjF3ITQwasLhLkDUriBQxw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sarina/v8/-F6wfjF3ITQwasLhLkDUriBQxw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58106,12 +60645,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sarpanch/v5/hESy6Xt4NCpRuk6Pzh2ARIrX_20n.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/sarpanch/v5/hES16Xt4NCpRuk6PziV0ba7f1HEuRHkM.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/sarpanch/v5/hES16Xt4NCpRuk6PziVYaq7f1HEuRHkM.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sarpanch/v5/hES16Xt4NCpRuk6PziU8a67f1HEuRHkM.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/sarpanch/v5/hES16Xt4NCpRuk6PziUgaK7f1HEuRHkM.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/sarpanch/v5/hES16Xt4NCpRuk6PziUEaa7f1HEuRHkM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sarpanch/v5/hESy6Xt4NCpRuk6Pzh2ARIrX_20n.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/sarpanch/v5/hES16Xt4NCpRuk6PziV0ba7f1HEuRHkM.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/sarpanch/v5/hES16Xt4NCpRuk6PziVYaq7f1HEuRHkM.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sarpanch/v5/hES16Xt4NCpRuk6PziU8a67f1HEuRHkM.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/sarpanch/v5/hES16Xt4NCpRuk6PziUgaK7f1HEuRHkM.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/sarpanch/v5/hES16Xt4NCpRuk6PziUEaa7f1HEuRHkM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58180,7 +60725,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/satisfy/v10/rP2Hp2yn6lkG50LoOZSCHBeHFl0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/satisfy/v10/rP2Hp2yn6lkG50LoOZSCHBeHFl0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58249,7 +60795,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sawarabigothic/v8/x3d4ckfVaqqa-BEj-I9mE65u3k3NBSk3E2YljQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sawarabigothic/v8/x3d4ckfVaqqa-BEj-I9mE65u3k3NBSk3E2YljQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58318,7 +60865,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sawarabimincho/v10/8QIRdiDaitzr7brc8ahpxt6GcIJTLahP46UDUw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sawarabimincho/v10/8QIRdiDaitzr7brc8ahpxt6GcIJTLahP46UDUw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58387,10 +60935,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/scada/v8/RLpxK5Pv5qumeWJoxzUobkvv.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/scada/v8/RLp_K5Pv5qumeVJqzTEKa1vvffg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/scada/v8/RLp8K5Pv5qumeVrU6BEgRVfmZOE5.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/scada/v8/RLp6K5Pv5qumeVJq9Y0lT1PEYfE5p6g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/scada/v8/RLpxK5Pv5qumeWJoxzUobkvv.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/scada/v8/RLp_K5Pv5qumeVJqzTEKa1vvffg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/scada/v8/RLp8K5Pv5qumeVrU6BEgRVfmZOE5.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/scada/v8/RLp6K5Pv5qumeVJq9Y0lT1PEYfE5p6g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58459,8 +61011,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/scheherazade/v17/YA9Ur0yF4ETZN60keViq1kQgt5OohvbJ9A.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/scheherazade/v17/YA9Lr0yF4ETZN60keViq1kQYC7yMjt3V_dB0Yw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/scheherazade/v17/YA9Ur0yF4ETZN60keViq1kQgt5OohvbJ9A.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/scheherazade/v17/YA9Lr0yF4ETZN60keViq1kQYC7yMjt3V_dB0Yw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58529,7 +61083,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/schoolbell/v10/92zQtBZWOrcgoe-fgnJIVxIQ6mRqfiQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/schoolbell/v10/92zQtBZWOrcgoe-fgnJIVxIQ6mRqfiQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58598,7 +61153,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/scopeone/v6/WBLnrEXKYFlGHrOKmGD1W0_MJMGxiQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/scopeone/v6/WBLnrEXKYFlGHrOKmGD1W0_MJMGxiQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58667,7 +61223,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/seaweedscript/v7/bx6cNx6Tne2pxOATYE8C_Rsoe0WJ-KcGVbLW.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/seaweedscript/v7/bx6cNx6Tne2pxOATYE8C_Rsoe0WJ-KcGVbLW.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58736,7 +61293,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/secularone/v4/8QINdiTajsj_87rMuMdKypDlMul7LJpK.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/secularone/v4/8QINdiTajsj_87rMuMdKypDlMul7LJpK.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58805,7 +61363,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sedgwickave/v5/uK_04rKEYuguzAcSYRdWTJq8Xmg1Vcf5JA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sedgwickave/v5/uK_04rKEYuguzAcSYRdWTJq8Xmg1Vcf5JA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58874,7 +61433,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sedgwickavedisplay/v5/xfuu0XPgU3jZPUoUo3ScvmPi-NapQ8OxM2czd-YnOzUD.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sedgwickavedisplay/v5/xfuu0XPgU3jZPUoUo3ScvmPi-NapQ8OxM2czd-YnOzUD.ttf',
     };
 
     return googleFontsTextStyle(
@@ -58943,7 +61503,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sevillana/v8/KFOlCnWFscmDt1Bfiy1vAx05IsDqlA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sevillana/v8/KFOlCnWFscmDt1Bfiy1vAx05IsDqlA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59012,7 +61573,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/seymourone/v7/4iCp6Khla9xbjQpoWGGd0myIPYBvgpUI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/seymourone/v7/4iCp6Khla9xbjQpoWGGd0myIPYBvgpUI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59081,7 +61643,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/shadowsintolight/v9/UqyNK9UOIntux_czAvDQx_ZcHqZXBNQDcsr4xzSMYA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/shadowsintolight/v9/UqyNK9UOIntux_czAvDQx_ZcHqZXBNQDcsr4xzSMYA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59150,7 +61713,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/shadowsintolighttwo/v7/4iC86LVlZsRSjQhpWGedwyOoW-0A6_kpsyNmlAvNGLNnIF0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/shadowsintolighttwo/v7/4iC86LVlZsRSjQhpWGedwyOoW-0A6_kpsyNmlAvNGLNnIF0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59219,7 +61783,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/shanti/v11/t5thIREMM4uSDgzgU0ezpKfwzA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/shanti/v11/t5thIREMM4uSDgzgU0ezpKfwzA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59288,10 +61853,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/share/v10/i7dEIFliZjKNF5VNHLq2cV5d.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/share/v10/i7dKIFliZjKNF6VPFr6UdE5dWFM.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/share/v10/i7dJIFliZjKNF63xM56-WkJUQUq7.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/share/v10/i7dPIFliZjKNF6VPLgK7UEZ2RFq7AwU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/share/v10/i7dEIFliZjKNF5VNHLq2cV5d.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/share/v10/i7dKIFliZjKNF6VPFr6UdE5dWFM.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/share/v10/i7dJIFliZjKNF63xM56-WkJUQUq7.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/share/v10/i7dPIFliZjKNF6VPLgK7UEZ2RFq7AwU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59360,7 +61929,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sharetech/v9/7cHtv4Uyi5K0OeZ7bohUwHoDmTcibrA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sharetech/v9/7cHtv4Uyi5K0OeZ7bohUwHoDmTcibrA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59429,7 +61999,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sharetechmono/v9/J7aHnp1uDWRBEqV98dVQztYldFc7pAsEIc3Xew.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sharetechmono/v9/J7aHnp1uDWRBEqV98dVQztYldFc7pAsEIc3Xew.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59498,7 +62069,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/shojumaru/v7/rax_HiWfutkLLnaKCtlMBBJek0vA8A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/shojumaru/v7/rax_HiWfutkLLnaKCtlMBBJek0vA8A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59567,7 +62139,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/shortstack/v9/bMrzmS2X6p0jZC6EcmPFX-SScX8D0nq6.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/shortstack/v9/bMrzmS2X6p0jZC6EcmPFX-SScX8D0nq6.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59636,7 +62209,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/shrikhand/v5/a8IbNovtLWfR7T7bMJwbBIiQ0zhMtA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/shrikhand/v5/a8IbNovtLWfR7T7bMJwbBIiQ0zhMtA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59705,7 +62279,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/siemreap/v12/Gg82N5oFbgLvHAfNl2YbnA8DLXpe.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/siemreap/v12/Gg82N5oFbgLvHAfNl2YbnA8DLXpe.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59774,7 +62349,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sigmarone/v10/co3DmWZ8kjZuErj9Ta3dk6Pjp3Di8U0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sigmarone/v10/co3DmWZ8kjZuErj9Ta3dk6Pjp3Di8U0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59843,10 +62419,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/signika/v10/vEFU2_JTCgwQ5ejvE_oEI3BDa0AdytM.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/signika/v10/vEFR2_JTCgwQ5ejvK1YsB3hod0k.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/signika/v10/vEFU2_JTCgwQ5ejvE44CI3BDa0AdytM.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/signika/v10/vEFU2_JTCgwQ5ejvE-oDI3BDa0AdytM.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/signika/v10/vEFU2_JTCgwQ5ejvE_oEI3BDa0AdytM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/signika/v10/vEFR2_JTCgwQ5ejvK1YsB3hod0k.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/signika/v10/vEFU2_JTCgwQ5ejvE44CI3BDa0AdytM.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/signika/v10/vEFU2_JTCgwQ5ejvE-oDI3BDa0AdytM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59915,10 +62495,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/signikanegative/v10/E217_cfngu7HiRpPX3ZpNE4kY5zKal6DipHD6z_iXAs.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/signikanegative/v10/E218_cfngu7HiRpPX3ZpNE4kY5zKUvKrrpno9zY.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/signikanegative/v10/E217_cfngu7HiRpPX3ZpNE4kY5zKaiqFipHD6z_iXAs.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/signikanegative/v10/E217_cfngu7HiRpPX3ZpNE4kY5zKak6EipHD6z_iXAs.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/signikanegative/v10/E217_cfngu7HiRpPX3ZpNE4kY5zKal6DipHD6z_iXAs.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/signikanegative/v10/E218_cfngu7HiRpPX3ZpNE4kY5zKUvKrrpno9zY.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/signikanegative/v10/E217_cfngu7HiRpPX3ZpNE4kY5zKaiqFipHD6z_iXAs.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/signikanegative/v10/E217_cfngu7HiRpPX3ZpNE4kY5zKak6EipHD6z_iXAs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -59987,10 +62571,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/simonetta/v10/x3dickHVYrCU5BU15c4BfPACvy_1BA.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/simonetta/v10/x3dkckHVYrCU5BU15c4xfvoGnSrlBBsy.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/simonetta/v10/x3dnckHVYrCU5BU15c45-N0mtwTpDQIrGg.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/simonetta/v10/x3d5ckHVYrCU5BU15c4xfsKCsA7tLwc7Gn88.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/simonetta/v10/x3dickHVYrCU5BU15c4BfPACvy_1BA.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/simonetta/v10/x3dkckHVYrCU5BU15c4xfvoGnSrlBBsy.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/simonetta/v10/x3dnckHVYrCU5BU15c45-N0mtwTpDQIrGg.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/simonetta/v10/x3d5ckHVYrCU5BU15c4xfsKCsA7tLwc7Gn88.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60059,7 +62647,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/singleday/v1/LYjHdGDjlEgoAcF95EI5jVoFUNfeQJU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/singleday/v1/LYjHdGDjlEgoAcF95EI5jVoFUNfeQJU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60128,8 +62717,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sintony/v7/XoHm2YDqR7-98cVUITQnu98ojjs.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sintony/v7/XoHj2YDqR7-98cVUGYgIn9cDkjLp6C8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sintony/v7/XoHm2YDqR7-98cVUITQnu98ojjs.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sintony/v7/XoHj2YDqR7-98cVUGYgIn9cDkjLp6C8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60198,7 +62789,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sirinstencil/v8/mem4YaWwznmLx-lzGfN7MdRydchGBq6al6o.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sirinstencil/v8/mem4YaWwznmLx-lzGfN7MdRydchGBq6al6o.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60267,7 +62859,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sixcaps/v10/6ae_4KGrU7VR7bNmabcS9XXaPCop.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sixcaps/v10/6ae_4KGrU7VR7bNmabcS9XXaPCop.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60336,8 +62929,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/skranji/v7/OZpDg_dtriVFNerMYzuuklTm3Ek.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/skranji/v7/OZpGg_dtriVFNerMW4eBtlzNwED-b4g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/skranji/v7/OZpDg_dtriVFNerMYzuuklTm3Ek.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/skranji/v7/OZpGg_dtriVFNerMW4eBtlzNwED-b4g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60406,7 +63001,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/slabo13px/v7/11hEGp_azEvXZUdSBzzRcKer2wkYnvI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/slabo13px/v7/11hEGp_azEvXZUdSBzzRcKer2wkYnvI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60475,7 +63071,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/slabo27px/v6/mFT0WbgBwKPR_Z4hGN2qsxgJ1EJ7i90.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/slabo27px/v6/mFT0WbgBwKPR_Z4hGN2qsxgJ1EJ7i90.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60544,7 +63141,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/slackey/v10/N0bV2SdQO-5yM0-dKlRaJdbWgdY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/slackey/v10/N0bV2SdQO-5yM0-dKlRaJdbWgdY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60613,7 +63211,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/smokum/v10/TK3iWkUbAhopmrdGHjUHte5fKg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/smokum/v10/TK3iWkUbAhopmrdGHjUHte5fKg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60682,7 +63281,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/smythe/v10/MwQ3bhT01--coT1BOLh_uGInjA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/smythe/v10/MwQ3bhT01--coT1BOLh_uGInjA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60751,8 +63351,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sniglet/v11/cIf9MaFLtkE3UjaJxCmrYGkHgIs.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/sniglet/v11/cIf4MaFLtkE3UjaJ_ImHRGEsnIJkWL4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sniglet/v11/cIf9MaFLtkE3UjaJxCmrYGkHgIs.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/sniglet/v11/cIf4MaFLtkE3UjaJ_ImHRGEsnIJkWL4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60821,7 +63423,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/snippet/v9/bWt47f7XfQH9Gupu2v_Afcp9QWc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/snippet/v9/bWt47f7XfQH9Gupu2v_Afcp9QWc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60890,7 +63493,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/snowburstone/v7/MQpS-WezKdujBsXY3B7I-UT7eZ-UPyacPbo.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/snowburstone/v7/MQpS-WezKdujBsXY3B7I-UT7eZ-UPyacPbo.ttf',
     };
 
     return googleFontsTextStyle(
@@ -60959,7 +63563,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sofadione/v8/JIA2UVBxdnVBuElZaMFGcDOIETkmYDU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sofadione/v8/JIA2UVBxdnVBuElZaMFGcDOIETkmYDU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61028,7 +63633,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sofia/v8/8QIHdirahM3j_vu-sowsrqjk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sofia/v8/8QIHdirahM3j_vu-sowsrqjk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61097,11 +63703,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/solway/v1/AMOTz46Cs2uTAOCuLlgZms0QW3mqyg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/solway/v1/AMOQz46Cs2uTAOCWgnA9kuYMUg.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/solway/v1/AMOTz46Cs2uTAOCudlkZms0QW3mqyg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/solway/v1/AMOTz46Cs2uTAOCuPl8Zms0QW3mqyg.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/solway/v1/AMOTz46Cs2uTAOCuIlwZms0QW3mqyg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/solway/v1/AMOTz46Cs2uTAOCuLlgZms0QW3mqyg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/solway/v1/AMOQz46Cs2uTAOCWgnA9kuYMUg.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/solway/v1/AMOTz46Cs2uTAOCudlkZms0QW3mqyg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/solway/v1/AMOTz46Cs2uTAOCuPl8Zms0QW3mqyg.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/solway/v1/AMOTz46Cs2uTAOCuIlwZms0QW3mqyg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61170,7 +63781,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/songmyung/v8/1cX2aUDWAJH5-EIC7DIhr1GqhcitzeM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/songmyung/v8/1cX2aUDWAJH5-EIC7DIhr1GqhcitzeM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61239,7 +63851,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sonsieone/v8/PbymFmP_EAnPqbKaoc18YVu80lbp8JM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sonsieone/v8/PbymFmP_EAnPqbKaoc18YVu80lbp8JM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61308,8 +63921,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sortsmillgoudy/v9/Qw3GZR9MED_6PSuS_50nEaVrfzgEXH0OjpM75PE.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/sortsmillgoudy/v9/Qw3AZR9MED_6PSuS_50nEaVrfzgEbH8EirE-9PGLfQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sortsmillgoudy/v9/Qw3GZR9MED_6PSuS_50nEaVrfzgEXH0OjpM75PE.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/sortsmillgoudy/v9/Qw3AZR9MED_6PSuS_50nEaVrfzgEbH8EirE-9PGLfQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61378,20 +63993,34 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_XiYsKILxRpg3hIP6sJ7fM7Pqt8srztO0rzmmkDQ.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_ViYsKILxRpg3hIP6sJ7fM7PqlONMbtecv7Gy0DRzS.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_XiYsKILxRpg3hIP6sJ7fM7PqtlsnztO0rzmmkDQ.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_ViYsKILxRpg3hIP6sJ7fM7PqlONN_tucv7Gy0DRzS.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_SiYsKILxRpg3hIP6sJ7fM7PqVOuHXvMY3xw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_QiYsKILxRpg3hIP6sJ7fM7PqlOOvTnsMnx3C9.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_XiYsKILxRpg3hIP6sJ7fM7PqtzsjztO0rzmmkDQ.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_ViYsKILxRpg3hIP6sJ7fM7PqlONMnt-cv7Gy0DRzS.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_XiYsKILxRpg3hIP6sJ7fM7Pqt4s_ztO0rzmmkDQ.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_ViYsKILxRpg3hIP6sJ7fM7PqlONMLsOcv7Gy0DRzS.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_XiYsKILxRpg3hIP6sJ7fM7Pqths7ztO0rzmmkDQ.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_ViYsKILxRpg3hIP6sJ7fM7PqlONNvsecv7Gy0DRzS.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_XiYsKILxRpg3hIP6sJ7fM7PqtvszztO0rzmmkDQ.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_ViYsKILxRpg3hIP6sJ7fM7PqlONNXs-cv7Gy0DRzS.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_XiYsKILxRpg3hIP6sJ7fM7Pqt8srztO0rzmmkDQ.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_ViYsKILxRpg3hIP6sJ7fM7PqlONMbtecv7Gy0DRzS.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_XiYsKILxRpg3hIP6sJ7fM7PqtlsnztO0rzmmkDQ.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_ViYsKILxRpg3hIP6sJ7fM7PqlONN_tucv7Gy0DRzS.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_SiYsKILxRpg3hIP6sJ7fM7PqVOuHXvMY3xw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_QiYsKILxRpg3hIP6sJ7fM7PqlOOvTnsMnx3C9.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_XiYsKILxRpg3hIP6sJ7fM7PqtzsjztO0rzmmkDQ.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_ViYsKILxRpg3hIP6sJ7fM7PqlONMnt-cv7Gy0DRzS.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_XiYsKILxRpg3hIP6sJ7fM7Pqt4s_ztO0rzmmkDQ.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_ViYsKILxRpg3hIP6sJ7fM7PqlONMLsOcv7Gy0DRzS.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_XiYsKILxRpg3hIP6sJ7fM7Pqths7ztO0rzmmkDQ.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_ViYsKILxRpg3hIP6sJ7fM7PqlONNvsecv7Gy0DRzS.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_XiYsKILxRpg3hIP6sJ7fM7PqtvszztO0rzmmkDQ.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/sourcecodepro/v11/HI_ViYsKILxRpg3hIP6sJ7fM7PqlONNXs-cv7Gy0DRzS.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61460,18 +64089,30 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKydSBYKcSV-LCoeQqfX1RYOo3i94_AkB1v_8CGxg.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKwdSBYKcSV-LCoeQqfX1RYOo3qPZYokRdr3cWWxg40.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKydSBYKcSV-LCoeQqfX1RYOo3ik4zAkB1v_8CGxg.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKwdSBYKcSV-LCoeQqfX1RYOo3qPZZMkhdr3cWWxg40.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sourcesanspro/v13/6xK3dSBYKcSV-LCoeQqfX1RYOo3aP6TkmDZz9g.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/sourcesanspro/v13/6xK1dSBYKcSV-LCoeQqfX1RYOo3qPa7gujNj9tmf.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKydSBYKcSV-LCoeQqfX1RYOo3i54rAkB1v_8CGxg.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKwdSBYKcSV-LCoeQqfX1RYOo3qPZY4lBdr3cWWxg40.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKydSBYKcSV-LCoeQqfX1RYOo3ig4vAkB1v_8CGxg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKwdSBYKcSV-LCoeQqfX1RYOo3qPZZclRdr3cWWxg40.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKydSBYKcSV-LCoeQqfX1RYOo3iu4nAkB1v_8CGxg.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKwdSBYKcSV-LCoeQqfX1RYOo3qPZZklxdr3cWWxg40.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKydSBYKcSV-LCoeQqfX1RYOo3i94_AkB1v_8CGxg.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKwdSBYKcSV-LCoeQqfX1RYOo3qPZYokRdr3cWWxg40.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKydSBYKcSV-LCoeQqfX1RYOo3ik4zAkB1v_8CGxg.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKwdSBYKcSV-LCoeQqfX1RYOo3qPZZMkhdr3cWWxg40.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sourcesanspro/v13/6xK3dSBYKcSV-LCoeQqfX1RYOo3aP6TkmDZz9g.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/sourcesanspro/v13/6xK1dSBYKcSV-LCoeQqfX1RYOo3qPa7gujNj9tmf.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKydSBYKcSV-LCoeQqfX1RYOo3i54rAkB1v_8CGxg.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKwdSBYKcSV-LCoeQqfX1RYOo3qPZY4lBdr3cWWxg40.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKydSBYKcSV-LCoeQqfX1RYOo3ig4vAkB1v_8CGxg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKwdSBYKcSV-LCoeQqfX1RYOo3qPZZclRdr3cWWxg40.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKydSBYKcSV-LCoeQqfX1RYOo3iu4nAkB1v_8CGxg.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/sourcesanspro/v13/6xKwdSBYKcSV-LCoeQqfX1RYOo3qPZZklxdr3cWWxg40.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61540,9 +64181,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sourceserifpro/v7/neIQzD-0qpwxpaWvjeD0X88SAOeaiXM0oSOL2Yw.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/sourceserifpro/v7/neIXzD-0qpwxpaWvjeD0X88SAOeasasahSugxYUvZrI.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sourceserifpro/v7/neIXzD-0qpwxpaWvjeD0X88SAOeasc8bhSugxYUvZrI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sourceserifpro/v7/neIQzD-0qpwxpaWvjeD0X88SAOeaiXM0oSOL2Yw.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/sourceserifpro/v7/neIXzD-0qpwxpaWvjeD0X88SAOeasasahSugxYUvZrI.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sourceserifpro/v7/neIXzD-0qpwxpaWvjeD0X88SAOeasc8bhSugxYUvZrI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61611,10 +64255,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/spacemono/v5/i7dPIFZifjKcF5UAWdDRUEZ2RFq7AwU.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/spacemono/v5/i7dNIFZifjKcF5UAWdDRYER8QHi-EwWMbg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/spacemono/v5/i7dMIFZifjKcF5UAWdDRaPpZYFKQHwyVd3U.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/spacemono/v5/i7dSIFZifjKcF5UAWdDRYERE_FeaGy6QZ3WfYg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/spacemono/v5/i7dPIFZifjKcF5UAWdDRUEZ2RFq7AwU.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/spacemono/v5/i7dNIFZifjKcF5UAWdDRYER8QHi-EwWMbg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/spacemono/v5/i7dMIFZifjKcF5UAWdDRaPpZYFKQHwyVd3U.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/spacemono/v5/i7dSIFZifjKcF5UAWdDRYERE_FeaGy6QZ3WfYg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61683,7 +64331,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/specialelite/v10/XLYgIZbkc4JPUL5CVArUVL0nhncESXFtUsM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/specialelite/v10/XLYgIZbkc4JPUL5CVArUVL0nhncESXFtUsM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61752,20 +64401,34 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/spectral/v6/rnCs-xNNww_2s0amA9v2s13GY_etWWIJ.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/spectral/v6/rnCu-xNNww_2s0amA9M8qrXHafOPXHIJErY.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/spectral/v6/rnCs-xNNww_2s0amA9uSsF3GY_etWWIJ.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/spectral/v6/rnCu-xNNww_2s0amA9M8qtHEafOPXHIJErY.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/spectral/v6/rnCr-xNNww_2s0amA-M-mHnOSOuk.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/spectral/v6/rnCt-xNNww_2s0amA9M8kn3sTfukQHs.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/spectral/v6/rnCs-xNNww_2s0amA9vKsV3GY_etWWIJ.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/spectral/v6/rnCu-xNNww_2s0amA9M8qonFafOPXHIJErY.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/spectral/v6/rnCs-xNNww_2s0amA9vmtl3GY_etWWIJ.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/spectral/v6/rnCu-xNNww_2s0amA9M8qqXCafOPXHIJErY.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/spectral/v6/rnCs-xNNww_2s0amA9uCt13GY_etWWIJ.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/spectral/v6/rnCu-xNNww_2s0amA9M8qsHDafOPXHIJErY.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/spectral/v6/rnCs-xNNww_2s0amA9uetF3GY_etWWIJ.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/spectral/v6/rnCu-xNNww_2s0amA9M8qt3AafOPXHIJErY.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCs-xNNww_2s0amA9v2s13GY_etWWIJ.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCu-xNNww_2s0amA9M8qrXHafOPXHIJErY.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCs-xNNww_2s0amA9uSsF3GY_etWWIJ.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCu-xNNww_2s0amA9M8qtHEafOPXHIJErY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCr-xNNww_2s0amA-M-mHnOSOuk.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCt-xNNww_2s0amA9M8kn3sTfukQHs.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCs-xNNww_2s0amA9vKsV3GY_etWWIJ.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCu-xNNww_2s0amA9M8qonFafOPXHIJErY.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCs-xNNww_2s0amA9vmtl3GY_etWWIJ.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCu-xNNww_2s0amA9M8qqXCafOPXHIJErY.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCs-xNNww_2s0amA9uCt13GY_etWWIJ.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCu-xNNww_2s0amA9M8qsHDafOPXHIJErY.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCs-xNNww_2s0amA9uetF3GY_etWWIJ.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/spectral/v6/rnCu-xNNww_2s0amA9M8qt3AafOPXHIJErY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61834,20 +64497,34 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/spectralsc/v5/Ktk0ALCRZonmalTgyPmRfs1qwkTXPYeVXJZB.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/spectralsc/v5/Ktk2ALCRZonmalTgyPmRfsWg26zWN4O3WYZB_sU.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/spectralsc/v5/Ktk0ALCRZonmalTgyPmRfs0OwUTXPYeVXJZB.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/spectralsc/v5/Ktk2ALCRZonmalTgyPmRfsWg28jVN4O3WYZB_sU.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/spectralsc/v5/KtkpALCRZonmalTgyPmRfvWi6WDfFpuc.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/spectralsc/v5/KtkrALCRZonmalTgyPmRfsWg42T9E4ucRY8.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/spectralsc/v5/Ktk0ALCRZonmalTgyPmRfs1WwETXPYeVXJZB.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/spectralsc/v5/Ktk2ALCRZonmalTgyPmRfsWg25DUN4O3WYZB_sU.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/spectralsc/v5/Ktk0ALCRZonmalTgyPmRfs16x0TXPYeVXJZB.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/spectralsc/v5/Ktk2ALCRZonmalTgyPmRfsWg27zTN4O3WYZB_sU.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/spectralsc/v5/Ktk0ALCRZonmalTgyPmRfs0exkTXPYeVXJZB.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/spectralsc/v5/Ktk2ALCRZonmalTgyPmRfsWg29jSN4O3WYZB_sU.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/spectralsc/v5/Ktk0ALCRZonmalTgyPmRfs0CxUTXPYeVXJZB.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/spectralsc/v5/Ktk2ALCRZonmalTgyPmRfsWg28TRN4O3WYZB_sU.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/Ktk0ALCRZonmalTgyPmRfs1qwkTXPYeVXJZB.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/Ktk2ALCRZonmalTgyPmRfsWg26zWN4O3WYZB_sU.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/Ktk0ALCRZonmalTgyPmRfs0OwUTXPYeVXJZB.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/Ktk2ALCRZonmalTgyPmRfsWg28jVN4O3WYZB_sU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/KtkpALCRZonmalTgyPmRfvWi6WDfFpuc.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/KtkrALCRZonmalTgyPmRfsWg42T9E4ucRY8.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/Ktk0ALCRZonmalTgyPmRfs1WwETXPYeVXJZB.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/Ktk2ALCRZonmalTgyPmRfsWg25DUN4O3WYZB_sU.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/Ktk0ALCRZonmalTgyPmRfs16x0TXPYeVXJZB.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/Ktk2ALCRZonmalTgyPmRfsWg27zTN4O3WYZB_sU.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/Ktk0ALCRZonmalTgyPmRfs0exkTXPYeVXJZB.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/Ktk2ALCRZonmalTgyPmRfsWg29jSN4O3WYZB_sU.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/Ktk0ALCRZonmalTgyPmRfs0CxUTXPYeVXJZB.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/spectralsc/v5/Ktk2ALCRZonmalTgyPmRfsWg28TRN4O3WYZB_sU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61916,7 +64593,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/spicyrice/v8/uK_24rSEd-Uqwk4jY1RyGv-2WkowRcc.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/spicyrice/v8/uK_24rSEd-Uqwk4jY1RyGv-2WkowRcc.ttf',
     };
 
     return googleFontsTextStyle(
@@ -61985,7 +64663,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/spinnaker/v11/w8gYH2oyX-I0_rvR6Hmn3HwLqOqSBg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/spinnaker/v11/w8gYH2oyX-I0_rvR6Hmn3HwLqOqSBg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62054,7 +64733,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/spirax/v8/buE3poKgYNLy0F3cXktt-Csn-Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/spirax/v8/buE3poKgYNLy0F3cXktt-Csn-Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62123,7 +64803,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/squadaone/v8/BCasqZ8XsOrx4mcOk6MtWaA8WDBkHgs.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/squadaone/v8/BCasqZ8XsOrx4mcOk6MtWaA8WDBkHgs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62192,7 +64873,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sreekrushnadevaraya/v7/R70FjzQeifmPepmyQQjQ9kvwMkWYPfTA_EWb2FhQuXir.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sreekrushnadevaraya/v7/R70FjzQeifmPepmyQQjQ9kvwMkWYPfTA_EWb2FhQuXir.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62261,7 +64943,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sriracha/v4/0nkrC9D4IuYBgWcI9ObYRQDioeb0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sriracha/v4/0nkrC9D4IuYBgWcI9ObYRQDioeb0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62330,8 +65013,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/srisakdi/v3/yMJRMIlvdpDbkB0A-jq8fSx5i814.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/srisakdi/v3/yMJWMIlvdpDbkB0A-gIAUghxoNFxW0Hz.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/srisakdi/v3/yMJRMIlvdpDbkB0A-jq8fSx5i814.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/srisakdi/v3/yMJWMIlvdpDbkB0A-gIAUghxoNFxW0Hz.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62400,7 +65085,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/staatliches/v3/HI_OiY8KO6hCsQSoAPmtMbectJG9O9PS.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/staatliches/v3/HI_OiY8KO6hCsQSoAPmtMbectJG9O9PS.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62469,7 +65155,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/stalemate/v7/taiIGmZ_EJq97-UfkZRpuqSs8ZQpaQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/stalemate/v7/taiIGmZ_EJq97-UfkZRpuqSs8ZQpaQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62538,7 +65225,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/stalinistone/v25/MQpS-WezM9W4Dd7D3B7I-UT7eZ-UPyacPbo.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/stalinistone/v25/MQpS-WezM9W4Dd7D3B7I-UT7eZ-UPyacPbo.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62607,8 +65295,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/stardosstencil/v10/X7n94bcuGPC8hrvEOHXOgaKCc2TR71R3tiSx0g.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/stardosstencil/v10/X7n44bcuGPC8hrvEOHXOgaKCc2TpU3tTvg-t29HSHw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/stardosstencil/v10/X7n94bcuGPC8hrvEOHXOgaKCc2TR71R3tiSx0g.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/stardosstencil/v10/X7n44bcuGPC8hrvEOHXOgaKCc2TpU3tTvg-t29HSHw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62677,7 +65367,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/stintultracondensed/v8/-W_gXIrsVjjeyEnPC45qD2NoFPtBE0xCh2A-qhUO2cNvdg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/stintultracondensed/v8/-W_gXIrsVjjeyEnPC45qD2NoFPtBE0xCh2A-qhUO2cNvdg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62746,7 +65437,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/stintultraexpanded/v7/CSRg4yNNh-GbW3o3JkwoDcdvMKMf0oBAd0qoATQkWwam.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/stintultraexpanded/v7/CSRg4yNNh-GbW3o3JkwoDcdvMKMf0oBAd0qoATQkWwam.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62815,8 +65507,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/stoke/v9/z7NXdRb7aTMfKNvFVgxC_pjcTeWU.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/stoke/v9/z7NadRb7aTMfKONpfihK1YTV.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/stoke/v9/z7NXdRb7aTMfKNvFVgxC_pjcTeWU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/stoke/v9/z7NadRb7aTMfKONpfihK1YTV.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62885,7 +65579,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/strait/v7/DtViJxy6WaEr1LZzeDhtkl0U7w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/strait/v7/DtViJxy6WaEr1LZzeDhtkl0U7w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -62954,7 +65649,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/stylish/v8/m8JSjfhPYriQkk7-fo35dLxEdmo.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/stylish/v8/m8JSjfhPYriQkk7-fo35dLxEdmo.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63023,7 +65719,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sueellenfrancisco/v10/wXK3E20CsoJ9j1DDkjHcQ5ZL8xRaxru9ropF2lqk9H4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sueellenfrancisco/v10/wXK3E20CsoJ9j1DDkjHcQ5ZL8xRaxru9ropF2lqk9H4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63092,7 +65789,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/suezone/v4/taiJGmd_EZ6rqscQgNFJkIqg-I0w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/suezone/v4/taiJGmd_EZ6rqscQgNFJkIqg-I0w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63161,9 +65859,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/sulphurpoint/v1/RLpkK5vv8KaycDcazWFPBj2afVU6n6kFUHPIFaU.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sulphurpoint/v1/RLp5K5vv8KaycDcazWFPBj2aRfkSu6EuTHo.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sulphurpoint/v1/RLpkK5vv8KaycDcazWFPBj2afUU9n6kFUHPIFaU.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/sulphurpoint/v1/RLpkK5vv8KaycDcazWFPBj2afVU6n6kFUHPIFaU.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sulphurpoint/v1/RLp5K5vv8KaycDcazWFPBj2aRfkSu6EuTHo.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sulphurpoint/v1/RLpkK5vv8KaycDcazWFPBj2afUU9n6kFUHPIFaU.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63232,8 +65933,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sumana/v4/4UaDrE5TqRBjGj-G8Bji76zR4w.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sumana/v4/4UaArE5TqRBjGj--TDfG54fN6ppsKg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sumana/v4/4UaDrE5TqRBjGj-G8Bji76zR4w.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sumana/v4/4UaArE5TqRBjGj--TDfG54fN6ppsKg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63302,9 +66005,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/sunflower/v9/RWmPoKeF8fUjqIj7Vc-06MfiqYsGBGBzCw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/sunflower/v9/RWmPoKeF8fUjqIj7Vc-0sMbiqYsGBGBzCw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sunflower/v9/RWmPoKeF8fUjqIj7Vc-0-MDiqYsGBGBzCw.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/sunflower/v9/RWmPoKeF8fUjqIj7Vc-06MfiqYsGBGBzCw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/sunflower/v9/RWmPoKeF8fUjqIj7Vc-0sMbiqYsGBGBzCw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sunflower/v9/RWmPoKeF8fUjqIj7Vc-0-MDiqYsGBGBzCw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63373,7 +66079,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sunshiney/v10/LDIwapGTLBwsS-wT4vcgE8moUePWkg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sunshiney/v10/LDIwapGTLBwsS-wT4vcgE8moUePWkg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63442,7 +66149,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/supermercadoone/v9/OpNXnpQWg8jc_xps_Gi14kVVEXOn60b3MClBRTs.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/supermercadoone/v9/OpNXnpQWg8jc_xps_Gi14kVVEXOn60b3MClBRTs.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63511,8 +66219,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/sura/v4/SZc23FL5PbyzFf5UWzXtjUM.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/sura/v4/SZc53FL5PbyzLUJ7fz3GkUrS8DI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/sura/v4/SZc23FL5PbyzFf5UWzXtjUM.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/sura/v4/SZc53FL5PbyzLUJ7fz3GkUrS8DI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63581,7 +66291,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/suranna/v7/gokuH6ztGkFjWe58tBRZT2KmgP0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/suranna/v7/gokuH6ztGkFjWe58tBRZT2KmgP0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63650,7 +66361,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/suravaram/v6/_gP61R_usiY7SCym4xIAi261Qv9roQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/suravaram/v6/_gP61R_usiY7SCym4xIAi261Qv9roQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63719,7 +66431,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/suwannaphum/v13/jAnCgHV7GtDvc8jbe8hXXIWl_8C0Wg2V.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/suwannaphum/v13/jAnCgHV7GtDvc8jbe8hXXIWl_8C0Wg2V.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63788,7 +66501,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/swankyandmoomoo/v9/flUlRrKz24IuWVI_WJYTYcqbEsMUZ3kUtbPkR64SYQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/swankyandmoomoo/v9/flUlRrKz24IuWVI_WJYTYcqbEsMUZ3kUtbPkR64SYQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63857,8 +66571,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/syncopate/v11/pe0sMIuPIYBCpEV5eFdyAv2-C99ycg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/syncopate/v11/pe0pMIuPIYBCpEV5eFdKvtKaA_Rue1UwVg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/syncopate/v11/pe0sMIuPIYBCpEV5eFdyAv2-C99ycg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/syncopate/v11/pe0pMIuPIYBCpEV5eFdKvtKaA_Rue1UwVg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -63927,13 +66643,20 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/tajawal/v3/Iurf6YBj_oCad4k1l_6gLrZjiLlJ-G0.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/tajawal/v3/Iurf6YBj_oCad4k1l5qjLrZjiLlJ-G0.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/tajawal/v3/Iura6YBj_oCad4k1rzaLCr5IlLA.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/tajawal/v3/Iurf6YBj_oCad4k1l8KiLrZjiLlJ-G0.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/tajawal/v3/Iurf6YBj_oCad4k1l4qkLrZjiLlJ-G0.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/tajawal/v3/Iurf6YBj_oCad4k1l5anLrZjiLlJ-G0.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/tajawal/v3/Iurf6YBj_oCad4k1l7KmLrZjiLlJ-G0.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/tajawal/v3/Iurf6YBj_oCad4k1l_6gLrZjiLlJ-G0.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/tajawal/v3/Iurf6YBj_oCad4k1l5qjLrZjiLlJ-G0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/tajawal/v3/Iura6YBj_oCad4k1rzaLCr5IlLA.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/tajawal/v3/Iurf6YBj_oCad4k1l8KiLrZjiLlJ-G0.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/tajawal/v3/Iurf6YBj_oCad4k1l4qkLrZjiLlJ-G0.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/tajawal/v3/Iurf6YBj_oCad4k1l5anLrZjiLlJ-G0.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/tajawal/v3/Iurf6YBj_oCad4k1l7KmLrZjiLlJ-G0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64002,8 +66725,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/tangerine/v11/IurY6Y5j_oScZZow4VOBDpxNhLBQ4Q.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/tangerine/v11/Iurd6Y5j_oScZZow4VO5srNpjJtM6G0t9w.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/tangerine/v11/IurY6Y5j_oScZZow4VOBDpxNhLBQ4Q.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/tangerine/v11/Iurd6Y5j_oScZZow4VO5srNpjJtM6G0t9w.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64072,7 +66797,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/taprom/v11/UcCn3F82JHycULbFQyk3-0kvHg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/taprom/v11/UcCn3F82JHycULbFQyk3-0kvHg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64141,7 +66867,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/tauri/v8/TwMA-IISS0AM3IpVWHU_TBqO.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/tauri/v8/TwMA-IISS0AM3IpVWHU_TBqO.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64210,24 +66937,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/taviraj/v5/ahcbv8Cj3ylylTXzRIorV8N1jU2gog.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/taviraj/v5/ahcdv8Cj3ylylTXzTOwTM8lxr0iwolLl.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzRCYKd-lbgUS5u0s.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwTn-hRhWa8q0v8ag.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzREIJd-lbgUS5u0s.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwT--tRhWa8q0v8ag.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/taviraj/v5/ahcZv8Cj3ylylTXzfO4hU-FwnU0.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/taviraj/v5/ahcbv8Cj3ylylTXzTOwrV8N1jU2gog.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzRBoId-lbgUS5u0s.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwTo-pRhWa8q0v8ag.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzRDYPd-lbgUS5u0s.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwTj-1RhWa8q0v8ag.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzRFIOd-lbgUS5u0s.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwT6-xRhWa8q0v8ag.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzRE4Nd-lbgUS5u0s.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwT9-9RhWa8q0v8ag.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzRGoMd-lbgUS5u0s.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwT0-5RhWa8q0v8ag.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahcbv8Cj3ylylTXzRIorV8N1jU2gog.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahcdv8Cj3ylylTXzTOwTM8lxr0iwolLl.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzRCYKd-lbgUS5u0s.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwTn-hRhWa8q0v8ag.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzREIJd-lbgUS5u0s.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwT--tRhWa8q0v8ag.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahcZv8Cj3ylylTXzfO4hU-FwnU0.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahcbv8Cj3ylylTXzTOwrV8N1jU2gog.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzRBoId-lbgUS5u0s.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwTo-pRhWa8q0v8ag.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzRDYPd-lbgUS5u0s.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwTj-1RhWa8q0v8ag.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzRFIOd-lbgUS5u0s.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwT6-xRhWa8q0v8ag.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzRE4Nd-lbgUS5u0s.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwT9-9RhWa8q0v8ag.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahccv8Cj3ylylTXzRGoMd-lbgUS5u0s.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/taviraj/v5/ahcev8Cj3ylylTXzTOwT0-5RhWa8q0v8ag.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64296,11 +67041,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/teko/v9/LYjCdG7kmE0gdQhfgCNqqVIuTN4.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/teko/v9/LYjNdG7kmE0gTaR3pCtBtVs.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/teko/v9/LYjCdG7kmE0gdVBegCNqqVIuTN4.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/teko/v9/LYjCdG7kmE0gdXxZgCNqqVIuTN4.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/teko/v9/LYjCdG7kmE0gdRhYgCNqqVIuTN4.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/teko/v9/LYjCdG7kmE0gdQhfgCNqqVIuTN4.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/teko/v9/LYjNdG7kmE0gTaR3pCtBtVs.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/teko/v9/LYjCdG7kmE0gdVBegCNqqVIuTN4.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/teko/v9/LYjCdG7kmE0gdXxZgCNqqVIuTN4.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/teko/v9/LYjCdG7kmE0gdRhYgCNqqVIuTN4.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64369,7 +67119,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/telex/v8/ieVw2Y1fKWmIO9fTB1piKFIf.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/telex/v8/ieVw2Y1fKWmIO9fTB1piKFIf.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64438,7 +67189,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/tenaliramakrishna/v6/raxgHj6Yt9gAN3LLKs0BZVMo8jmwn1-8KJXqUFFvtA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/tenaliramakrishna/v6/raxgHj6Yt9gAN3LLKs0BZVMo8jmwn1-8KJXqUFFvtA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64507,7 +67259,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/tenorsans/v11/bx6ANxqUneKx06UkIXISr3JyC22IyqI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/tenorsans/v11/bx6ANxqUneKx06UkIXISr3JyC22IyqI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64576,7 +67329,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/textmeone/v7/i7dOIFdlayuLUvgoFvHQFWZcalayGhyV.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/textmeone/v7/i7dOIFdlayuLUvgoFvHQFWZcalayGhyV.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64645,10 +67399,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/thasadith/v3/mtG44_1TIqPYrd_f5R1YsEkU0CWuFw.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/thasadith/v3/mtG-4_1TIqPYrd_f5R1oskMQ8iC-F1ZE.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/thasadith/v3/mtG94_1TIqPYrd_f5R1gDGYw2A6yHk9d8w.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/thasadith/v3/mtGj4_1TIqPYrd_f5R1osnus3QS2PEpN8zxA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/thasadith/v3/mtG44_1TIqPYrd_f5R1YsEkU0CWuFw.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/thasadith/v3/mtG-4_1TIqPYrd_f5R1oskMQ8iC-F1ZE.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/thasadith/v3/mtG94_1TIqPYrd_f5R1gDGYw2A6yHk9d8w.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/thasadith/v3/mtGj4_1TIqPYrd_f5R1osnus3QS2PEpN8zxA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64717,7 +67475,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/thegirlnextdoor/v10/pe0zMJCIMIsBjFxqYBIcZ6_OI5oFHCYIV7t7w6bE2A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/thegirlnextdoor/v10/pe0zMJCIMIsBjFxqYBIcZ6_OI5oFHCYIV7t7w6bE2A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64786,9 +67545,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/tienne/v12/AYCKpX7pe9YCRP0LkEPHSFNyxw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/tienne/v12/AYCJpX7pe9YCRP0zLGzjQHhuzvef5Q.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/tienne/v12/AYCJpX7pe9YCRP0zFG7jQHhuzvef5Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/tienne/v12/AYCKpX7pe9YCRP0LkEPHSFNyxw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/tienne/v12/AYCJpX7pe9YCRP0zLGzjQHhuzvef5Q.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/tienne/v12/AYCJpX7pe9YCRP0zFG7jQHhuzvef5Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64857,11 +67619,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/tillana/v5/VuJxdNvf35P4qJ1OeKbXOIFneRo.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/tillana/v5/VuJ0dNvf35P4qJ1OQFL-HIlMZRNcp0o.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/tillana/v5/VuJ0dNvf35P4qJ1OQH75HIlMZRNcp0o.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/tillana/v5/VuJ0dNvf35P4qJ1OQBr4HIlMZRNcp0o.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/tillana/v5/VuJ0dNvf35P4qJ1OQAb7HIlMZRNcp0o.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/tillana/v5/VuJxdNvf35P4qJ1OeKbXOIFneRo.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/tillana/v5/VuJ0dNvf35P4qJ1OQFL-HIlMZRNcp0o.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/tillana/v5/VuJ0dNvf35P4qJ1OQH75HIlMZRNcp0o.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/tillana/v5/VuJ0dNvf35P4qJ1OQBr4HIlMZRNcp0o.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/tillana/v5/VuJ0dNvf35P4qJ1OQAb7HIlMZRNcp0o.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64930,7 +67697,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/timmana/v4/6xKvdShfL9yK-rvpCmvbKHwJUOM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/timmana/v4/6xKvdShfL9yK-rvpCmvbKHwJUOM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -64999,10 +67767,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/tinos/v13/buE4poGnedXvwgX8dGVh8TI-.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/tinos/v13/buE2poGnedXvwjX-fmFD9CI-4NU.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/tinos/v13/buE1poGnedXvwj1AW0Fp2i43-cxL.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/tinos/v13/buEzpoGnedXvwjX-Rt1s0CoV_NxLeiw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/tinos/v13/buE4poGnedXvwgX8dGVh8TI-.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/tinos/v13/buE2poGnedXvwjX-fmFD9CI-4NU.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/tinos/v13/buE1poGnedXvwj1AW0Fp2i43-cxL.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/tinos/v13/buEzpoGnedXvwjX-Rt1s0CoV_NxLeiw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -65071,7 +67843,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/titanone/v7/mFTzWbsGxbbS_J5cQcjykzIn2Etikg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/titanone/v7/mFTzWbsGxbbS_J5cQcjykzIn2Etikg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -65140,17 +67913,28 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/titilliumweb/v8/NaPDcZTIAOhVxoMyOr9n_E7ffAzHKIx5YrSYqWM.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/titilliumweb/v8/NaPFcZTIAOhVxoMyOr9n_E7fdMbewI1zZpaduWMmxA.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/titilliumweb/v8/NaPDcZTIAOhVxoMyOr9n_E7ffGjEKIx5YrSYqWM.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/titilliumweb/v8/NaPFcZTIAOhVxoMyOr9n_E7fdMbepI5zZpaduWMmxA.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/titilliumweb/v8/NaPecZTIAOhVxoMyOr9n_E7fRMTsDIRSfr0.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/titilliumweb/v8/NaPAcZTIAOhVxoMyOr9n_E7fdMbmCKZXbr2BsA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/titilliumweb/v8/NaPDcZTIAOhVxoMyOr9n_E7ffBzCKIx5YrSYqWM.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/titilliumweb/v8/NaPFcZTIAOhVxoMyOr9n_E7fdMbe0IhzZpaduWMmxA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/titilliumweb/v8/NaPDcZTIAOhVxoMyOr9n_E7ffHjDKIx5YrSYqWM.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/titilliumweb/v8/NaPFcZTIAOhVxoMyOr9n_E7fdMbetIlzZpaduWMmxA.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/titilliumweb/v8/NaPDcZTIAOhVxoMyOr9n_E7ffEDBKIx5YrSYqWM.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/titilliumweb/v8/NaPDcZTIAOhVxoMyOr9n_E7ffAzHKIx5YrSYqWM.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/titilliumweb/v8/NaPFcZTIAOhVxoMyOr9n_E7fdMbewI1zZpaduWMmxA.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/titilliumweb/v8/NaPDcZTIAOhVxoMyOr9n_E7ffGjEKIx5YrSYqWM.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/titilliumweb/v8/NaPFcZTIAOhVxoMyOr9n_E7fdMbepI5zZpaduWMmxA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/titilliumweb/v8/NaPecZTIAOhVxoMyOr9n_E7fRMTsDIRSfr0.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/titilliumweb/v8/NaPAcZTIAOhVxoMyOr9n_E7fdMbmCKZXbr2BsA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/titilliumweb/v8/NaPDcZTIAOhVxoMyOr9n_E7ffBzCKIx5YrSYqWM.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/titilliumweb/v8/NaPFcZTIAOhVxoMyOr9n_E7fdMbe0IhzZpaduWMmxA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/titilliumweb/v8/NaPDcZTIAOhVxoMyOr9n_E7ffHjDKIx5YrSYqWM.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/titilliumweb/v8/NaPFcZTIAOhVxoMyOr9n_E7fdMbetIlzZpaduWMmxA.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/titilliumweb/v8/NaPDcZTIAOhVxoMyOr9n_E7ffEDBKIx5YrSYqWM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -65219,24 +68003,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLgrETNbFtZCeGqgR2xe2XiKMiokE4.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLirETNbFtZCeGqgRXXQwHoLOqtgE5h0A.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR0dWkXIBsShiVd4.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ63JDMCDjEd4yVY.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR15WUXIBsShiVd4.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ8nKDMCDjEd4yVY.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLmrETNbFtZCeGqgSXVcWHALdio.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLgrETNbFtZCeGqgRXXe2XiKMiokE4.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR0hWEXIBsShiVd4.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ5HLDMCDjEd4yVY.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR0NX0XIBsShiVd4.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ73MDMCDjEd4yVY.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR1pXkXIBsShiVd4.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ9nNDMCDjEd4yVY.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR11XUXIBsShiVd4.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ8XODMCDjEd4yVY.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR1RXEXIBsShiVd4.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ-HPDMCDjEd4yVY.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLgrETNbFtZCeGqgR2xe2XiKMiokE4.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLirETNbFtZCeGqgRXXQwHoLOqtgE5h0A.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR0dWkXIBsShiVd4.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ63JDMCDjEd4yVY.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR15WUXIBsShiVd4.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ8nKDMCDjEd4yVY.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLmrETNbFtZCeGqgSXVcWHALdio.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLgrETNbFtZCeGqgRXXe2XiKMiokE4.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR0hWEXIBsShiVd4.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ5HLDMCDjEd4yVY.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR0NX0XIBsShiVd4.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ73MDMCDjEd4yVY.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR1pXkXIBsShiVd4.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ9nNDMCDjEd4yVY.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR11XUXIBsShiVd4.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ8XODMCDjEd4yVY.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLhrETNbFtZCeGqgR1RXEXIBsShiVd4.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/tomorrow/v2/WBLjrETNbFtZCeGqgRXXQ-HPDMCDjEd4yVY.ttf',
     };
 
     return googleFontsTextStyle(
@@ -65305,7 +68107,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/tradewinds/v8/AYCPpXPpYNIIT7h8-QenM3Jq7PKP5Z_G.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/tradewinds/v8/AYCPpXPpYNIIT7h8-QenM3Jq7PKP5Z_G.ttf',
     };
 
     return googleFontsTextStyle(
@@ -65374,24 +68177,42 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/trirong/v5/7r3EqXNgp8wxdOdOl-go3YRl6ujngw.ttf',
-      GoogleFontsVariant.fromString('100italic'): 'http://fonts.gstatic.com/s/trirong/v5/7r3CqXNgp8wxdOdOn44QuY5hyO33g8IY.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOl0QJ_a5L5uH-mts.ttf',
-      GoogleFontsVariant.fromString('200italic'): 'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QFa9B4sP7itsB5g.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOlyAK_a5L5uH-mts.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QcaxB4sP7itsB5g.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/trirong/v5/7r3GqXNgp8wxdOdOr4wi2aZg-ug.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/trirong/v5/7r3EqXNgp8wxdOdOn44o3YRl6ujngw.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOl3gL_a5L5uH-mts.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QKa1B4sP7itsB5g.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOl1QM_a5L5uH-mts.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QBapB4sP7itsB5g.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOlzAN_a5L5uH-mts.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QYatB4sP7itsB5g.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOlywO_a5L5uH-mts.ttf',
-      GoogleFontsVariant.fromString('800italic'): 'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QfahB4sP7itsB5g.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOlwgP_a5L5uH-mts.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QWalB4sP7itsB5g.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3EqXNgp8wxdOdOl-go3YRl6ujngw.ttf',
+      GoogleFontsVariant.fromString('100italic'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3CqXNgp8wxdOdOn44QuY5hyO33g8IY.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOl0QJ_a5L5uH-mts.ttf',
+      GoogleFontsVariant.fromString('200italic'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QFa9B4sP7itsB5g.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOlyAK_a5L5uH-mts.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QcaxB4sP7itsB5g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3GqXNgp8wxdOdOr4wi2aZg-ug.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3EqXNgp8wxdOdOn44o3YRl6ujngw.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOl3gL_a5L5uH-mts.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QKa1B4sP7itsB5g.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOl1QM_a5L5uH-mts.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QBapB4sP7itsB5g.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOlzAN_a5L5uH-mts.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QYatB4sP7itsB5g.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOlywO_a5L5uH-mts.ttf',
+      GoogleFontsVariant.fromString('800italic'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QfahB4sP7itsB5g.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3DqXNgp8wxdOdOlwgP_a5L5uH-mts.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/trirong/v5/7r3BqXNgp8wxdOdOn44QWalB4sP7itsB5g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -65460,7 +68281,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/trocchi/v8/qWcqB6WkuIDxDZLcDrtUvMeTYD0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/trocchi/v8/qWcqB6WkuIDxDZLcDrtUvMeTYD0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -65529,9 +68351,12 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/trochut/v7/CHyjV-fDDlP9bDIw5nSIfVIPLns.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/trochut/v7/CHyhV-fDDlP9bDIw1naCeXAKPns8jw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/trochut/v7/CHymV-fDDlP9bDIw3sinWVokMnIllmA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/trochut/v7/CHyjV-fDDlP9bDIw5nSIfVIPLns.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/trochut/v7/CHyhV-fDDlP9bDIw1naCeXAKPns8jw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/trochut/v7/CHymV-fDDlP9bDIw3sinWVokMnIllmA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -65600,7 +68425,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/trykker/v8/KtktALyWZJXudUPzhNnoOd2j22U.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/trykker/v8/KtktALyWZJXudUPzhNnoOd2j22U.ttf',
     };
 
     return googleFontsTextStyle(
@@ -65669,7 +68495,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/tulpenone/v9/dFa6ZfeC474skLgesc0CWj0w_HyIRlE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/tulpenone/v9/dFa6ZfeC474skLgesc0CWj0w_HyIRlE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -65738,12 +68565,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/turretroad/v1/pxidypMgpcBFjE84Zv-fE0ONEdeLYk1Mq3ap.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/turretroad/v1/pxidypMgpcBFjE84Zv-fE0PpEteLYk1Mq3ap.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/turretroad/v1/pxiAypMgpcBFjE84Zv-fE3tFOvODSVFF.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/turretroad/v1/pxidypMgpcBFjE84Zv-fE0OxE9eLYk1Mq3ap.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/turretroad/v1/pxidypMgpcBFjE84Zv-fE0P5FdeLYk1Mq3ap.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/turretroad/v1/pxidypMgpcBFjE84Zv-fE0PlFteLYk1Mq3ap.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/turretroad/v1/pxidypMgpcBFjE84Zv-fE0ONEdeLYk1Mq3ap.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/turretroad/v1/pxidypMgpcBFjE84Zv-fE0PpEteLYk1Mq3ap.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/turretroad/v1/pxiAypMgpcBFjE84Zv-fE3tFOvODSVFF.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/turretroad/v1/pxidypMgpcBFjE84Zv-fE0OxE9eLYk1Mq3ap.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/turretroad/v1/pxidypMgpcBFjE84Zv-fE0P5FdeLYk1Mq3ap.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/turretroad/v1/pxidypMgpcBFjE84Zv-fE0PlFteLYk1Mq3ap.ttf',
     };
 
     return googleFontsTextStyle(
@@ -65812,14 +68645,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/ubuntu/v14/4iCv6KVjbNBYlgoC1CzTt2aMH4V_gg.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/ubuntu/v14/4iCp6KVjbNBYlgoKejZftWyIPYBvgpUI.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ubuntu/v14/4iCs6KVjbNBYlgo6eAT3v02QFg.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/ubuntu/v14/4iCu6KVjbNBYlgoKeg7znUiAFpxm.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/ubuntu/v14/4iCv6KVjbNBYlgoCjC3Tt2aMH4V_gg.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/ubuntu/v14/4iCp6KVjbNBYlgoKejYHtGyIPYBvgpUI.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ubuntu/v14/4iCv6KVjbNBYlgoCxCvTt2aMH4V_gg.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/ubuntu/v14/4iCp6KVjbNBYlgoKejZPsmyIPYBvgpUI.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/ubuntu/v14/4iCv6KVjbNBYlgoC1CzTt2aMH4V_gg.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/ubuntu/v14/4iCp6KVjbNBYlgoKejZftWyIPYBvgpUI.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ubuntu/v14/4iCs6KVjbNBYlgo6eAT3v02QFg.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/ubuntu/v14/4iCu6KVjbNBYlgoKeg7znUiAFpxm.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/ubuntu/v14/4iCv6KVjbNBYlgoCjC3Tt2aMH4V_gg.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/ubuntu/v14/4iCp6KVjbNBYlgoKejYHtGyIPYBvgpUI.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ubuntu/v14/4iCv6KVjbNBYlgoCxCvTt2aMH4V_gg.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/ubuntu/v14/4iCp6KVjbNBYlgoKejZPsmyIPYBvgpUI.ttf',
     };
 
     return googleFontsTextStyle(
@@ -65888,7 +68729,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ubuntucondensed/v10/u-4k0rCzjgs5J7oXnJcM_0kACGMtf-fVqvHoJXw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ubuntucondensed/v10/u-4k0rCzjgs5J7oXnJcM_0kACGMtf-fVqvHoJXw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -65957,10 +68799,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ubuntumono/v9/KFOjCneDtsqEr0keqCMhbBc9AMX6lJBP.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/ubuntumono/v9/KFOhCneDtsqEr0keqCMhbCc_CsHYkYBPY3o.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/ubuntumono/v9/KFO-CneDtsqEr0keqCMhbC-BL-Hyv4xGemO1.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/ubuntumono/v9/KFO8CneDtsqEr0keqCMhbCc_Mn33tYhkf3O1GVg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ubuntumono/v9/KFOjCneDtsqEr0keqCMhbBc9AMX6lJBP.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/ubuntumono/v9/KFOhCneDtsqEr0keqCMhbCc_CsHYkYBPY3o.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/ubuntumono/v9/KFO-CneDtsqEr0keqCMhbC-BL-Hyv4xGemO1.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/ubuntumono/v9/KFO8CneDtsqEr0keqCMhbCc_Mn33tYhkf3O1GVg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66029,7 +68875,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/ultra/v12/zOLy4prXmrtY-tT6yLOD6NxF.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/ultra/v12/zOLy4prXmrtY-tT6yLOD6NxF.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66098,7 +68945,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/uncialantiqua/v7/N0bM2S5WOex4OUbESzoESK-i-PfRS5VBBSSF.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/uncialantiqua/v7/N0bM2S5WOex4OUbESzoESK-i-PfRS5VBBSSF.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66167,7 +69015,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/underdog/v8/CHygV-jCElj7diMroVSiU14GN2Il.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/underdog/v8/CHygV-jCElj7diMroVSiU14GN2Il.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66236,7 +69085,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/unicaone/v7/DPEuYwWHyAYGVTSmalshdtffuEY7FA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/unicaone/v7/DPEuYwWHyAYGVTSmalshdtffuEY7FA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66305,7 +69155,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/unifrakturcook/v11/IurA6Yli8YOdcoky-0PTTdkm56n05Uw13ILXs-h6.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/unifrakturcook/v11/IurA6Yli8YOdcoky-0PTTdkm56n05Uw13ILXs-h6.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66374,7 +69225,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/unifrakturmaguntia/v10/WWXPlieVYwiGNomYU-ciRLRvEmK7oaVun2xNNgNa1A.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/unifrakturmaguntia/v10/WWXPlieVYwiGNomYU-ciRLRvEmK7oaVun2xNNgNa1A.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66443,8 +69295,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/unkempt/v11/2EbnL-Z2DFZue0DSSYYf8z2Yt_c.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/unkempt/v11/2EbiL-Z2DFZue0DScTow1zWzq_5uT84.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/unkempt/v11/2EbnL-Z2DFZue0DSSYYf8z2Yt_c.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/unkempt/v11/2EbiL-Z2DFZue0DScTow1zWzq_5uT84.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66513,7 +69367,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/unlock/v9/7Au-p_8ykD-cDl7GKAjSwkUVOQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/unlock/v9/7Au-p_8ykD-cDl7GKAjSwkUVOQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66582,10 +69437,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/unna/v13/AYCEpXzofN0NCpgBlGHCWFM.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/unna/v13/AYCKpXzofN0NOpoLkEPHSFNyxw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/unna/v13/AYCLpXzofN0NMiQusGnpRFpr3vc.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/unna/v13/AYCJpXzofN0NOpozLGzjQHhuzvef5Q.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/unna/v13/AYCEpXzofN0NCpgBlGHCWFM.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/unna/v13/AYCKpXzofN0NOpoLkEPHSFNyxw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/unna/v13/AYCLpXzofN0NMiQusGnpRFpr3vc.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/unna/v13/AYCJpXzofN0NOpozLGzjQHhuzvef5Q.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66654,7 +69513,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/vt323/v11/pxiKyp0ihIEF2hsYHpT2dkNE.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/vt323/v11/pxiKyp0ihIEF2hsYHpT2dkNE.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66723,7 +69583,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/vampiroone/v10/gokqH6DoDl5yXvJytFsdLkqnsvhIor3K.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/vampiroone/v10/gokqH6DoDl5yXvJytFsdLkqnsvhIor3K.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66792,7 +69653,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/varela/v10/DPEtYwqExx0AWHXJBBQFfvzDsQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/varela/v10/DPEtYwqExx0AWHXJBBQFfvzDsQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66861,7 +69723,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/varelaround/v12/w8gdH283Tvk__Lua32TysjIvoMGOD9gxZw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/varelaround/v12/w8gdH283Tvk__Lua32TysjIvoMGOD9gxZw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66930,7 +69793,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/vastshadow/v9/pe0qMImKOZ1V62ZwbVY9dfe6Kdpickwp.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/vastshadow/v9/pe0qMImKOZ1V62ZwbVY9dfe6Kdpickwp.ttf',
     };
 
     return googleFontsTextStyle(
@@ -66999,10 +69863,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/vesperlibre/v11/bx6CNxyWnf-uxPdXDHUD_Rd4D0-N2qIWVQ.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/vesperlibre/v11/bx6dNxyWnf-uxPdXDHUD_RdA-2ap0okKXKvPlw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/vesperlibre/v11/bx6dNxyWnf-uxPdXDHUD_RdAs2Cp0okKXKvPlw.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/vesperlibre/v11/bx6dNxyWnf-uxPdXDHUD_RdAi2Kp0okKXKvPlw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/vesperlibre/v11/bx6CNxyWnf-uxPdXDHUD_Rd4D0-N2qIWVQ.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/vesperlibre/v11/bx6dNxyWnf-uxPdXDHUD_RdA-2ap0okKXKvPlw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/vesperlibre/v11/bx6dNxyWnf-uxPdXDHUD_RdAs2Cp0okKXKvPlw.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/vesperlibre/v11/bx6dNxyWnf-uxPdXDHUD_RdAi2Kp0okKXKvPlw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67071,7 +69939,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/vibes/v1/QdVYSTsmIB6tmbd3HpbsuBlh.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/vibes/v1/QdVYSTsmIB6tmbd3HpbsuBlh.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67140,7 +70009,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/vibur/v10/DPEiYwmEzw0QRjTpLjoJd-Xa.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/vibur/v10/DPEiYwmEzw0QRjTpLjoJd-Xa.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67209,7 +70079,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/vidaloka/v12/7cHrv4c3ipenMKlEass8yn4hnCci.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/vidaloka/v12/7cHrv4c3ipenMKlEass8yn4hnCci.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67278,7 +70149,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/viga/v8/xMQbuFFdSaiX_QIjD4e2OX8.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/viga/v8/xMQbuFFdSaiX_QIjD4e2OX8.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67347,7 +70219,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/voces/v9/-F6_fjJyLyU8d4PBBG7YpzlJ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/voces/v9/-F6_fjJyLyU8d4PBBG7YpzlJ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67416,10 +70289,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/volkhov/v11/SlGQmQieoJcKemNeQTIOhHxzcD0.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/volkhov/v11/SlGSmQieoJcKemNecTAEgF52YD0NYw.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/volkhov/v11/SlGVmQieoJcKemNeeY4hoHRYbDQUego.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/volkhov/v11/SlGXmQieoJcKemNecTA8PHFSaBYRagrQrA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/volkhov/v11/SlGQmQieoJcKemNeQTIOhHxzcD0.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/volkhov/v11/SlGSmQieoJcKemNecTAEgF52YD0NYw.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/volkhov/v11/SlGVmQieoJcKemNeeY4hoHRYbDQUego.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/volkhov/v11/SlGXmQieoJcKemNecTA8PHFSaBYRagrQrA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67488,14 +70365,22 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/vollkorn/v10/0yb9GDoxxrvAnPhYGykuYkw2rQg1.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/vollkorn/v10/0yb7GDoxxrvAnPhYGxksaEgUqBg15TY.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/vollkorn/v10/0yb6GDoxxrvAnPhYGxH2TGg-hhQ8_C_3.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/vollkorn/v10/0yb4GDoxxrvAnPhYGxksUJA6jBAe-T_34DM.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/vollkorn/v10/0yb6GDoxxrvAnPhYGxGSTWg-hhQ8_C_3.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/vollkorn/v10/0yb4GDoxxrvAnPhYGxksUPQ7jBAe-T_34DM.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/vollkorn/v10/0yb6GDoxxrvAnPhYGxGqT2g-hhQ8_C_3.ttf',
-      GoogleFontsVariant.fromString('900italic'): 'http://fonts.gstatic.com/s/vollkorn/v10/0yb4GDoxxrvAnPhYGxksUMw5jBAe-T_34DM.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/vollkorn/v10/0yb9GDoxxrvAnPhYGykuYkw2rQg1.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/vollkorn/v10/0yb7GDoxxrvAnPhYGxksaEgUqBg15TY.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/vollkorn/v10/0yb6GDoxxrvAnPhYGxH2TGg-hhQ8_C_3.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/vollkorn/v10/0yb4GDoxxrvAnPhYGxksUJA6jBAe-T_34DM.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/vollkorn/v10/0yb6GDoxxrvAnPhYGxGSTWg-hhQ8_C_3.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/vollkorn/v10/0yb4GDoxxrvAnPhYGxksUPQ7jBAe-T_34DM.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/vollkorn/v10/0yb6GDoxxrvAnPhYGxGqT2g-hhQ8_C_3.ttf',
+      GoogleFontsVariant.fromString('900italic'):
+          'http://fonts.gstatic.com/s/vollkorn/v10/0yb4GDoxxrvAnPhYGxksUMw5jBAe-T_34DM.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67564,10 +70449,14 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/vollkornsc/v3/j8_v6-zQ3rXpceZj9cqnVhF5NH-iSq_E.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/vollkornsc/v3/j8_y6-zQ3rXpceZj9cqnVimhGluqYbPN5Yjn.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/vollkornsc/v3/j8_y6-zQ3rXpceZj9cqnVinFG1uqYbPN5Yjn.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/vollkornsc/v3/j8_y6-zQ3rXpceZj9cqnVin9GVuqYbPN5Yjn.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/vollkornsc/v3/j8_v6-zQ3rXpceZj9cqnVhF5NH-iSq_E.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/vollkornsc/v3/j8_y6-zQ3rXpceZj9cqnVimhGluqYbPN5Yjn.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/vollkornsc/v3/j8_y6-zQ3rXpceZj9cqnVinFG1uqYbPN5Yjn.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/vollkornsc/v3/j8_y6-zQ3rXpceZj9cqnVin9GVuqYbPN5Yjn.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67636,7 +70525,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/voltaire/v9/1Pttg8PcRfSblAvGvQooYKVnBOif.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/voltaire/v9/1Pttg8PcRfSblAvGvQooYKVnBOif.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67705,7 +70595,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/waitingforthesunrise/v10/WBL1rFvOYl9CEv2i1mO6KUW8RKWJ2zoXoz5JsYZQ9h_ZYk5J.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/waitingforthesunrise/v10/WBL1rFvOYl9CEv2i1mO6KUW8RKWJ2zoXoz5JsYZQ9h_ZYk5J.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67736,19 +70627,26 @@ class GoogleFonts {
   static TextTheme waitingfortheSunriseTextTheme([TextTheme textTheme]) {
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(
-      display4: GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.display4),
-      display3: GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.display3),
-      display2: GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.display2),
-      display1: GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.display1),
-      headline: GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.headline),
+      display4:
+          GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.display4),
+      display3:
+          GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.display3),
+      display2:
+          GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.display2),
+      display1:
+          GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.display1),
+      headline:
+          GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.headline),
       title: GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.title),
       subhead: GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.subhead),
       body2: GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.body2),
       body1: GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.body1),
       caption: GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.caption),
       button: GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.button),
-      subtitle: GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.subtitle),
-      overline: GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.overline),
+      subtitle:
+          GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.subtitle),
+      overline:
+          GoogleFonts.waitingfortheSunrise(textStyle: textTheme?.overline),
     );
   }
 
@@ -67774,7 +70672,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/wallpoet/v11/f0X10em2_8RnXVVdUNbu7cXP8L8G.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/wallpoet/v11/f0X10em2_8RnXVVdUNbu7cXP8L8G.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67843,7 +70742,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/walterturncoat/v10/snfys0Gs98ln43n0d-14ULoToe67YB2dQ5ZPqQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/walterturncoat/v10/snfys0Gs98ln43n0d-14ULoToe67YB2dQ5ZPqQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67912,7 +70812,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/warnes/v9/pONn1hc0GsW6sW5OpiC2o6Lkqg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/warnes/v9/pONn1hc0GsW6sW5OpiC2o6Lkqg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -67981,7 +70882,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/wellfleet/v7/nuF7D_LfQJb3VYgX6eyT42aLDhO2HA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/wellfleet/v7/nuF7D_LfQJb3VYgX6eyT42aLDhO2HA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68050,7 +70952,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/wendyone/v8/2sDcZGJOipXfgfXV5wgDb2-4C7wFZQ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/wendyone/v8/2sDcZGJOipXfgfXV5wgDb2-4C7wFZQ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68119,7 +71022,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/wireone/v10/qFdH35Wah5htUhV75WGiWdrCwwcJ.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/wireone/v10/qFdH35Wah5htUhV75WGiWdrCwwcJ.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68188,15 +71092,24 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/worksans/v5/QGYqz_wNahGAdqQ43Rh3H6DstfxA4OD3.ttf',
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh3s4HMn9JM6fnuKg.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh314LMn9JM6fnuKg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/worksans/v5/QGYsz_wNahGAdqQ43RhPe6rol_lQ4A.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh3j4PMn9JM6fnuKg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh3o4TMn9JM6fnuKg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh3x4XMn9JM6fnuKg.ttf',
-      GoogleFontsVariant.fromString('800'): 'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh324bMn9JM6fnuKg.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh3_4fMn9JM6fnuKg.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/worksans/v5/QGYqz_wNahGAdqQ43Rh3H6DstfxA4OD3.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh3s4HMn9JM6fnuKg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh314LMn9JM6fnuKg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/worksans/v5/QGYsz_wNahGAdqQ43RhPe6rol_lQ4A.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh3j4PMn9JM6fnuKg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh3o4TMn9JM6fnuKg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh3x4XMn9JM6fnuKg.ttf',
+      GoogleFontsVariant.fromString('800'):
+          'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh324bMn9JM6fnuKg.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/worksans/v5/QGYpz_wNahGAdqQ43Rh3_4fMn9JM6fnuKg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68265,12 +71178,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('200'): 'http://fonts.gstatic.com/s/yanonekaffeesatz/v13/3y9I6aknfjLm_3lMKjiMgmUUYBs04aUXNxt9gW2LIftodtWpcGuLCnXkVA.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/yanonekaffeesatz/v13/3y9I6aknfjLm_3lMKjiMgmUUYBs04aUXNxt9gW2LIftoqNWpcGuLCnXkVA.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/yanonekaffeesatz/v13/3y9I6aknfjLm_3lMKjiMgmUUYBs04aUXNxt9gW2LIfto9tWpcGuLCnXkVA.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/yanonekaffeesatz/v13/3y9I6aknfjLm_3lMKjiMgmUUYBs04aUXNxt9gW2LIftoxNWpcGuLCnXkVA.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/yanonekaffeesatz/v13/3y9I6aknfjLm_3lMKjiMgmUUYBs04aUXNxt9gW2LIftoKNKpcGuLCnXkVA.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/yanonekaffeesatz/v13/3y9I6aknfjLm_3lMKjiMgmUUYBs04aUXNxt9gW2LIftoEdKpcGuLCnXkVA.ttf',
+      GoogleFontsVariant.fromString('200'):
+          'http://fonts.gstatic.com/s/yanonekaffeesatz/v13/3y9I6aknfjLm_3lMKjiMgmUUYBs04aUXNxt9gW2LIftodtWpcGuLCnXkVA.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/yanonekaffeesatz/v13/3y9I6aknfjLm_3lMKjiMgmUUYBs04aUXNxt9gW2LIftoqNWpcGuLCnXkVA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/yanonekaffeesatz/v13/3y9I6aknfjLm_3lMKjiMgmUUYBs04aUXNxt9gW2LIfto9tWpcGuLCnXkVA.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/yanonekaffeesatz/v13/3y9I6aknfjLm_3lMKjiMgmUUYBs04aUXNxt9gW2LIftoxNWpcGuLCnXkVA.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/yanonekaffeesatz/v13/3y9I6aknfjLm_3lMKjiMgmUUYBs04aUXNxt9gW2LIftoKNKpcGuLCnXkVA.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/yanonekaffeesatz/v13/3y9I6aknfjLm_3lMKjiMgmUUYBs04aUXNxt9gW2LIftoEdKpcGuLCnXkVA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68339,12 +71258,18 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('100'): 'http://fonts.gstatic.com/s/yantramanav/v5/flU-Rqu5zY00QEpyWJYWN5-QXeNzDB41rZg.ttf',
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/yantramanav/v5/flUhRqu5zY00QEpyWJYWN59Yf8NZIhI8tIHh.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/yantramanav/v5/flU8Rqu5zY00QEpyWJYWN6f0V-dRCQ41.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/yantramanav/v5/flUhRqu5zY00QEpyWJYWN58AfsNZIhI8tIHh.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/yantramanav/v5/flUhRqu5zY00QEpyWJYWN59IeMNZIhI8tIHh.ttf',
-      GoogleFontsVariant.fromString('900'): 'http://fonts.gstatic.com/s/yantramanav/v5/flUhRqu5zY00QEpyWJYWN59wesNZIhI8tIHh.ttf',
+      GoogleFontsVariant.fromString('100'):
+          'http://fonts.gstatic.com/s/yantramanav/v5/flU-Rqu5zY00QEpyWJYWN5-QXeNzDB41rZg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/yantramanav/v5/flUhRqu5zY00QEpyWJYWN59Yf8NZIhI8tIHh.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/yantramanav/v5/flU8Rqu5zY00QEpyWJYWN6f0V-dRCQ41.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/yantramanav/v5/flUhRqu5zY00QEpyWJYWN58AfsNZIhI8tIHh.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/yantramanav/v5/flUhRqu5zY00QEpyWJYWN59IeMNZIhI8tIHh.ttf',
+      GoogleFontsVariant.fromString('900'):
+          'http://fonts.gstatic.com/s/yantramanav/v5/flUhRqu5zY00QEpyWJYWN59wesNZIhI8tIHh.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68413,7 +71338,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/yatraone/v6/C8ch4copsHzj8p7NaF0xw1OBbRDvXw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/yatraone/v6/C8ch4copsHzj8p7NaF0xw1OBbRDvXw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68482,7 +71408,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/yellowtail/v10/OZpGg_pnoDtINPfRIlLotlzNwED-b4g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/yellowtail/v10/OZpGg_pnoDtINPfRIlLotlzNwED-b4g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68551,7 +71478,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/yeonsung/v8/QldMNTpbohAGtsJvUn6xSVNazqx2xg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/yeonsung/v8/QldMNTpbohAGtsJvUn6xSVNazqx2xg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68620,7 +71548,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/yesevaone/v14/OpNJno4ck8vc-xYpwWWxpipfWhXD00c.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/yesevaone/v14/OpNJno4ck8vc-xYpwWWxpipfWhXD00c.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68689,7 +71618,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/yesteryear/v8/dg4g_p78rroaKl8kRKo1r7wHTwonmyw.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/yesteryear/v8/dg4g_p78rroaKl8kRKo1r7wHTwonmyw.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68758,11 +71688,16 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/yrsa/v5/wlpxgwnQFlxs3af93IQ73W5OcCk.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/yrsa/v5/wlp-gwnQFlxs5QvV-IwQwWc.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/yrsa/v5/wlpxgwnQFlxs3f_83IQ73W5OcCk.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/yrsa/v5/wlpxgwnQFlxs3dP73IQ73W5OcCk.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/yrsa/v5/wlpxgwnQFlxs3bf63IQ73W5OcCk.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/yrsa/v5/wlpxgwnQFlxs3af93IQ73W5OcCk.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/yrsa/v5/wlp-gwnQFlxs5QvV-IwQwWc.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/yrsa/v5/wlpxgwnQFlxs3f_83IQ73W5OcCk.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/yrsa/v5/wlpxgwnQFlxs3dP73IQ73W5OcCk.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/yrsa/v5/wlpxgwnQFlxs3bf63IQ73W5OcCk.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68831,7 +71766,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/zcoolkuaile/v5/tssqApdaRQokwFjFJjvM6h2WpozzoXhC2g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/zcoolkuaile/v5/tssqApdaRQokwFjFJjvM6h2WpozzoXhC2g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68900,7 +71836,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/zcoolqingkehuangyou/v5/2Eb5L_R5IXJEWhD3AOhSvFC554MOOahI4mRIi_28c8bHWA.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/zcoolqingkehuangyou/v5/2Eb5L_R5IXJEWhD3AOhSvFC554MOOahI4mRIi_28c8bHWA.ttf',
     };
 
     return googleFontsTextStyle(
@@ -68969,7 +71906,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/zcoolxiaowei/v5/i7dMIFFrTRywPpUVX9_RJyM1YFKQHwyVd3U.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/zcoolxiaowei/v5/i7dMIFFrTRywPpUVX9_RJyM1YFKQHwyVd3U.ttf',
     };
 
     return googleFontsTextStyle(
@@ -69038,7 +71976,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/zeyada/v9/11hAGpPTxVPUbgZDNGatWKaZ3g.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/zeyada/v9/11hAGpPTxVPUbgZDNGatWKaZ3g.ttf',
     };
 
     return googleFontsTextStyle(
@@ -69107,7 +72046,8 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/zhimangxing/v5/f0Xw0ey79sErYFtWQ9a2rq-g0actfektIJ0.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/zhimangxing/v5/f0Xw0ey79sErYFtWQ9a2rq-g0actfektIJ0.ttf',
     };
 
     return googleFontsTextStyle(
@@ -69176,16 +72116,26 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('300'): 'http://fonts.gstatic.com/s/zillaslab/v5/dFa5ZfeM_74wlPZtksIFYpEY2HSjWlhzbaw.ttf',
-      GoogleFontsVariant.fromString('300italic'): 'http://fonts.gstatic.com/s/zillaslab/v5/dFanZfeM_74wlPZtksIFaj8CVHapXnp2fazkfg.ttf',
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/zillaslab/v5/dFa6ZfeM_74wlPZtksIFWj0w_HyIRlE.ttf',
-      GoogleFontsVariant.fromString('italic'): 'http://fonts.gstatic.com/s/zillaslab/v5/dFa4ZfeM_74wlPZtksIFaj86-F6NVlFqdA.ttf',
-      GoogleFontsVariant.fromString('500'): 'http://fonts.gstatic.com/s/zillaslab/v5/dFa5ZfeM_74wlPZtksIFYskZ2HSjWlhzbaw.ttf',
-      GoogleFontsVariant.fromString('500italic'): 'http://fonts.gstatic.com/s/zillaslab/v5/dFanZfeM_74wlPZtksIFaj8CDHepXnp2fazkfg.ttf',
-      GoogleFontsVariant.fromString('600'): 'http://fonts.gstatic.com/s/zillaslab/v5/dFa5ZfeM_74wlPZtksIFYuUe2HSjWlhzbaw.ttf',
-      GoogleFontsVariant.fromString('600italic'): 'http://fonts.gstatic.com/s/zillaslab/v5/dFanZfeM_74wlPZtksIFaj8CIHCpXnp2fazkfg.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/zillaslab/v5/dFa5ZfeM_74wlPZtksIFYoEf2HSjWlhzbaw.ttf',
-      GoogleFontsVariant.fromString('700italic'): 'http://fonts.gstatic.com/s/zillaslab/v5/dFanZfeM_74wlPZtksIFaj8CRHGpXnp2fazkfg.ttf',
+      GoogleFontsVariant.fromString('300'):
+          'http://fonts.gstatic.com/s/zillaslab/v5/dFa5ZfeM_74wlPZtksIFYpEY2HSjWlhzbaw.ttf',
+      GoogleFontsVariant.fromString('300italic'):
+          'http://fonts.gstatic.com/s/zillaslab/v5/dFanZfeM_74wlPZtksIFaj8CVHapXnp2fazkfg.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/zillaslab/v5/dFa6ZfeM_74wlPZtksIFWj0w_HyIRlE.ttf',
+      GoogleFontsVariant.fromString('italic'):
+          'http://fonts.gstatic.com/s/zillaslab/v5/dFa4ZfeM_74wlPZtksIFaj86-F6NVlFqdA.ttf',
+      GoogleFontsVariant.fromString('500'):
+          'http://fonts.gstatic.com/s/zillaslab/v5/dFa5ZfeM_74wlPZtksIFYskZ2HSjWlhzbaw.ttf',
+      GoogleFontsVariant.fromString('500italic'):
+          'http://fonts.gstatic.com/s/zillaslab/v5/dFanZfeM_74wlPZtksIFaj8CDHepXnp2fazkfg.ttf',
+      GoogleFontsVariant.fromString('600'):
+          'http://fonts.gstatic.com/s/zillaslab/v5/dFa5ZfeM_74wlPZtksIFYuUe2HSjWlhzbaw.ttf',
+      GoogleFontsVariant.fromString('600italic'):
+          'http://fonts.gstatic.com/s/zillaslab/v5/dFanZfeM_74wlPZtksIFaj8CIHCpXnp2fazkfg.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/zillaslab/v5/dFa5ZfeM_74wlPZtksIFYoEf2HSjWlhzbaw.ttf',
+      GoogleFontsVariant.fromString('700italic'):
+          'http://fonts.gstatic.com/s/zillaslab/v5/dFanZfeM_74wlPZtksIFaj8CRHGpXnp2fazkfg.ttf',
     };
 
     return googleFontsTextStyle(
@@ -69254,8 +72204,10 @@ class GoogleFonts {
     double decorationThickness,
   }) {
     final fonts = <GoogleFontsVariant, String>{
-      GoogleFontsVariant.fromString('regular'): 'http://fonts.gstatic.com/s/zillaslabhighlight/v7/gNMbW2BrTpK8-inLtBJgMMfbm6uNVDvRxhtIY2DwSXlM.ttf',
-      GoogleFontsVariant.fromString('700'): 'http://fonts.gstatic.com/s/zillaslabhighlight/v7/gNMUW2BrTpK8-inLtBJgMMfbm6uNVDvRxiP0TET4YmVF0Mb6.ttf',
+      GoogleFontsVariant.fromString('regular'):
+          'http://fonts.gstatic.com/s/zillaslabhighlight/v7/gNMbW2BrTpK8-inLtBJgMMfbm6uNVDvRxhtIY2DwSXlM.ttf',
+      GoogleFontsVariant.fromString('700'):
+          'http://fonts.gstatic.com/s/zillaslabhighlight/v7/gNMUW2BrTpK8-inLtBJgMMfbm6uNVDvRxiP0TET4YmVF0Mb6.ttf',
     };
 
     return googleFontsTextStyle(
@@ -69301,5 +72253,4 @@ class GoogleFonts {
       overline: GoogleFonts.zillaSlabHighlight(textStyle: textTheme?.overline),
     );
   }
-
 }

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -74,7 +74,7 @@ TextStyle googleFontsTextStyle({
     decoration: decoration,
     decorationColor: decorationColor,
     decorationStyle: decorationStyle,
-    decorationThickness: decorationThickness
+    decorationThickness: decorationThickness,
   );
 
   final variant = _closestMatch(

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -2,7 +2,7 @@ set -e
 
 # Backs up one directory at a time, looking for one called "flutter".
 function getFlutterPath() {
-    local path="."
+    local path=".."
     local counter=0
 
     while [[ "${counter}" -lt 10 ]]; do

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -1,0 +1,34 @@
+set -e
+
+# Backs up one directory at a time, looking for one called "flutter".
+function getFlutterPath() {
+    local path="."
+    local counter=0
+
+    while [[ "${counter}" -lt 10 ]]; do
+        [ -d "${path}/flutter" ] && echo "${path}/flutter" && return 0
+        let counter++
+        path="${path}/.."
+    done
+}
+
+echo "== Testing on Flutter's $FLUTTER_VERSION channel =="
+
+localSdkPath=$(getFlutterPath)
+
+if [ -z "$localSdkPath" ]
+then
+    echo "Failed to find Flutter SDK."
+    exit 1
+fi
+
+# Run the analyzer to find any static analysis issues.
+"${localSdkPath}/bin/flutter" analyze
+
+# Run the formatter on all the dart files to make sure everything's linted.
+"${localSdkPath}/bin/flutter" format -n --set-exit-if-changed .
+
+# Run the actual tests.
+"${localSdkPath}/bin/flutter" test
+
+echo "-- Success --"


### PR DESCRIPTION
* Added `.travis.yml` script.
* Added `travis_script.sh`.
* Ran `flutter format` to get `google_fonts` library to adhere to travis checks.

Travis script will:
1. Run `flutter analyze`.
1. Run `flutter format` and make sure the given PR is formatted.
1. Run all the tests in the package.

Closes https://github.com/material-foundation/google-fonts-flutter/issues/25