### PR TITLE
Use Support directory for saving font files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.4] - 2020-01-23
+
+* Store downloaded font files in device's support directory instead of documents directory.
+
 ## [0.3.3] - 2020-01-22
 
 * Update font URLs to https to properly support web.

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -198,7 +198,7 @@ Future<ByteData> _httpFetchFontAndSaveToDevice(
 }
 
 Future<String> get _localPath async {
-  final directory = await getApplicationDocumentsDirectory();
+  final directory = await getApplicationSupportDirectory();
   return directory.path;
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_fonts
 description: A package to include fonts from fonts.google.com in your flutter app.
-version: 0.3.3
+version: 0.3.4
 homepage: https://github.com/material-foundation/google-fonts-flutter/
 
 environment:

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -27,7 +27,7 @@ main() {
     final directory = await Directory.systemTemp.createTemp();
     const MethodChannel('plugins.flutter.io/path_provider')
         .setMockMethodCallHandler((methodCall) async {
-      if (methodCall.method == 'getApplicationDocumentsDirectory') {
+      if (methodCall.method == 'getApplicationSupportDirectory') {
         return directory.path;
       }
       return null;
@@ -95,11 +95,11 @@ main() {
       fontUrl: fakeUrl.toString(),
     );
 
-    var directoryContents = await getApplicationDocumentsDirectory();
+    var directoryContents = await getApplicationSupportDirectory();
     expect(directoryContents.listSync().isEmpty, isTrue);
 
     await loadFontIfNecessary(fakeDescriptor);
-    directoryContents = await getApplicationDocumentsDirectory();
+    directoryContents = await getApplicationSupportDirectory();
 
     expect(directoryContents.listSync().isNotEmpty, isTrue);
     expect(


### PR DESCRIPTION
Fixes https://github.com/material-foundation/google-fonts-flutter/issues/52.

I've also tested the example app and an app I'm writing using my forked version, and they work as expected, without displaying the font files to the end user 🎉 