### PR TITLE
A better explanation of {{methodName}}TextTheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can also use `GoogleFonts.latoTextTheme()` to make or modify an entire text 
 MaterialApp(
   theme: ThemeData(
     textTheme: GoogleFonts.latoTextTheme(
-      Theme.of(context).textTheme,
+      Theme.of(context).textTheme, // If this is not set, then ThemeData.light().textTheme is used.
     ),
   ),
 );
@@ -150,7 +150,7 @@ void main() {
     final license = await rootBundle.loadString('google_fonts/OFL.txt');
     yield LicenseEntryWithLineBreaks(['google_fonts'], license);
   });
-  
+
   runApp(...);
 }
 ```


### PR DESCRIPTION
This PR solves https://github.com/material-foundation/google-fonts-flutter/issues/23.

I make a mistake while opening https://github.com/material-foundation/google-fonts-flutter/issues/23. I thought that if you have `latoTextTheme` (or any Google Font `TextTheme`) you can't have a custom because is in use `ThemeData`:

```dart
/// My super awesome theme.
ThemeData mainTheme = ThemeData(
  brightness: Brightness.light,
  primaryColor: primaryColor,
  accentColor: accentColor,
  scaffoldBackgroundColor: Colors.indigo[50],
);
```

```dart
class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      theme: ThemeData( // Can't use `mainTheme` here because ThemeData is in use. <----------------
        textTheme: GoogleFonts.latoTextTheme(
          Theme.of(context).textTheme,
        ),
      ),
    );
  }
}
```
 
But that's not the case, you can have the following:
```dart
/// My super awesome theme.
ThemeData mainTheme = ThemeData(
  ...
  textTheme: GoogleFonts.latoTextTheme(), // "Lato" in all instances (headline1, button, caption, etc...) <------------
  ...
);
```

**Why I opened this PR? And why I opened https://github.com/material-foundation/google-fonts-flutter/issues/23? If everything is ok.**

At the time I used the package I didn't know Dart very well, I didn't know there was positional parameters, I thought there was only "named/default parameter" and "required parameters" and I was not alone in this, other people thought `ThemeData` couldn't be used if `GoogleFonts.{typographyName}TextTheme`  was in use (If you take a look at the issue you will see that it get quite a support), if `textTheme` parameter were really a required parameter there will be a big a problem because to use this `Theme.of(context).textTheme` you will need to have access to `context`, and you not always have it if you declare it like this:

```dart
/// My super awesome theme.
ThemeData mainTheme = ThemeData(
  ...
  textTheme: textTheme: GoogleFonts.latoTextTheme(
      Theme.of(context).textTheme, // context was not found <----------
  ),
 ...
);
```

You can see in this [line of code](https://github.com/Classy-Bear/google-fonts-flutter/blob/e64ef6ad34c4a8160552e376bd7081a92e1886e9/generator/google_fonts.tmpl#L213) that if `textTheme` is `null` then is set to `ThemeData.light().textTheme`.

I decided to add this line in the README.md...
```dart
Theme.of(context).textTheme, // If this is not set, then ThemeData.light().textTheme is used.
 ```

to explain that this is not required the `textTheme` parameter, I know that the language itself explain this but no one noticed until this moment, I will recommend adding this or something similar to clarify that is not required for newcomers.

Not related:

I was using VIM(because my PC is slow AF, and it restarts when I open VSC) at the time when I found the issue, so because VIM doesn't complain it's just a text editor (unless you add plugins) I thought the positional parameter were a required parameter and didn't check the code that was behind the scenes because an IDE is required for it. 

The funny thing is that I was catching up with my issues and found this, that's why the late response so sorry about that.