### PR TITLE
hide AssetManifest from flutter services imports

### DIFF
--- a/lib/src/asset_manifest.dart
+++ b/lib/src/asset_manifest.dart
@@ -5,7 +5,11 @@
 import 'dart:convert' as convert;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
+// TODO(andrewkolos): remove this after flutter adds its own AssetManifest API
+// (see https://github.com/flutter/flutter/pull/119277) which will replace the
+// one defined here.
+// ignore: undefined_hidden_name
+import 'package:flutter/services.dart' hide AssetManifest;
 
 /// A class to obtain and memoize the app's asset manifest.
 ///

--- a/lib/src/google_fonts_base.dart
+++ b/lib/src/google_fonts_base.dart
@@ -6,7 +6,16 @@ import 'dart:ui';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+// TODO(andrewkolos): The flutter framework wishes to add a new class named
+// `AssetManifest` to its API (see https://github.com/flutter/flutter/pull/119277).
+// However, doing so would break integration tests that utilize google_fonts due
+// to name collision with the `AssetManifest` class that this package already
+// defines (see https://github.com/flutter/flutter/pull/119273).
+// Once the AssetManifest API is added to flutter, update this package to use it
+// instead of the AssetManifest class this package defines and remove this `hide`
+// and the ignore annotation.
+// ignore: undefined_hidden_name
+import 'package:flutter/services.dart' hide AssetManifest;
 import 'package:http/http.dart' as http;
 
 import '../google_fonts.dart';

--- a/test/asset_manifest_test.dart
+++ b/test/asset_manifest_test.dart
@@ -4,7 +4,8 @@
 
 import 'dart:convert';
 
-import 'package:flutter/services.dart';
+// ignore: undefined_hidden_name
+import 'package:flutter/services.dart' hide AssetManifest;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/src/asset_manifest.dart';
 

--- a/test/load_font_if_necessary_test.dart
+++ b/test/load_font_if_necessary_test.dart
@@ -2,7 +2,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/services.dart';
+// ignore: undefined_hidden_name
+import 'package:flutter/services.dart' hide AssetManifest;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:google_fonts/src/asset_manifest.dart';

--- a/test/load_font_if_necessary_with_local_fonts_test.dart
+++ b/test/load_font_if_necessary_with_local_fonts_test.dart
@@ -2,7 +2,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+// ignore: undefined_hidden_name
+import 'package:flutter/services.dart' hide AssetManifest;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:google_fonts/src/google_fonts_base.dart';


### PR DESCRIPTION
The flutter framework wishes to add a new class named `AssetManifest` to its API (see https://github.com/flutter/flutter/pull/119277). However, doing so would break integration tests that utilize google_fonts due to name collision with the [`AssetManifest` class](https://github.com/material-foundation/google-fonts-flutter/blob/main/lib/src/asset_manifest.dart#L13) that this package already defines (see https://github.com/flutter/flutter/pull/119273).

This PR adds `hide AssetManifest` to the `package:flutter/services.dart` imports this package contains, which will allow the flutter framework to introduce this class without breaking its integration tests that utilize google_fonts.

Once flutter's new `AssetManifest` API is available, this package can be updated to use it instead of defining its own custom `AssetManifest` class, since flutter's will provide the same functionality and more.