### PR TITLE
Implement memoized AssetManifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.6.1] - 2020-04-17
+
+* Memoize asset manifest.
+
 ## [0.6.0] - 2020-04-16
 
 * Rename `config.allowHttp` to `config.allowRuntimeFetching`.

--- a/lib/src/asset_manifest.dart
+++ b/lib/src/asset_manifest.dart
@@ -1,0 +1,53 @@
+// Copyright 2019 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert' as convert;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+class AssetManifest {
+  AssetManifest({this.enableCache = true});
+
+  static Future<Map<String, List<String>>> _jsonFuture;
+  // Whether the rootBundle should cache AssetManifest.json. Should only be
+  // disabled during tests.
+  final bool enableCache;
+
+  Future<Map<String, List<String>>> json() {
+    _jsonFuture ??= _loadAssetManifestJson();
+    return _jsonFuture;
+  }
+
+  Future<Map<String, List<String>>> _loadAssetManifestJson() async {
+    try {
+      final jsonString =
+          await rootBundle.loadString('AssetManifest.json', cache: enableCache);
+      return _manifestParser(jsonString);
+    } catch (e) {
+      print('Error loading AssetManifest.json, e: $e');
+      rootBundle.evict('AssetManifest.json');
+    }
+    return null;
+  }
+
+  static Future<Map<String, List<String>>> _manifestParser(String jsonData) {
+    if (jsonData == null) {
+      return SynchronousFuture<Map<String, List<String>>>(null);
+    }
+    final Map<String, dynamic> parsedJson =
+        convert.json.decode(jsonData) as Map<String, dynamic>;
+    final Iterable<String> keys = parsedJson.keys;
+    final Map<String, List<String>> parsedManifest =
+        Map<String, List<String>>.fromIterables(
+            keys,
+            keys.map<List<String>>(
+                (key) => List<String>.from(parsedJson[key] as List<dynamic>)));
+    return SynchronousFuture<Map<String, List<String>>>(parsedManifest);
+  }
+
+  @visibleForTesting
+  static void reset() {
+    _jsonFuture = null;
+  }
+}

