### PR TITLE
Fix tests by faking `PathProviderPlatform`

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -129,7 +129,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2"
   meta:
     dependency: transitive
     description:
@@ -253,7 +260,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -267,7 +274,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   win32:
     dependency: transitive
     description:
@@ -283,5 +290,5 @@ packages:
     source: hosted
     version: "0.2.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,4 +19,5 @@ dev_dependencies:
     sdk: flutter
   mockito: ^5.0.0
   mustache: ^1.1.1
-  protobuf: ^1.0.1
+  protobuf: ^2.0.1
+  test: ^1.19.5

--- a/test/load_font_if_necessary_with_local_fonts_test.dart
+++ b/test/load_font_if_necessary_with_local_fonts_test.dart
@@ -12,11 +12,26 @@ import 'package:google_fonts/src/google_fonts_family_with_variant.dart';
 import 'package:google_fonts/src/google_fonts_variant.dart';
 import 'package:http/http.dart' as http;
 import 'package:mockito/mockito.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 class MockHttpClient extends Mock implements http.Client {
   Future<http.Response> gets(dynamic uri, {dynamic headers}) {
     super.noSuchMethod(Invocation.method(#get, [uri], {#headers: headers}));
     return Future.value(http.Response('', 200));
+  }
+}
+
+class FakePathProviderPlatform extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  FakePathProviderPlatform(this._applicationSupportPath);
+
+  final String _applicationSupportPath;
+
+  @override
+  Future<String?> getApplicationSupportPath() async {
+    return _applicationSupportPath;
   }
 }
 
@@ -55,16 +70,8 @@ void main() {
       return Future.value(encoded.buffer.asByteData());
     });
 
-    // The following snippet pulled from
-    //  * https://flutter.dev/docs/cookbook/persistence/reading-writing-files#testing
     final directory = await Directory.systemTemp.createTemp();
-    const MethodChannel('plugins.flutter.io/path_provider')
-        .setMockMethodCallHandler((methodCall) async {
-      if (methodCall.method == 'getApplicationSupportDirectory') {
-        return directory.path;
-      }
-      return null;
-    });
+    PathProviderPlatform.instance = FakePathProviderPlatform(directory.path);
   });
 
   testWidgets(
@@ -101,5 +108,5 @@ void main() {
     // Bar-BoldItalic is not in the asset bundle.
     await loadFontIfNecessary(descriptorNotInAssets);
     verify(_httpClient.gets(anything)).called(1);
-  }, skip: true);
+  });
 }


### PR DESCRIPTION
This is the expected usage for tests that use `path_provider`.

Closes #200