### PR TITLE
[pubspec] fix dependency on crypto to allow for future versions.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
   http: ^0.12.0+2
   path_provider: ^1.4.0
-  crypto: 2.1.3
+  crypto: ^2.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This is based on a suggestion from the pub tool:


```
Suggestions:
* Your dependency on "crypto" should allow more than one version. For example:

  dependencies:
    crypto: ^2.1.3

  Constraints that are too tight will make it difficult for people to use your package
  along with other packages that also depend on "crypto".

Package has 1 warning.
```