--- a/lib/src/asset_manifest.dart
+++ b/lib/src/asset_manifest.dart
@@ -10,8 +10,8 @@ class AssetManifest {
   AssetManifest({this.enableCache = true});
 
   static Future<Map<String, List<String>>> _jsonFuture;
-  // Whether the rootBundle should cache AssetManifest.json. Should only be
-  // disabled during tests.
+  // Whether the rootBundle should cache AssetManifest.json. Enabled by default.
+  // Should only be disabled during tests.
   final bool enableCache;
 
   Future<Map<String, List<String>>> json() {

--- a/lib/src/asset_manifest.dart
+++ b/lib/src/asset_manifest.dart
@@ -6,6 +6,8 @@ import 'dart:convert' as convert;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+// A class to obtain and memoize the app's asset manifest. Used to check whether
+// a font is provided as an asset.
 class AssetManifest {
   AssetManifest({this.enableCache = true});
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_fonts
 description: A package to include fonts from fonts.google.com in your flutter app.
-version: 0.5.0+1
+version: 0.6.1
 homepage: https://github.com/material-foundation/google-fonts-flutter/
 
 environment:

--- a/test/asset_manifest_test.dart
+++ b/test/asset_manifest_test.dart
@@ -1,0 +1,89 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/src/asset_manifest.dart';
+
+const _fakeAssetManifestText = '{"value": ["fake"]}';
+var _assetManifestLoadCount = 0;
+
+AssetManifest assetManifest;
+
+void main() {
+  setUpAll(() async {
+    ServicesBinding.instance.defaultBinaryMessenger
+        .setMockMessageHandler('flutter/assets', (message) {
+      _assetManifestLoadCount++;
+      final Uint8List encoded = utf8.encoder.convert(_fakeAssetManifestText);
+      return Future.value(encoded.buffer.asByteData());
+    });
+    // Disable cache so that we can see if AssetManifest.json is requested more
+    // than once.
+    assetManifest = AssetManifest(enableCache: false);
+  });
+
+  tearDown(() async {
+    _assetManifestLoadCount = 0;
+    AssetManifest.reset();
+  });
+
+  testWidgets('AssetManifest loads once when called multiple times in parallel',
+      (tester) async {
+    final manifestJsons = await Future.wait([
+      assetManifest.json(),
+      assetManifest.json(),
+      assetManifest.json(),
+    ]);
+    _verifyAssetManifestLoadedOnce();
+    manifestJsons.forEach(_verifyAssetManifestContent);
+  });
+
+  testWidgets(
+      'AssetManifest loads once when called multiple times in parallel then multiple times in succession',
+      (tester) async {
+    final manifestJsons = await Future.wait([
+      assetManifest.json(),
+      assetManifest.json(),
+      assetManifest.json(),
+    ]);
+    _verifyAssetManifestLoadedOnce();
+    manifestJsons.forEach(_verifyAssetManifestContent);
+
+    final manifestJson3 = await assetManifest.json();
+    final manifestJson4 = await assetManifest.json();
+    _verifyAssetManifestLoadedOnce();
+    _verifyAssetManifestContent(manifestJson3);
+    _verifyAssetManifestContent(manifestJson4);
+  });
+
+  testWidgets('AssetManifest loads', (tester) async {
+    final manifestJson = await assetManifest.json();
+    _verifyAssetManifestLoadedOnce();
+    _verifyAssetManifestContent(manifestJson);
+  });
+
+  testWidgets(
+      'AssetManifest loads once when called multiple times in succession',
+      (tester) async {
+    final manifestJson1 = await assetManifest.json();
+    _verifyAssetManifestLoadedOnce();
+    _verifyAssetManifestContent(manifestJson1);
+
+    final manifestJson2 = await assetManifest.json();
+    _verifyAssetManifestLoadedOnce();
+    _verifyAssetManifestContent(manifestJson2);
+  });
+}
+
+void _verifyAssetManifestLoadedOnce() {
+  expect(_assetManifestLoadCount, 1);
+}
+
+void _verifyAssetManifestContent(Map<String, dynamic> manifestJson) {
+  expect(manifestJson['value'], ['fake']);
+}

--- a/test/generated_font_methods_test.dart
+++ b/test/generated_font_methods_test.dart
@@ -7,13 +7,19 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:google_fonts/src/asset_manifest.dart';
 import 'package:google_fonts/src/google_fonts_base.dart';
 import 'package:mockito/mockito.dart';
 import 'package:http/http.dart' as http;
 
 class MockHttpClient extends Mock implements http.Client {}
 
+class MockAssetManifest extends Mock implements AssetManifest {}
+
 void main() {
+  setUpAll(() {
+    assetManifest = MockAssetManifest();
+  });
   tearDown(() {
     clearCache();
   });

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:google_fonts/src/asset_manifest.dart';
 import 'package:google_fonts/src/google_fonts_base.dart';
 import 'package:google_fonts/src/google_fonts_descriptor.dart';
 import 'package:google_fonts/src/google_fonts_family_with_variant.dart';
@@ -14,6 +15,8 @@ import 'package:mockito/mockito.dart';
 import 'package:path_provider/path_provider.dart';
 
 class MockHttpClient extends Mock implements http.Client {}
+
+class MockAssetManifest extends Mock implements AssetManifest {}
 
 const _fakeResponse = 'fake response body - success';
 // The number of bytes in _fakeResponse.
@@ -40,6 +43,7 @@ void main() {
   setUp(() async {
     isWeb = false;
     httpClient = MockHttpClient();
+    assetManifest = MockAssetManifest();
     GoogleFonts.config.allowHttp = true;
     when(httpClient.get(any)).thenAnswer((_) async {
       return http.Response(_fakeResponse, 200);


### PR DESCRIPTION
There may be multiple concurrent calls to fetch the asset manifest (one per font variant loaded). Memoize it so only one load request happens. 

This is a redundancy because `rootBundle.loadString` sometimes doesn't cache requests.