### PR TITLE
Migrate the deprecated  body1 to bodyText2 in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ final textTheme = Theme.of(context).textTheme;
 MaterialApp(
   theme: ThemeData(
     textTheme: GoogleFonts.latoTextTheme(textTheme).copyWith(
-      body1: GoogleFonts.oswald(textStyle: textTheme.body1),
+      bodyText2: GoogleFonts.oswald(textStyle: textTheme.bodyText2),
     ),
   ),
 );


### PR DESCRIPTION
This removes the deprecated API from TextTheme in the example to avoid confusion.

Deprecated in https://github.com/flutter/flutter/pull/48547