### PR TITLE
Only attempt to load a unique font family once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.4.1] - 2020-04-14
+
+* Change loadFontIfNecessary to only follow through once per unique family when called in parallel.
+
 ## [0.4.1] - 2020-04-13
 
 * Update README to include instructions for how to include licenses for fonts. 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_fonts
 description: A package to include fonts from fonts.google.com in your flutter app.
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/material-foundation/google-fonts-flutter/
 
 environment:

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -167,6 +167,28 @@ void main() {
     verifyNever(httpClient.get(anything));
   });
 
+  testWidgets(
+      'loadFontIfNecessary does not make more than 1 http get request on '
+          'parallel calls', (tester) async {
+    final fakeDescriptor = GoogleFontsDescriptor(
+      familyWithVariant: GoogleFontsFamilyWithVariant(
+        family: 'Foo',
+        googleFontsVariant: GoogleFontsVariant(
+          fontWeight: FontWeight.w400,
+          fontStyle: FontStyle.normal,
+        ),
+      ),
+      file: _fakeResponseFile,
+    );
+
+    await Future.wait([
+      loadFontIfNecessary(fakeDescriptor),
+      loadFontIfNecessary(fakeDescriptor),
+      loadFontIfNecessary(fakeDescriptor)
+    ]);
+    verify(httpClient.get(anything)).called(1);
+  });
+
   testWidgets('loadFontIfNecessary method writes font file', (tester) async {
     final fakeDescriptor = GoogleFontsDescriptor(
       familyWithVariant: GoogleFontsFamilyWithVariant(

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -169,7 +169,7 @@ void main() {
 
   testWidgets(
       'loadFontIfNecessary does not make more than 1 http get request on '
-          'parallel calls', (tester) async {
+      'parallel calls', (tester) async {
     final fakeDescriptor = GoogleFontsDescriptor(
       familyWithVariant: GoogleFontsFamilyWithVariant(
         family: 'Foo',
@@ -187,6 +187,33 @@ void main() {
       loadFontIfNecessary(fakeDescriptor)
     ]);
     verify(httpClient.get(anything)).called(1);
+  });
+
+  testWidgets(
+      'loadFontIfNecessary makes second attempt if the first attempt failed ',
+      (tester) async {
+    final fakeDescriptor = GoogleFontsDescriptor(
+      familyWithVariant: GoogleFontsFamilyWithVariant(
+        family: 'Foo',
+        googleFontsVariant: GoogleFontsVariant(
+          fontWeight: FontWeight.w400,
+          fontStyle: FontStyle.normal,
+        ),
+      ),
+      file: _fakeResponseFile,
+    );
+
+    // Have the first call throw an error.
+    when(httpClient.get(any)).thenThrow('error');
+    await loadFontIfNecessary(fakeDescriptor);
+    verify(httpClient.get(any)).called(1);
+
+    // The second call will retry the http fetch.
+    when(httpClient.get(any)).thenAnswer((_) async {
+      return http.Response(_fakeResponse, 200);
+    });
+    await loadFontIfNecessary(fakeDescriptor);
+    verify(httpClient.get(any)).called(1);
   });
 
   testWidgets('loadFontIfNecessary method writes font file', (tester) async {


### PR DESCRIPTION
This changes the logic of loadFontIfNecessary to only continue if it's never been attempted before, instead of if the font actually loaded. This ensures that there are not multiple requests to load the same font.