### PR TITLE
Fixes #146

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.0-nullsafety.1] - 2021-02-24
+
+* Fixes an issue while loading fonts ([#146](https://github.com/material-foundation/google-fonts-flutter/issues/146))
+
 ## [2.0.0-nullsafety.0] - 2021-02-11
 
 * Migrated the main library to null safety.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -94,7 +94,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-nullsafety.0"
+    version: "2.0.0-nullsafety.1"
   http:
     dependency: transitive
     description:

--- a/lib/src/file_io_desktop_and_mobile.dart
+++ b/lib/src/file_io_desktop_and_mobile.dart
@@ -26,7 +26,7 @@ Future<ByteData?> loadFontFromDeviceFileSystem(String name) async {
 
 Future<String> get _localPath async {
   final directory = await getApplicationSupportDirectory();
-  return directory!.path;
+  return directory.path;
 }
 
 Future<File> _localFile(String name) async {

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -143,14 +143,14 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
       byteData = rootBundle.load(assetPath);
     }
     if (await byteData != null) {
-      return _loadFontByteData(familyWithVariantString, byteData);
+      return loadFontByteData(familyWithVariantString, byteData);
     }
 
     // Check if this font can be loaded from the device file system.
     byteData = file_io.loadFontFromDeviceFileSystem(familyWithVariantString);
 
     if (await byteData != null) {
-      return _loadFontByteData(familyWithVariantString, byteData);
+      return loadFontByteData(familyWithVariantString, byteData);
     }
 
     // Attempt to load this font via http, unless disallowed.
@@ -160,7 +160,7 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
         descriptor.file,
       );
       if (await byteData != null) {
-        return _loadFontByteData(familyWithVariantString, byteData);
+        return loadFontByteData(familyWithVariantString, byteData);
       }
     } else {
       throw Exception(
@@ -177,7 +177,8 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
 }
 
 /// Loads a font with [FontLoader], given its name and byte-representation.
-Future<void> _loadFontByteData(
+@visibleForTesting
+Future<void> loadFontByteData(
   String familyWithVariantString,
   Future<ByteData?>? byteData,
 ) async {

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -181,12 +181,13 @@ Future<void> _loadFontByteData(
   String familyWithVariantString,
   Future<ByteData?>? byteData,
 ) async {
-  final anyFontDataFound = byteData != null && await byteData != null;
-  if (anyFontDataFound) {
-    final fontLoader = FontLoader(familyWithVariantString);
-    fontLoader.addFont(byteData as Future<ByteData>);
-    await fontLoader.load();
-  }
+  if (byteData == null) return;
+  final fontData = await byteData;
+  if (fontData == null) return;
+
+  final fontLoader = FontLoader(familyWithVariantString);
+  fontLoader.addFont(byteData as Future<ByteData>);
+  await fontLoader.load();
 }
 
 /// Returns [GoogleFontsVariant] from [variantsToCompare] that most closely

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -186,7 +186,7 @@ Future<void> _loadFontByteData(
   if (fontData == null) return;
 
   final fontLoader = FontLoader(familyWithVariantString);
-  fontLoader.addFont(byteData as Future<ByteData>);
+  fontLoader.addFont(Future.value(fontData));
   await fontLoader.load();
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_fonts
 description: A package to include fonts from fonts.google.com in your Flutter app.
-version: 2.0.0-nullsafety.0
+version: 2.0.0-nullsafety.1
 repository: https://github.com/material-foundation/google-fonts-flutter/
 
 environment:

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -242,12 +242,12 @@ void main() {
     );
 
     var directoryContents = await getApplicationSupportDirectory();
-    expect(directoryContents!.listSync().isEmpty, isTrue);
+    expect(directoryContents.listSync().isEmpty, isTrue);
 
     await loadFontIfNecessary(fakeDescriptor);
     directoryContents = await getApplicationSupportDirectory();
 
-    expect(directoryContents!.listSync().isNotEmpty, isTrue);
+    expect(directoryContents.listSync().isNotEmpty, isTrue);
     expect(
       directoryContents.listSync().single.toString().contains('Foo'),
       isTrue,
@@ -272,10 +272,10 @@ void main() {
     );
 
     var directoryContents = await getApplicationSupportDirectory();
-    expect(directoryContents!.listSync().isEmpty, isTrue);
+    expect(directoryContents.listSync().isEmpty, isTrue);
 
     await loadFontIfNecessary(fakeDescriptor);
     directoryContents = await getApplicationSupportDirectory();
-    expect(directoryContents!.listSync().isEmpty, isTrue);
+    expect(directoryContents.listSync().isEmpty, isTrue);
   });
 }

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -278,4 +278,25 @@ void main() {
     directoryContents = await getApplicationSupportDirectory();
     expect(directoryContents.listSync().isEmpty, isTrue);
   });
+
+  test('loadFontByteData doesn\'t fail', () {
+    expect(
+      () async => loadFontByteData('fontFamily', Future.value(ByteData(0))),
+      returnsNormally,
+    );
+    expect(
+      () async => loadFontByteData('fontFamily', Future.value(null)),
+      returnsNormally,
+    );
+    expect(
+      () async => loadFontByteData('fontFamily', null),
+      returnsNormally,
+    );
+
+    expect(
+      () async => loadFontByteData('fontFamily',
+          Future.delayed(Duration(milliseconds: 100), () => null)),
+      returnsNormally,
+    );
+  });
 }


### PR DESCRIPTION
This PR fixes https://github.com/material-foundation/google-fonts-flutter/issues/146. 

As per discussed in #148 it would be better to tackle this issue first, so here is the PR.

WWhile running the tests, the `google-fonts-flutter\test\load_font_if_necessary_test.dart: loadFontIfNecessary method calls http get` test hangs indefinitely regardless of my fix or not. Am I doing anything wrong ?