### PR TITLE
[Google Fonts] add config with option to turn off http requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.6] - 2020-01-31
+
+* Add a config to the `GoogleFonts` class with an `allowHttp` option.
+
 ## [0.3.5] - 2020-01-23
 
 * Update generator to get most up-to-date urls from fonts.google.com. 

--- a/generator/google_fonts.tmpl
+++ b/generator/google_fonts.tmpl
@@ -11,7 +11,25 @@ import 'package:flutter/material.dart';
 import 'src/google_fonts_base.dart';
 import 'src/google_fonts_variant.dart';
 
+/// A collection of properties used to specify custom behavior of the GoogleFonts library.
+class _Config {
+  /// Whether or not the GoogleFonts library can make requests to fonts.google.com to retrieve font
+  /// files.
+  var allowHttp = true;
+}
+
 class GoogleFonts {
+  /// Configuration for the [GoogleFonts] library.
+  ///
+  /// Use this to define custom behavior of the GoogleFonts library in your app. For example, if you
+  /// do not want the GoogleFonts library to make any http requests for fonts, add the following
+  /// snippet to your app's `main` method.
+  ///
+  /// ```dart
+  /// GoogleFonts.config.allowHttp = false;
+  /// ```
+  static final config = _Config();
+
   {{#method}}
   /// Applies the {{fontFamilyDisplay}} font family from Google Fonts to the given [textStyle].
   ///

--- a/lib/google_fonts.dart
+++ b/lib/google_fonts.dart
@@ -11,12 +11,23 @@ import 'package:flutter/material.dart';
 import 'src/google_fonts_base.dart';
 import 'src/google_fonts_variant.dart';
 
+/// A collection of properties used to specify custom behavior of the GoogleFonts library.
 class _Config {
+  /// Whether or not the GoogleFonts library can make requests to fonts.google.com to retrieve font
+  /// files.
   var allowHttp = true;
-  var allowWritingLocalFiles = true;
 }
 
 class GoogleFonts {
+  /// Configuration for the [GoogleFonts] library.
+  ///
+  /// Use this to define custom behavior of the GoogleFonts library in your app. For example, if you
+  /// do not want the GoogleFonts library to make any http requests for fonts, add the following
+  /// snippet to your app's `main` method.
+  ///
+  /// ```dart
+  /// GoogleFonts.config.allowHttp = false;
+  /// ```
   static final config = _Config();
 
   /// Applies the ABeeZee font family from Google Fonts to the given [textStyle].

--- a/lib/google_fonts.dart
+++ b/lib/google_fonts.dart
@@ -11,7 +11,14 @@ import 'package:flutter/material.dart';
 import 'src/google_fonts_base.dart';
 import 'src/google_fonts_variant.dart';
 
+class _Config {
+  var allowHttp = true;
+  var allowWritingLocalFiles = true;
+}
+
 class GoogleFonts {
+  static final config = _Config();
+
   /// Applies the ABeeZee font family from Google Fonts to the given [textStyle].
   ///
   /// See:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_fonts
 description: A package to include fonts from fonts.google.com in your flutter app.
-version: 0.3.5
+version: 0.3.6
 homepage: https://github.com/material-foundation/google-fonts-flutter/
 
 environment:

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -20,7 +20,6 @@ main() {
   setUp(() async {
     httpClient = MockHttpClient();
     GoogleFonts.config.allowHttp = true;
-    GoogleFonts.config.allowWritingLocalFiles = true;
     when(httpClient.get(any)).thenAnswer((_) async {
       return http.Response('fake response body - success', 200);
     });

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:google_fonts/src/google_fonts_base.dart';
 import 'package:google_fonts/src/google_fonts_descriptor.dart';
 import 'package:google_fonts/src/google_fonts_family_with_variant.dart';
@@ -18,6 +19,8 @@ class MockHttpClient extends Mock implements http.Client {}
 main() {
   setUp(() async {
     httpClient = MockHttpClient();
+    GoogleFonts.config.allowHttp = true;
+    GoogleFonts.config.allowWritingLocalFiles = true;
     when(httpClient.get(any)).thenAnswer((_) async {
       return http.Response('fake response body - success', 200);
     });
@@ -53,6 +56,26 @@ main() {
     await loadFontIfNecessary(fakeDescriptor);
 
     verify(httpClient.get(fakeUrl)).called(1);
+  });
+
+  testWidgets('does not call http if config is false', (tester) async {
+    final fakeUrl = Uri.http('fonts.google.com', '/Foo');
+    final fakeDescriptor = GoogleFontsDescriptor(
+      familyWithVariant: GoogleFontsFamilyWithVariant(
+        family: 'Foo',
+        googleFontsVariant: GoogleFontsVariant(
+          fontWeight: FontWeight.w400,
+          fontStyle: FontStyle.normal,
+        ),
+      ),
+      fontUrl: fakeUrl.toString(),
+    );
+
+    GoogleFonts.config.allowHttp = false;
+
+    await loadFontIfNecessary(fakeDescriptor);
+
+    verifyNever(httpClient.get(anything));
   });
 
   testWidgets(


### PR DESCRIPTION
In the user's `main` method, they would do the following.

```dart
GoogleFonts.config.allowHttp = false;
```