### PR TITLE
Update pub.dev links

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: google_fonts
 description: A Flutter package to use fonts from fonts.google.com. Supports HTTP fetching, caching, and asset bundling.
 version: 3.0.1
 repository: https://github.com/material-foundation/google-fonts-flutter
+issue_tracker: https://github.com/material-foundation/google-fonts-flutter/issues
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).