### PR TITLE
Implement cache busting for updates to existing fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+### Added
+- Cache busting for font updates
+
 ### Changed
 - Complete null safety migration
 

--- a/lib/src/file_io.dart
+++ b/lib/src/file_io.dart
@@ -9,10 +9,14 @@ bool get isMacOS => false;
 
 /// Stubbed out version of saveFontToDeviceFileSystem from
 /// `file_io_desktop_and_mobile.dart`.
-Future<void> saveFontToDeviceFileSystem(String name, List<int> bytes) =>
+Future<void> saveFontToDeviceFileSystem(
+  String name,
+  String fileHash,
+  List<int> bytes,
+) =>
     Future.value(null);
 
 /// Stubbed out version of loadFontFromDeviceFileSystem from
 /// `file_io_desktop_and_mobile.dart`.
-Future<ByteData?> loadFontFromDeviceFileSystem(String name) =>
+Future<ByteData?> loadFontFromDeviceFileSystem(String name, String fileHash) =>
     Future.value(null);

--- a/lib/src/file_io_desktop_and_mobile.dart
+++ b/lib/src/file_io_desktop_and_mobile.dart
@@ -5,14 +5,20 @@ import 'package:path_provider/path_provider.dart';
 
 bool get isMacOS => Platform.isMacOS;
 
