### PR TITLE
[Google Fonts] Fix loading fonts from assets and offline behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 .history
 .svn/
 .firebase/
-.flutter-plugins-dependencies
 
 # IntelliJ related
 *.iml
@@ -27,6 +26,7 @@
 .dart_tool/
 .flutter-plugins
 .flutter-plugins-dependencies
+example/.flutter-plugins-dependencies
 .packages
 .pub-cache/
 .pub/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.3.6] - 2020-01-29
+
+* Fix asset font loading bug
+* Update asset font README instructions 
+
 ## [0.3.5] - 2020-01-23
 
 * Update generator to get most up-to-date urls from fonts.google.com. 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The `google_fonts` package for Flutter allows you to easily use any of the 977 f
 
 With the `google_fonts` package, `.ttf` or `.otf` files do not need to be stored in your assets folder and mapped in
 the pubspec. Instead, they can be fetched once via http at runtime, and cached in the app's file system. This is ideal for development, and can be the preferred behavior for production apps that
-are looking to reduce the app bundle size. Still, you may at any time choose to include the font file in the assets, and the Google Fonts package will prioritize pre-bundled files over http fetching. 
+are looking to reduce the app bundle size. Still, you may at any time choose to include the font file in the assets, and the Google Fonts package will prioritize pre-bundled files over http fetching.
 Because of this, the Google Fonts package allows developers to choose between pre-bundling the fonts and loading them over http, while using the same API.
 
 For example, say you want to use the [Lato](https://fonts.google.com/specimen/Lato) font from Google Fonts in your Flutter app.
@@ -95,12 +95,12 @@ MaterialApp(
 
 ### Bundling font files in your application's assets
 
-The `google_fonts` will automatically use matching font files in your `pubspec.yaml`'s
+The `google_fonts` package will automatically use matching font files in your `pubspec.yaml`'s
 `assets` (rather than fetching them at runtime via HTTP). Once you've settled on the fonts
 you want to use:
 
-1. Download the font files from [https://fonts.google.com](https://fonts.google.com). 
-You only need to download the weights and styles you are using for any given family. 
+1. Download the font files from [https://fonts.google.com](https://fonts.google.com).
+You only need to download the weights and styles you are using for any given family.
 Italic styles will include `Italic` in the filename. Font weights map to file names as follows:
 
 ```dart

--- a/README.md
+++ b/README.md
@@ -93,18 +93,15 @@ MaterialApp(
 );
 ```
 
-### Choosing to include a font without having to http fetch it
+### Bundling font files in your application's assets
 
-If you want the Google Fonts package to use font files that you have included in your pubspec's
-assets (rather than fetching at runtime via http), first download the font files from 
-[https://fonts.google.com](https://fonts.google.com). Then, create a folder at the top level of 
-your app directory named `google_fonts`, and copy the font files that you want to be used into that folder.
+The `google_fonts` will automatically use matching font files in your `pubspec.yaml`'s
+`assets` (rather than fetching them at runtime via HTTP). Once you've settled on the fonts
+you want to use:
 
-![](https://raw.githubusercontent.com/material-foundation/google-fonts-flutter/master/readme_images/google_fonts_folder.png)
-
-You only need to copy the files in for the font weight and font styles that you are using for any
-given family. Italic styles will include `Italic` in the filename, and the font weights map to 
-filenames as follows:
+1. Download the font files from [https://fonts.google.com](https://fonts.google.com). 
+You only need to download the weights and styles you are using for any given family. 
+Italic styles will include `Italic` in the filename. Font weights map to file names as follows:
 
 ```dart
 {
@@ -120,10 +117,14 @@ filenames as follows:
 }
 ```
 
-Finally, make sure you have listed the `google_fonts` folder in your `pubspec.yaml`.
+2. Move those fonts to a top-level app directory (e.g. `google_fonts`).
+
+![](https://raw.githubusercontent.com/material-foundation/google-fonts-flutter/master/readme_images/google_fonts_folder.png)
+
+3. Ensure sure you have listed the folder (e.g. `google_fonts/`) in your `pubspec.yaml` under `assets`.
 
 ![](https://raw.githubusercontent.com/material-foundation/google-fonts-flutter/master/readme_images/google_fonts_pubspec_assets.png)
 
-Note: Since these files are listed as assets, there is no need to list them in the fonts section
+Note: Since these files are listed as assets, there is no need to list them in the `fonts` section
 of the `pubspec.yaml`. This can be done because the files are consistently named from the Google Fonts API
 (so be sure not to rename them!)

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Italic styles will include `Italic` in the filename. Font weights map to file na
 
 ![](https://raw.githubusercontent.com/material-foundation/google-fonts-flutter/master/readme_images/google_fonts_folder.png)
 
-3. Ensure sure you have listed the folder (e.g. `google_fonts/`) in your `pubspec.yaml` under `assets`.
+3. Ensure that you have listed the folder (e.g. `google_fonts/`) in your `pubspec.yaml` under `assets`.
 
 ![](https://raw.githubusercontent.com/material-foundation/google-fonts-flutter/master/readme_images/google_fonts_pubspec_assets.png)
 

--- a/example/.flutter-plugins-dependencies
+++ b/example/.flutter-plugins-dependencies
@@ -1,1 +1,0 @@
-{"_info":"// This is a generated file; do not edit or check into version control.","dependencyGraph":[{"name":"path_provider","dependencies":[]}]}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -80,7 +80,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.3"
+    version: "0.3.7"
   http:
     dependency: transitive
     description:

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -153,7 +153,7 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
     }
   } catch (e) {
     final fontName = descriptor.familyWithVariant.toApiFilenamePrefix();
-    throw Exception('google_fonts was unable to load font $fontName\n$e');
+    print('error: google_fonts was unable to load font $fontName\n$e');
   }
 }
 

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -153,7 +153,8 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
     }
   } catch (e) {
     final fontName = descriptor.familyWithVariant.toApiFilenamePrefix();
-    print('error: google_fonts was unable to load font $fontName\n$e');
+    print('error: google_fonts was unable to load font $fontName because the '
+        'following exception occured\n$e');
   }
 }
 

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -94,7 +94,12 @@ TextStyle googleFontsTextStyle({
     fontUrl: fonts[matchedVariant],
   );
 
-  loadFontIfNecessary(descriptor);
+  try {
+    loadFontIfNecessary(descriptor);
+  } catch (e) {
+    final fontName = descriptor.familyWithVariant.toApiFilenamePrefix();
+    print('error: google_fonts was unable to load font $fontName\n$e');
+  }
 
   return textStyle.copyWith(
     fontFamily: familyWithVariant.toString(),
@@ -121,40 +126,34 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
 
   Future<ByteData> byteData;
 
-  try {
-    // Check if this font can be loaded by the pre-bundled assets.
-    final assetManifestJson = await _loadAssetManifestJson();
-    final assetPath = getFamilyWithVariantManifestPath(
-      descriptor.familyWithVariant,
-      assetManifestJson,
-    );
-    if (assetPath != '') {
-      byteData = rootBundle.load(assetPath);
-    }
-    if (await byteData != null) {
-      return loadFontByteData(familyWithVariantString, byteData);
-    }
-
-    // Check if this font can be loaded from the device file system.
-    if (!kIsWeb) {
-      byteData = _loadFontFromDeviceFileSystem(familyWithVariantString);
-    }
-    if (await byteData != null) {
-      return loadFontByteData(familyWithVariantString, byteData);
-    }
-
-    // Attempt to load this font via http.
-    byteData = _httpFetchFontAndSaveToDevice(
-      familyWithVariantString,
-      descriptor.fontUrl,
-    );
-    if (await byteData != null) {
-      return loadFontByteData(familyWithVariantString, byteData);
-    }
-  } catch (e) {
-    final fontName = descriptor.familyWithVariant.toApiFilenamePrefix();
-    throw Exception('google_fonts was unable to load font $fontName\n$e');
+  // Check if this font can be loaded by the pre-bundled assets.
+  final assetManifestJson = await _loadAssetManifestJson();
+  final assetPath = getFamilyWithVariantManifestPath(
+    descriptor.familyWithVariant,
+    assetManifestJson,
+  );
+  if (assetPath != '') {
+    byteData = rootBundle.load(assetPath);
   }
+  if (await byteData != null) {
+    return loadFontByteData(familyWithVariantString, byteData);
+  }
+
+  // Check if this font can be loaded from the device file system.
+  if (!kIsWeb) {
+    byteData = _loadFontFromDeviceFileSystem(familyWithVariantString);
+  }
+  if (await byteData != null) {
+    return loadFontByteData(familyWithVariantString, byteData);
+  }
+
+  // Attempt to load this font via http.
+  byteData = _httpFetchFontAndSaveToDevice(
+    familyWithVariantString,
+    descriptor.fontUrl,
+  );
+  await byteData;
+  return loadFontByteData(familyWithVariantString, byteData);
 }
 
 /// Loads a font with [FontLoader], given its name and byte-representation.

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -124,7 +124,7 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
   try {
     // Check if this font can be loaded by the pre-bundled assets.
     final assetManifestJson = await _loadAssetManifestJson();
-    final assetPath = getFamilyWithVariantManifestPath(
+    final assetPath = _findFamilyWithVariantAssetPath(
       descriptor.familyWithVariant,
       assetManifestJson,
     );
@@ -275,7 +275,9 @@ Future<Map<String, dynamic>> _loadAssetManifestJson() async {
   }
 }
 
-String getFamilyWithVariantManifestPath(
+/// Looks for a matching [familyWithVariant] font, provided the asset manifest.
+/// Returns the path of the font asset if found, otherwise an empty string.
+String _findFamilyWithVariantAssetPath(
   GoogleFontsFamilyWithVariant familyWithVariant,
   Map<String, dynamic> manifestJson,
 ) {

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -156,7 +156,7 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
       }
     } else {
       throw (Exception(
-          "GoogleFonts.config.allowHttp is true but font $fontName was not found "
+          "GoogleFonts.config.allowHttp is false but font $fontName was not found "
           "in the application assets. Ensure $fontName.otf exists in a folder "
           "that is included in your pubspec's assets."));
     }

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -128,11 +128,11 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
       descriptor.familyWithVariant,
       assetManifestJson,
     );
-    if (assetPath != '') {
+    if (assetPath != null) {
       byteData = rootBundle.load(assetPath);
     }
     if (await byteData != null) {
-      return loadFontByteData(familyWithVariantString, byteData);
+      return _loadFontByteData(familyWithVariantString, byteData);
     }
 
     // Check if this font can be loaded from the device file system.
@@ -140,7 +140,7 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
       byteData = _loadFontFromDeviceFileSystem(familyWithVariantString);
     }
     if (await byteData != null) {
-      return loadFontByteData(familyWithVariantString, byteData);
+      return _loadFontByteData(familyWithVariantString, byteData);
     }
 
     // Attempt to load this font via http.
@@ -149,7 +149,7 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
       descriptor.fontUrl,
     );
     if (await byteData != null) {
-      return loadFontByteData(familyWithVariantString, byteData);
+      return _loadFontByteData(familyWithVariantString, byteData);
     }
   } catch (e) {
     final fontName = descriptor.familyWithVariant.toApiFilenamePrefix();
@@ -159,7 +159,7 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
 }
 
 /// Loads a font with [FontLoader], given its name and byte-representation.
-void loadFontByteData(
+void _loadFontByteData(
     String familyWithVariantString, Future<ByteData> byteData) async {
   _loadedFonts.add(familyWithVariantString);
   final fontLoader = FontLoader(familyWithVariantString);
@@ -282,7 +282,7 @@ String _findFamilyWithVariantAssetPath(
   GoogleFontsFamilyWithVariant familyWithVariant,
   Map<String, dynamic> manifestJson,
 ) {
-  if (manifestJson == null) return '';
+  if (manifestJson == null) return null;
 
   final apiFilenamePrefix = familyWithVariant.toApiFilenamePrefix();
 
@@ -306,5 +306,5 @@ String _findFamilyWithVariantAssetPath(
     }
   }
 
-  return '';
+  return null;
 }

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -231,13 +231,13 @@ Future<ByteData> _httpFetchFontAndSaveToDevice(
   }
 }
 
-Future<String> _localPath() async {
+Future<String> get _localPath async {
   final directory = await getApplicationSupportDirectory();
   return directory.path;
 }
 
 Future<File> _localFile(String name) async {
-  final path = await _localPath();
+  final path = await _localPath;
   // TODO(clocksmith): what if this file is an otf?
   return File('$path/$name.ttf');
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_fonts
 description: A package to include fonts from fonts.google.com in your flutter app.
-version: 0.3.5
+version: 0.3.6
 homepage: https://github.com/material-foundation/google-fonts-flutter/
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_fonts
 description: A package to include fonts from fonts.google.com in your flutter app.
-version: 0.3.6
+version: 0.3.7
 homepage: https://github.com/material-foundation/google-fonts-flutter/
 
 environment:

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -108,6 +108,33 @@ main() {
     );
   });
 
+  testWidgets('loadFontIfNecessary method throws if font cannot be loaded',
+      (tester) async {
+    // Mock a bad response.
+    when(httpClient.get(any)).thenAnswer((_) async {
+      return http.Response('fake response body - failure', 300);
+    });
+
+    final fooUrl = Uri.http('fonts.google.com', '/Foo');
+    final descriptorInAssets = GoogleFontsDescriptor(
+      familyWithVariant: GoogleFontsFamilyWithVariant(
+        family: 'Foo',
+        googleFontsVariant: GoogleFontsVariant(
+          fontWeight: FontWeight.w900,
+          fontStyle: FontStyle.italic,
+        ),
+      ),
+      fontUrl: fooUrl.toString(),
+    );
+
+    // Call loadFontIfNecessary and verify that it throws an exception.
+    expect(
+      loadFontIfNecessary(descriptorInAssets),
+      throwsA(predicate((e) => e.message.toString().startsWith(
+          'Failed to load font with url: http://fonts.google.com/Foo'))),
+    );
+  });
+
   testWidgets(
       'loadFontIfNecessary method does nothing if the font is in the '
       'Asset Manifest', (tester) async {
@@ -153,33 +180,5 @@ main() {
     // Bar-BoldItalic is in the asset bundle.
     await loadFontIfNecessary(descriptorNotInAssets);
     verify(httpClient.get(barUrl)).called(1);
-  });
-
-  testWidgets('loadFontIfNecessary method throws if font cannot be loaded',
-      (tester) async {
-    // Mock a bad response.
-    when(httpClient.get(any)).thenAnswer((_) async {
-      return http.Response('fake response body - failure', 300);
-    });
-
-    final fooUrl = Uri.http('fonts.google.com', '/Foo');
-    final descriptorInAssets = GoogleFontsDescriptor(
-      familyWithVariant: GoogleFontsFamilyWithVariant(
-        family: 'Foo',
-        googleFontsVariant: GoogleFontsVariant(
-          fontWeight: FontWeight.w900,
-          fontStyle: FontStyle.italic,
-        ),
-      ),
-      fontUrl: fooUrl.toString(),
-    );
-
-    // Call loadFontIfNecessary and verify that it throws an exception.
-    expect(
-      loadFontIfNecessary(descriptorInAssets),
-      throwsA(predicate((e) => e.message
-          .toString()
-          .startsWith('google_fonts was unable to load font Foo'))),
-    );
   });
 }

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
@@ -14,6 +15,15 @@ import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 
 class MockHttpClient extends Mock implements http.Client {}
+
+var printLog = [];
+overridePrint(testFn()) => () {
+      var spec = new ZoneSpecification(print: (_, __, ___, String msg) {
+        // Add to log instead of printing to stdout
+        printLog.add(msg);
+      });
+      return Zone.current.fork(specification: spec).run(testFn);
+    };
 
 main() {
   setUp(() async {
@@ -35,6 +45,7 @@ main() {
   });
 
   tearDown(() {
+    printLog = [];
     clearCache();
   });
 
@@ -53,6 +64,36 @@ main() {
     await loadFontIfNecessary(fakeDescriptor);
 
     verify(httpClient.get(fakeUrl)).called(1);
+  });
+
+  testWidgets('loadFontIfNecessary method throws if font cannot be loaded',
+      (tester) async {
+    // Mock a bad response.
+    when(httpClient.get(any)).thenAnswer((_) async {
+      return http.Response('fake response body - failure', 300);
+    });
+
+    final fooUrl = Uri.http('fonts.google.com', '/Foo');
+    final descriptorInAssets = GoogleFontsDescriptor(
+      familyWithVariant: GoogleFontsFamilyWithVariant(
+        family: 'Foo',
+        googleFontsVariant: GoogleFontsVariant(
+          fontWeight: FontWeight.w900,
+          fontStyle: FontStyle.italic,
+        ),
+      ),
+      fontUrl: fooUrl.toString(),
+    );
+
+    // Call loadFontIfNecessary and verify that it prints an error.
+    overridePrint(() async {
+      await loadFontIfNecessary(descriptorInAssets);
+      expect(printLog.length, 1);
+      expect(
+        printLog[0],
+        startsWith('google_fonts was unable to load font Foo-BlackItalic'),
+      );
+    });
   });
 
   testWidgets(
@@ -153,33 +194,5 @@ main() {
     // Bar-BoldItalic is in the asset bundle.
     await loadFontIfNecessary(descriptorNotInAssets);
     verify(httpClient.get(barUrl)).called(1);
-  });
-
-  testWidgets('loadFontIfNecessary method throws if font cannot be loaded',
-      (tester) async {
-    // Mock a bad response.
-    when(httpClient.get(any)).thenAnswer((_) async {
-      return http.Response('fake response body - failure', 300);
-    });
-
-    final fooUrl = Uri.http('fonts.google.com', '/Foo');
-    final descriptorInAssets = GoogleFontsDescriptor(
-      familyWithVariant: GoogleFontsFamilyWithVariant(
-        family: 'Foo',
-        googleFontsVariant: GoogleFontsVariant(
-          fontWeight: FontWeight.w900,
-          fontStyle: FontStyle.italic,
-        ),
-      ),
-      fontUrl: fooUrl.toString(),
-    );
-
-    // Call loadFontIfNecessary and verify that it throws an exception.
-    expect(
-      loadFontIfNecessary(descriptorInAssets),
-      throwsA(predicate((e) => e.message
-          .toString()
-          .startsWith('google_fonts was unable to load font Foo'))),
-    );
   });
 }

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -108,33 +108,6 @@ main() {
     );
   });
 
-  testWidgets('loadFontIfNecessary method throws if font cannot be loaded',
-      (tester) async {
-    // Mock a bad response.
-    when(httpClient.get(any)).thenAnswer((_) async {
-      return http.Response('fake response body - failure', 300);
-    });
-
-    final fooUrl = Uri.http('fonts.google.com', '/Foo');
-    final descriptorInAssets = GoogleFontsDescriptor(
-      familyWithVariant: GoogleFontsFamilyWithVariant(
-        family: 'Foo',
-        googleFontsVariant: GoogleFontsVariant(
-          fontWeight: FontWeight.w900,
-          fontStyle: FontStyle.italic,
-        ),
-      ),
-      fontUrl: fooUrl.toString(),
-    );
-
-    // Call loadFontIfNecessary and verify that it throws an exception.
-    expect(
-      loadFontIfNecessary(descriptorInAssets),
-      throwsA(predicate((e) => e.message.toString().startsWith(
-          'Failed to load font with url: http://fonts.google.com/Foo'))),
-    );
-  });
-
   testWidgets(
       'loadFontIfNecessary method does nothing if the font is in the '
       'Asset Manifest', (tester) async {
@@ -180,5 +153,33 @@ main() {
     // Bar-BoldItalic is in the asset bundle.
     await loadFontIfNecessary(descriptorNotInAssets);
     verify(httpClient.get(barUrl)).called(1);
+  });
+
+  testWidgets('loadFontIfNecessary method throws if font cannot be loaded',
+      (tester) async {
+    // Mock a bad response.
+    when(httpClient.get(any)).thenAnswer((_) async {
+      return http.Response('fake response body - failure', 300);
+    });
+
+    final fooUrl = Uri.http('fonts.google.com', '/Foo');
+    final descriptorInAssets = GoogleFontsDescriptor(
+      familyWithVariant: GoogleFontsFamilyWithVariant(
+        family: 'Foo',
+        googleFontsVariant: GoogleFontsVariant(
+          fontWeight: FontWeight.w900,
+          fontStyle: FontStyle.italic,
+        ),
+      ),
+      fontUrl: fooUrl.toString(),
+    );
+
+    // Call loadFontIfNecessary and verify that it throws an exception.
+    expect(
+      loadFontIfNecessary(descriptorInAssets),
+      throwsA(predicate((e) => e.message
+          .toString()
+          .startsWith('google_fonts was unable to load font Foo'))),
+    );
   });
 }

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -154,4 +154,32 @@ main() {
     await loadFontIfNecessary(descriptorNotInAssets);
     verify(httpClient.get(barUrl)).called(1);
   });
+
+  testWidgets('loadFontIfNecessary method throws if font cannot be loaded',
+      (tester) async {
+    // Mock a bad response.
+    when(httpClient.get(any)).thenAnswer((_) async {
+      return http.Response('fake response body - failure', 300);
+    });
+
+    final fooUrl = Uri.http('fonts.google.com', '/Foo');
+    final descriptorInAssets = GoogleFontsDescriptor(
+      familyWithVariant: GoogleFontsFamilyWithVariant(
+        family: 'Foo',
+        googleFontsVariant: GoogleFontsVariant(
+          fontWeight: FontWeight.w900,
+          fontStyle: FontStyle.italic,
+        ),
+      ),
+      fontUrl: fooUrl.toString(),
+    );
+
+    // Call loadFontIfNecessary and verify that it throws an exception.
+    expect(
+      loadFontIfNecessary(descriptorInAssets),
+      throwsA(predicate((e) => e.message
+          .toString()
+          .startsWith('google_fonts was unable to load font Foo'))),
+    );
+  });
 }

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -113,7 +113,21 @@ main() {
 
     GoogleFonts.config.allowHttp = false;
 
-    await loadFontIfNecessary(fakeDescriptor);
+    // Call loadFontIfNecessary and verify that it prints an error.
+    overridePrint(() async {
+      await loadFontIfNecessary(fakeDescriptor);
+      expect(printLog.length, 1);
+      expect(
+        printLog[0],
+        startsWith("google_fonts was unable to load font Foo-Regular"),
+      );
+      expect(
+        printLog[0],
+        endsWith(
+          "Ensure Foo-Regular.otf exists in a folder that is included in your pubspec's assets.",
+        ),
+      );
+    });
 
     verifyNever(httpClient.get(anything));
   });


### PR DESCRIPTION
Fixes asset font loading and gracefully handles exception cases (i.e. offline) by printing errors to console. This PR also updates the bundling instructions and removes files which shouldn't be checked-in.

## Related issues
Closes #40 
Closes #31
Closes #28
#49
#54
#38