### PR TITLE
fix: inserting button in themeParams

### DIFF
--- a/generator/generator.dart
+++ b/generator/generator.dart
@@ -216,6 +216,7 @@ String _generateDartCode(Directory fontDirectory) {
       'labelLarge',
       'labelMedium',
       'labelSmall',
+      'button',
     ];
 
     methods.add(<String, dynamic>{


### PR DESCRIPTION
Hello guys,

`button` is one of the `TextTheme` styles but it is not generated when using the `GoogleFonts` theme creation functions.

Do you see any problem with inserting this parameter in the generator?