-Future<void> saveFontToDeviceFileSystem(String name, List<int> bytes) async {
-  final file = await _localFile(name);
+Future<void> saveFontToDeviceFileSystem(
+  String name,
+  String fileHash,
+  List<int> bytes,
+) async {
+  final file = await _localFile(name, fileHash);
+  print('saving $file');
   await file.writeAsBytes(bytes);
 }
 
-Future<ByteData?> loadFontFromDeviceFileSystem(String name) async {
+Future<ByteData?> loadFontFromDeviceFileSystem(
+    String name, String fileHash) async {
   try {
-    final file = await _localFile(name);
+    final file = await _localFile(name, fileHash);
     final fileExists = file.existsSync();
     if (fileExists) {
       List<int> contents = await file.readAsBytes();
@@ -31,10 +37,10 @@ Future<String> get _localPath async {
   return directory.path;
 }
 
-Future<File> _localFile(String name) async {
+Future<File> _localFile(String name, String fileHash) async {
   final path = await _localPath;
   // We expect only ttf files to be provided to us by the Google Fonts API.
   // That's why we can be sure a previously saved Google Font is in the ttf
   // format instead of, for example, otf.
-  return File('$path/$name.ttf');
+  return File('$path/${name}_$fileHash.ttf');
 }

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -120,6 +120,7 @@ TextStyle googleFontsTextStyle({
 Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
   final familyWithVariantString = descriptor.familyWithVariant.toString();
   final fontName = descriptor.familyWithVariant.toApiFilenamePrefix();
+  final fileHash = descriptor.file.expectedFileHash;
   // If this font has already already loaded or is loading, then there is no
   // need to attempt to load it again, unless the attempted load results in an
   // error.
@@ -146,7 +147,10 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
     }
 
     // Check if this font can be loaded from the device file system.
-    byteData = file_io.loadFontFromDeviceFileSystem(familyWithVariantString);
+    byteData = file_io.loadFontFromDeviceFileSystem(
+      familyWithVariantString,
+      fileHash,
+    );
 
     if (await byteData != null) {
       return loadFontByteData(familyWithVariantString, byteData);
@@ -164,7 +168,7 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
     } else {
       throw Exception(
         'GoogleFonts.config.allowRuntimeFetching is false but font $fontName was not '
-        'found in the application assets. Ensure $fontName.otf exists in a '
+        'found in the application assets. Ensure $fontName.ttf exists in a '
         "folder that is included in your pubspec's assets.",
       );
     }
@@ -241,8 +245,11 @@ Future<ByteData> _httpFetchFontAndSaveToDevice(
       );
     }
 
-    _unawaited(
-        file_io.saveFontToDeviceFileSystem(fontName, response.bodyBytes));
+    _unawaited(file_io.saveFontToDeviceFileSystem(
+      fontName,
+      file.expectedFileHash,
+      response.bodyBytes,
+    ));
 
     return ByteData.view(response.bodyBytes.buffer);
   } else {

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -304,10 +304,10 @@ void main() {
 
     // What if the file is different (e.g. the font has been improved)?
     await loadFontIfNecessary(fakeDescriptorDifferentFile);
-    // Give enough time for the file to be saved
-    await Future.delayed(const Duration(seconds: 1), () {});
     verify(mockHttpClient.gets(any)).called(1);
 
+    // Give enough time for the file to be saved
+    await Future.delayed(const Duration(seconds: 1), () {});
     expect(directoryContents.listSync().length == 2, isTrue);
     expect(
       directoryContents.listSync().toString(),

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -45,9 +45,41 @@ const _fakeResponseLengthInBytes = 28;
 // Computed by converting _fakeResponse to bytes and getting sha 256 hash.
 const _fakeResponseHash =
     '1194f6ffe4d2f05258573616a77932c38041f3102763096c19437c3db1818a04';
+const expectedCachedFile =
+    'Foo_regular_1194f6ffe4d2f05258573616a77932c38041f3102763096c19437c3db1818a04.ttf';
+// ignore: unused_element
+const _fakeResponseDifferent = 'different response';
+// The number of bytes in _fakeResponseDifferent.
+const _fakeResponseDifferentLengthInBytes = 18;
+// Computed by converting _fakeResponseDifferent to bytes and getting sha 256 hash.
+const _fakeResponseDifferentHash =
+    '2a989d235f2408511069bc7d8460c62aec1a75ac399bd7f2a2ae740c4326dadf';
+const expectedDifferentCachedFile =
+    'Foo_regular_2a989d235f2408511069bc7d8460c62aec1a75ac399bd7f2a2ae740c4326dadf.ttf';
+
 final _fakeResponseFile = GoogleFontsFile(
   _fakeResponseHash,
   _fakeResponseLengthInBytes,
+);
+final _fakeResponseDifferentFile = GoogleFontsFile(
+  _fakeResponseDifferentHash,
+  _fakeResponseDifferentLengthInBytes,
+);
+
+final fakeDescriptor = GoogleFontsDescriptor(
+  familyWithVariant: const GoogleFontsFamilyWithVariant(
+      family: 'Foo',
+      googleFontsVariant: GoogleFontsVariant(
+        fontWeight: FontWeight.w400,
+        fontStyle: FontStyle.normal,
+      )),
+  file: _fakeResponseFile,
+);
+
+// Same family & variant, different file.
+final fakeDescriptorDifferentFile = GoogleFontsDescriptor(
+  familyWithVariant: fakeDescriptor.familyWithVariant,
+  file: _fakeResponseDifferentFile,
 );
 
 var printLog = <String>[];
@@ -83,16 +115,6 @@ void main() {
   });
 
   test('loadFontIfNecessary method calls http get', () async {
-    final fakeDescriptor = GoogleFontsDescriptor(
-      familyWithVariant: const GoogleFontsFamilyWithVariant(
-          family: 'Foo',
-          googleFontsVariant: GoogleFontsVariant(
-            fontWeight: FontWeight.w400,
-            fontStyle: FontStyle.normal,
-          )),
-      file: _fakeResponseFile,
-    );
-
     await loadFontIfNecessary(fakeDescriptor);
 
     verify(mockHttpClient.gets(anything)).called(1);
@@ -151,7 +173,7 @@ void main() {
       expect(
         printLog[0],
         endsWith(
-          "Ensure Foo-Regular.otf exists in a folder that is included in your pubspec's assets.",
+          "Ensure Foo-Regular.ttf exists in a folder that is included in your pubspec's assets.",
         ),
       );
     });
@@ -234,17 +256,7 @@ void main() {
     verify(mockHttpClient.gets(any)).called(1);
   });
 
-  test('loadFontIfNecessary method writes font file', () async {
-    final fakeDescriptor = GoogleFontsDescriptor(
-      familyWithVariant: const GoogleFontsFamilyWithVariant(
-          family: 'Foo',
-          googleFontsVariant: GoogleFontsVariant(
-            fontWeight: FontWeight.w400,
-            fontStyle: FontStyle.normal,
-          )),
-      file: _fakeResponseFile,
-    );
-
+  test('loadFontIfNecessary method correctly stores in cache', () async {
     var directoryContents = await getApplicationSupportDirectory();
     expect(directoryContents.listSync().isEmpty, isTrue);
 
@@ -254,10 +266,59 @@ void main() {
     directoryContents = await getApplicationSupportDirectory();
 
     expect(directoryContents.listSync().isNotEmpty, isTrue);
-    expect(
-      directoryContents.listSync().single.toString().contains('Foo'),
-      isTrue,
+
+    expect(directoryContents.listSync().single.toString(),
+        contains(expectedCachedFile));
+  });
+
+  test('loadFontIfNecessary method correctly uses cache', () async {
+    var directoryContents = await getApplicationSupportDirectory();
+    expect(directoryContents.listSync().isEmpty, isTrue);
+
+    final cachedFile = File(
+      '${directoryContents.path}/$expectedCachedFile',
     );
+    cachedFile.createSync();
+    cachedFile.writeAsStringSync('file contents');
+
+    // Should use cache from now on.
+    await loadFontIfNecessary(fakeDescriptor);
+    await loadFontIfNecessary(fakeDescriptor);
+    await loadFontIfNecessary(fakeDescriptor);
+    verifyNever(mockHttpClient.gets(anything));
+  });
+
+  test('loadFontIfNecessary method re-caches when font file changes', () async {
+    when(mockHttpClient.gets(any)).thenAnswer((_) async {
+      return http.Response(_fakeResponseDifferent, 200);
+    });
+
+    var directoryContents = await getApplicationSupportDirectory();
+    expect(directoryContents.listSync().isEmpty, isTrue);
+
+    final cachedFile = File(
+      '${directoryContents.path}/$expectedCachedFile',
+    );
+    cachedFile.createSync();
+    cachedFile.writeAsStringSync('file contents');
+
+    // What if the file is different (e.g. the font has been improved)?
+    await loadFontIfNecessary(fakeDescriptorDifferentFile);
+    // Give enough time for the file to be saved
+    await Future.delayed(const Duration(seconds: 1), () {});
+    verify(mockHttpClient.gets(any)).called(1);
+
+    expect(directoryContents.listSync().length == 2, isTrue);
+    expect(
+      directoryContents.listSync().toString(),
+      contains(expectedDifferentCachedFile),
+    );
+
+    // Should use cache from now on.
+    await loadFontIfNecessary(fakeDescriptorDifferentFile);
+    await loadFontIfNecessary(fakeDescriptorDifferentFile);
+    await loadFontIfNecessary(fakeDescriptorDifferentFile);
+    verifyNever(mockHttpClient.gets(anything));
   });
 
   test(


### PR DESCRIPTION
Previously, updates to existing fonts would not reach users whose devices has cached that font.

This PR enables cache busting by using the font file's hash in the cached filename.

Fixes #189